### PR TITLE
feat: add global nav and site subpages

### DIFF
--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -31,32 +31,56 @@ body{
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Arial,Helvetica,"PingFang SC","Hiragino Sans GB","Microsoft YaHei",sans-serif;
 }
 
-/* ------ Sidebar (kept dark) ------ */
+/* ------ Top Navigation ------ */
+.top-nav{background:var(--brand);color:#fff;position:sticky;top:0;z-index:2000;width:100%;}
+.top-nav .nav-inner{max-width:1200px;margin:0 auto;display:flex;justify-content:space-between;align-items:center;padding:8px 16px;}
+.top-nav .top-menu{list-style:none;margin:0;padding:0;display:flex;gap:20px;}
+.top-nav .top-menu>li{position:relative;}
+.top-nav .top-menu>li>a{color:#fff;text-decoration:none;padding:6px 10px;border-radius:6px;display:block;font-weight:700;}
+.top-nav .top-menu>li>a:hover{background:rgba(255,255,255,0.1);}
+.top-nav .dropdown{display:none;position:absolute;top:100%;left:0;background:#fff;color:#111;min-width:120px;border-radius:6px;box-shadow:0 2px 8px rgba(0,0,0,.15);z-index:2100;}
+.top-nav .dropdown li{position:relative;}
+.top-nav .dropdown a{color:#111;text-decoration:none;padding:6px 12px;display:block;}
+.top-nav .dropdown a:hover{background:#f3f4f6;}
+.top-nav .top-menu>li:hover>.dropdown{display:block;}
+.top-nav .dropdown li:hover>ul{display:block;}
+.top-nav .dropdown ul{display:none;position:absolute;top:0;left:100%;background:#fff;min-width:120px;border-radius:6px;box-shadow:0 2px 8px rgba(0,0,0,.15);z-index:2100;}
+.top-nav .user-area{margin-left:0;}
+.top-nav .user-area a{color:#fff;text-decoration:none;font-weight:700;}
+
+/* ------ Sidebar ------ */
 .sidebar{
-  width:220px;
-  background:#0f172a;
-  color:#fff;
-  padding:16px;
-  height:100vh;
+  width:180px;
+  flex:0 0 180px;
+  background:#f1f5f9;
+  color:#1e293b;
+  padding:12px;
+  height:calc(100vh - 50px);
   overflow:auto;
-  border-right:1px solid #1f2937;
-  position:sticky; top:0; z-index:1000;
+  border-right:1px solid #cbd5e1;
+  position:sticky; top:50px; z-index:1000;
 }
-.sidebar h3{ margin:0 0 10px; font-size:16px }
+.sidebar h3{ margin:0 0 8px; font-size:16px }
+.site-header{ display:flex; align-items:center; justify-content:space-between; margin-bottom:8px; }
+.add-site-btn{ background:var(--brand); color:#fff; border:none; border-radius:4px; width:20px; height:20px; cursor:pointer; line-height:20px; text-align:center; }
+.add-site-btn:hover{ background:#2563eb; }
 .sidebar ul{ list-style:none; padding-left:0; margin:0 }
-.sidebar li{ margin-bottom:10px }
+.sidebar li{ margin-bottom:6px }
 .sidebar a{
   display:block; text-decoration:none;
-  color:#94a3b8; font-size:14px; padding:6px 8px; border-radius:6px;
+  color:#475569; font-size:14px; padding:4px 6px; border-radius:6px;
 }
-.sidebar a:hover{ color:#fff; background:#0b1a3b }
+.sidebar a:hover{ color:#1e293b; background:#e2e8f0 }
 .sidebar .submenu{ list-style:none; padding-left:14px; display:none }
 .sidebar .has-submenu>a{ cursor:pointer }
 .sidebar .has-submenu.open .submenu{ display:block }
-.sidebar .submenu a.active{ color:#fff; background:var(--brand) }
+.sidebar .submenu a.active{ color:#1e293b; background:#cbd5e1 }
+.sidebar .sub-nav{ list-style:none; padding-left:0; margin:0 }
+.sidebar .sub-nav li{ margin-bottom:6px }
+.sidebar .sub-nav a.active{ color:#1e293b; background:#cbd5e1 }
 
 /* ------ Layout ------ */
-.container{ display:flex; min-height:100vh }
+.container{ display:flex; min-height:calc(100vh - 50px); max-width:1200px; margin:0 auto }
 .main{
   flex:1; display:flex; flex-direction:column; gap:12px;
   padding:16px; background:#ffffff;
@@ -72,6 +96,9 @@ body{
   box-shadow: var(--shadow);
 }
 .controls{ display:flex; align-items:center; gap:8px }
+/* upload section header */
+.upload-top{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:10px}
+.user-area{margin-left:auto}
 .sel, select, input[type="text"]{
   padding:6px 8px; border:1px solid var(--panel-border);
   border-radius:8px; background:#fff; color:var(--text);
@@ -81,6 +108,10 @@ body{
   background:#fff; color:var(--text); cursor:pointer;
 }
 .upload-btn:hover, .btn:hover{ background:#f8fafc }
+input[type="file"]{ display:none }
+
+.grid{ display:grid; gap:16px }
+.grid-2{ grid-template-columns:repeat(auto-fit,minmax(320px,1fr)) }
 
 /* Divider */
 .divider{ height:1px; background:var(--panel-border); margin:8px 0 12px }

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -14,85 +14,56 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
   
-<link rel="stylesheet" href="assets/theme.css?v=20250810b">
+  <link rel="stylesheet" href="assets/theme.css?v=20250811-single">
 </head>
-<body>
+<body class="fm">
+<header class="top-nav"><div class="nav-inner"><ul class="top-menu"><li><a href="#">速卖通</a><ul class="dropdown"><li class="submenu"><a href="#">全托管</a><ul id="managedMenu"></ul></li><li><a href="self-operated.html">自运营</a></li></ul></li><li><a href="#">亚马逊</a></li><li><a href="#">TikTok Shop</a></li><li><a href="#">Temu</a></li><li><a href="#">Ozon</a></li><li><a href="independent-site.html">独立站</a></li></ul><div id="userArea" class="user-area"></div></div></header>
 <div class="container">
   <nav class="sidebar" id="sidebar">
-    <h3>产品导航</h3>
-    <ul>
-      <li class="has-submenu">
-        <a href="#">速卖通</a>
-        <ul class="submenu">
-          <li><a href="index.html">全托管</a></li>
-          <li><a href="self-operated.html">自运营</a></li>
-        </ul>
-      </li>
-      <li><a href="#">TikTok Shop</a></li>
-      <li><a href="#">亚马逊</a></li>
-      <li class="has-submenu">
-        <a href="#">独立站</a>
-        <ul class="submenu">
-          <li><a href="independent-site.html">数据分析</a></li>
-        </ul>
-      </li>
+    <div class="site-header"><span id="currentSite">独立站 A站</span><button id="addSite" class="add-site-btn">+</button></div>
+    <ul class="sub-nav">
+      <li><a href="#" class="active" data-target="detail">详细数据</a></li>
+      <li><a href="#" data-target="analysis">运营分析</a></li>
+      <li><a href="#" data-target="product">产品分析</a></li>
     </ul>
   </nav>
-  <div class="main">
+  <main class="main">
     <div class="upload-section">
       <div class="upload-top">
-        <label for="fileInput" class="upload-btn">选择文件</label>
-        <input type="file" id="fileInput" accept=".xlsx,.xls,.csv">
-        <div>
+        <div style="font-size:28px;font-weight:800;">独立站数据分析</div>
+        <div class="controls">
+          <label for="fileInput" class="upload-btn">选择文件</label>
+          <input type="file" id="fileInput" accept=".xlsx,.xls,.csv">
+          <span id="progress" class="progress"></span>
           <label>筛选时间：</label>
           <input id="dateFilter" class="date-filter" placeholder="选择日期范围">
         </div>
       </div>
-      <div class="stats-cards">
-        <div class="stat-card">
-          <h4>平均访客比
-            <span class="info" onclick="showInfo('visitorRate')" title="点击查看公式">?</span>
-          </h4>
-          <p id="avgVisitor">0%</p>
+    </div>
+    <div class="content">
+      <div class="content-pad">
+        <div class="stats-cards" id="kpi">
+          <div class="stat-card"><h4>平均访客比</h4><p id="avgVisitor">0%</p></div>
+          <div class="stat-card"><h4>平均加购比</h4><p id="avgCart">0%</p></div>
+          <div class="stat-card"><h4>平均支付比</h4><p id="avgPay">0%</p></div>
+          <div class="stat-card"><h4>商品总数</h4><p id="totalProducts">0</p></div>
+          <div class="stat-card"><h4>加购商品数</h4><p id="cartedProducts">0</p></div>
+          <div class="stat-card"><h4>支付商品数</h4><p id="purchasedProducts">0</p></div>
         </div>
-        <div class="stat-card">
-          <h4>平均加购比
-            <span class="info" onclick="showInfo('cartRate')" title="点击查看公式">?</span>
-          </h4>
-          <p id="avgCart">0%</p>
-        </div>
-        <div class="stat-card">
-          <h4>平均支付比
-            <span class="info" onclick="showInfo('payRate')" title="点击查看公式">?</span>
-          </h4>
-          <p id="avgPay">0%</p>
-        </div>
-        <div class="stat-card"><h4>商品总数</h4><p id="totalProducts">0</p></div>
-        <div class="stat-card"><h4>加购商品数</h4><p id="cartedProducts">0</p></div>
-        <div class="stat-card"><h4>支付商品数</h4><p id="purchasedProducts">0</p></div>
+        <div class="divider"></div>
+        <section id="detail" class="content-pad">
+          <div class="table-section">
+            <table id="report" class="display nowrap" style="width:100%"></table>
+          </div>
+        </section>
+        <section id="analysis" class="content-pad" style="display:none;"><p>运营分析建设中...</p></section>
+        <section id="product" class="content-pad" style="display:none;"><p>产品分析建设中...</p></section>
       </div>
     </div>
-    <div class="table-section">
-      <div class="table-wrapper">
-        <table id="report" class="display nowrap" style="width:100%"></table>
-      </div>
-    </div>
-  </div>
+  </main>
 </div>
-<script>
-// --- Sidebar: set active & toggle ---
-(function() {
-  var currentPage = window.location.pathname.split('/').pop();
-  if (!currentPage) currentPage = 'independent-site.html';
-  $('.sidebar a[href="' + currentPage + '"]').addClass('active');
-  $('.sidebar a.active').closest('.has-submenu').addClass('open');
-  $('.has-submenu > a').on('click', function(e){
-    e.preventDefault();
-    $(this).parent().toggleClass('open');
-  });
-})();
-
-function showInfo(key) {
+  <script>
+  function showInfo(key) {
   const infoMap = {
     visitorRate: '访客比 = 商品访客数 ÷ 搜索曝光量 × 100% （注：独立站若无曝光量字段，则该指标显示为 N/A）',
     cartRate:   '加购比 = 商品加购人数 ÷ 商品访客数 × 100%',
@@ -216,69 +187,64 @@ $('#fileInput').on('change', function(e) {
     const body = sheet.slice(1).filter(r => r.length);
     fullData = body;
     renderTable(body);
-  };
+};
   reader.readAsArrayBuffer(file);
 });
-</script>
-
-
-
-<script>
-(function() {
-  var page = location.pathname.split('/').pop() || 'index.html';
-
-  // Highlight current page
-  var links = document.querySelectorAll('.sidebar a[href]');
-  for (var i=0;i<links.length;i++) {
-    if (links[i].getAttribute('href') === page) {
-      links[i].classList.add('active');
-      var p = links[i].closest('.has-submenu');
-      if (p) p.classList.add('open');
-    }
-  }
-
-  // Make sure sidebar sits above content and is clickable
-  var sb = document.querySelector('.sidebar');
-  if (sb) { sb.style.zIndex = 1000; }
-
-  // Parent click: if only one child, go directly; else toggle
-  var parents = document.querySelectorAll('.has-submenu > a');
-  for (var j=0;j<parents.length;j++) {
-    parents[j].addEventListener('click', function(e){
-      var li = this.parentElement;
-      var submenu = li.querySelector('.submenu');
-      if (!submenu) return;
-      var items = submenu.querySelectorAll('a[href]');
-      if (items.length === 1) {
-        window.location.href = items[0].getAttribute('href');
-      } else {
-        e.preventDefault();
-        li.classList.toggle('open');
-      }
+document.addEventListener('DOMContentLoaded',()=>{
+  const siteListKey='managedSites';
+  const currentSiteKey='currentSite';
+  let sites=JSON.parse(localStorage.getItem(siteListKey)||'null');
+  if(!Array.isArray(sites)||!sites.length){sites=['A站','B站','C站'];}
+  const menuEl=document.getElementById('managedMenu');
+  const currentSiteEl=document.getElementById('currentSite');
+  function save(){localStorage.setItem(siteListKey,JSON.stringify(sites));}
+  function renderMenu(){
+    menuEl.innerHTML='';
+    sites.forEach((name,idx)=>{
+      const li=document.createElement('li');
+      const a=document.createElement('a');
+      a.href='index.html';
+      a.textContent=name;
+      a.addEventListener('click',(e)=>{e.preventDefault();localStorage.setItem(currentSiteKey,name);window.location.href='index.html';});
+      a.addEventListener('dblclick',()=>{const n=prompt('修改站点名',name);if(n){sites[idx]=n;save();renderMenu();updateCurrent();}});
+      li.appendChild(a);menuEl.appendChild(li);
     });
   }
-
-  // Submenu links: always navigate
-  var subLinks = document.querySelectorAll('.submenu a[href]');
-  for (var k=0;k<subLinks.length;k++) {
-    subLinks[k].addEventListener('click', function(e){
-      // Some browsers may have preventDefault from other handlers; enforce navigation
-      window.location.href = this.getAttribute('href');
+  function updateCurrent(){
+    const name=localStorage.getItem(currentSiteKey)||sites[0];
+    currentSiteEl.textContent='独立站 '+name;
+    localStorage.setItem(currentSiteKey,name);
+  }
+  currentSiteEl.addEventListener('dblclick',()=>{
+    const cur=localStorage.getItem(currentSiteKey)||sites[0];
+    const idx=sites.indexOf(cur);
+    const n=prompt('修改站点名',cur);
+    if(n){sites[idx]=n;save();renderMenu();localStorage.setItem(currentSiteKey,n);updateCurrent();}
+  });
+  document.getElementById('addSite').addEventListener('click',()=>{
+    const n=prompt('新增站点名');
+    if(n){sites.push(n);save();renderMenu();updateCurrent();}
+  });
+  renderMenu();updateCurrent();
+  const userArea=document.getElementById('userArea');
+  function refreshUser(){
+    const u=localStorage.getItem('username');
+    if(u){userArea.textContent=u;}else{userArea.innerHTML='<a href="login.html">登录</a>';}
+  }
+  refreshUser();
+  document.querySelectorAll('.sub-nav a').forEach(a=>{
+    a.addEventListener('click',e=>{
+      e.preventDefault();
+      const t=a.dataset.target;
+      document.querySelectorAll('.sub-nav a').forEach(x=>x.classList.remove('active'));
+      a.classList.add('active');
+      ['detail','analysis','product'].forEach(id=>{
+        const el=document.getElementById(id);
+        if(el) el.style.display=id===t?'':'none';
+      });
     });
-  }
-
-  // If we're on independent-site.html, auto-open the 速卖通菜单（第一个带有"速卖通"文本的父级）
-  if (page === 'independent-site.html') {
-    var groups = document.querySelectorAll('.has-submenu');
-    for (var g=0; g<groups.length; g++) {
-      var txt = groups[g].textContent || '';
-      if (txt.indexOf('速卖通') !== -1 || txt.toLowerCase().indexOf('aliexpress') !== -1) {
-        groups[g].classList.add('open');
-        break;
-      }
-    }
-  }
-})();
+  });
+});
 </script>
 
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -34,25 +34,14 @@
 #kpi-new-self-ctrl, #kpi-new-managed-ctrl, .kpi .kpi-ctrl { display: none !important; }</style>
 </head>
 <body class="fm">
+<header class="top-nav"><div class="nav-inner"><ul class="top-menu"><li><a href="#">速卖通</a><ul class="dropdown"><li class="submenu"><a href="#">全托管</a><ul id="managedMenu"></ul></li><li><a href="self-operated.html">自运营</a></li></ul></li><li><a href="#">亚马逊</a></li><li><a href="#">TikTok Shop</a></li><li><a href="#">Temu</a></li><li><a href="#">Ozon</a></li><li><a href="independent-site.html">独立站</a></li></ul><div id="userArea" class="user-area"></div></div></header>
 <div class="container">
   <nav class="sidebar" id="sidebar">
-    <h3>产品导航</h3>
-    <ul>
-      <li class="has-submenu open">
-        <a href="#">速卖通</a>
-        <ul class="submenu">
-          <li><a href="index.html" class="active">全托管</a></li>
-          <li><a href="self-operated.html">自运营</a></li>
-        </ul>
-      </li>
-      <li><a href="#">TikTok Shop</a></li>
-      <li><a href="#">亚马逊</a></li>
-      <li class="has-submenu open">
-        <a href="#">独立站</a>
-        <ul class="submenu">
-          <li><a href="independent-site.html">数据分析</a></li>
-        </ul>
-      </li>
+    <div class="site-header"><span id="currentSite">全托管 A站</span><button id="addSite" class="add-site-btn">+</button></div>
+    <ul class="sub-nav">
+      <li><a href="#" class="active" data-target="detail">详细数据</a></li>
+      <li><a href="#" data-target="analysis">运营分析</a></li>
+      <li><a href="#" data-target="product">产品分析</a></li>
     </ul>
   </nav>
 
@@ -80,11 +69,6 @@
       <div class="content-pad">
         <div class="stats-cards" id="kpi"></div>
         <div class="divider"></div>
-        
-<div class="tabs">
-  <div class="tab active" data-tab="detail">明细表</div>
-  <div class="tab" data-tab="analysis">运营分析</div>
-</div>
 
 <section id="detail" class="content-pad">
   <div class="table-section">
@@ -112,30 +96,26 @@
 
 <section id="analysis" class="content-pad" style="display:none;">
   <div class="grid grid-2">
-    
-        <div class="grid grid-2">
-          <div class="panel">
-            <h3>转化漏斗（A vs B）</h3>
-            <div id="funnel" style="width:100%;height:320px;"></div>
-          </div>
-          <div class="panel">
-            <h3>周期对比（曝光 / 加购件数 / 支付订单数）</h3>
-            <div id="sumCompareBar" style="width:100%;height:320px;"></div>
-          </div>
-        </div>
-        <div class="grid grid-2" style="margin-top:16px;">
-          <div class="panel">
-            <h3>Top10 访客比（UV/曝光）· A</h3>
-            <div id="vrBar" style="width:100%;height:320px;"></div>
-          </div>
-          <div class="panel">
-            <h3>Top10 加购→支付 转化率 · A</h3>
-            <div id="payBar" style="width:100%;height:320px;"></div>
-          </div>
-        </div>
-        
+    <div class="panel">
+      <h3>转化漏斗（A vs B）</h3>
+      <div id="funnel" style="width:100%;height:320px;"></div>
+    </div>
+    <div class="panel">
+      <h3>周期对比（曝光 / 加购件数 / 支付订单数）</h3>
+      <div id="sumCompareBar" style="width:100%;height:320px;"></div>
+    </div>
+    <div class="panel">
+      <h3>Top10 访客比（UV/曝光）· A</h3>
+      <div id="vrBar" style="width:100%;height:320px;"></div>
+    </div>
+    <div class="panel">
+      <h3>Top10 加购→支付 转化率 · A</h3>
+      <div id="payBar" style="width:100%;height:320px;"></div>
+    </div>
   </div>
 </section>
+
+<section id="product" class="content-pad" style="display:none;"><p>产品分析建设中...</p></section>
 
       </div>
     </div>
@@ -144,16 +124,6 @@
 
 <script>
 (function(){
-  document.querySelectorAll('.has-submenu > a').forEach(a => {
-    a.addEventListener('click', function(e){
-      const li = this.parentElement;
-      const sub = li.querySelector('.submenu');
-      if (!sub) return;
-      e.preventDefault();
-      li.classList.toggle('open');
-    });
-  });
-
   const state = { granularity: 'week', table: null, uploading: false };
 
   $('input[name="gran"]').on('change', function(){
@@ -815,5 +785,51 @@
     }
   });
 })();</script>
+<script>
+document.addEventListener('DOMContentLoaded', ()=>{
+  const siteListKey='managedSites';
+  const currentSiteKey='currentSite';
+  let sites=JSON.parse(localStorage.getItem(siteListKey)||'null');
+  if(!Array.isArray(sites)||!sites.length){sites=['A站','B站','C站'];}
+  const menuEl=document.getElementById('managedMenu');
+  const currentSiteEl=document.getElementById('currentSite');
+  function save(){localStorage.setItem(siteListKey,JSON.stringify(sites));}
+  function renderMenu(){
+    menuEl.innerHTML='';
+    sites.forEach((name,idx)=>{
+      const li=document.createElement('li');
+      const a=document.createElement('a');
+      a.href='index.html';
+      a.textContent=name;
+      a.addEventListener('click',(e)=>{e.preventDefault();localStorage.setItem(currentSiteKey,name);window.location.href='index.html';});
+      a.addEventListener('dblclick',()=>{const n=prompt('修改站点名',name);if(n){sites[idx]=n;save();renderMenu();updateCurrent();}});
+      li.appendChild(a);menuEl.appendChild(li);
+    });
+  }
+  function updateCurrent(){
+    const name=localStorage.getItem(currentSiteKey)||sites[0];
+    currentSiteEl.textContent='全托管 '+name;
+    localStorage.setItem(currentSiteKey,name);
+  }
+  currentSiteEl.addEventListener('dblclick',()=>{
+    const cur=localStorage.getItem(currentSiteKey)||sites[0];
+    const idx=sites.indexOf(cur);
+    const n=prompt('修改站点名',cur);
+    if(n){sites[idx]=n;save();renderMenu();localStorage.setItem(currentSiteKey,n);updateCurrent();}
+  });
+  document.getElementById('addSite').addEventListener('click',()=>{
+    const n=prompt('新增站点名');
+    if(n){sites.push(n);save();renderMenu();updateCurrent();}
+  });
+  renderMenu();updateCurrent();
+  const userArea=document.getElementById('userArea');
+  function refreshUser(){
+    const u=localStorage.getItem('username');
+    if(u){userArea.textContent=u;}else{userArea.innerHTML='<a href="login.html">登录</a>';}
+  }
+  refreshUser();
+  document.querySelectorAll('.sub-nav a').forEach(a=>{a.addEventListener('click',e=>{e.preventDefault();const t=a.dataset.target;document.querySelectorAll('.sub-nav a').forEach(x=>x.classList.remove('active'));a.classList.add('active');['detail','analysis','product'].forEach(id=>{const el=document.getElementById(id);if(el)el.style.display=id===t?'':'none';});});});
+});
+</script>
 </body>
 </html>

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <title>登录/注册</title>
+  <link rel="stylesheet" href="assets/theme.css?v=20250811-single">
+</head>
+<body class="fm">
+<header class="top-nav"><div class="nav-inner"><ul class="top-menu"><li><a href="#">速卖通</a><ul class="dropdown"><li class="submenu"><a href="#">全托管</a><ul id="managedMenu"></ul></li><li><a href="self-operated.html">自运营</a></li></ul></li><li><a href="#">亚马逊</a></li><li><a href="#">TikTok Shop</a></li><li><a href="#">Temu</a></li><li><a href="#">Ozon</a></li><li><a href="independent-site.html">独立站</a></li></ul><div id="userArea" class="user-area"></div></div></header>
+  <div class="container" style="justify-content:center;align-items:center;">
+    <main class="main" style="max-width:400px;">
+      <h2>登录/注册</h2>
+      <div class="content-pad">
+        <input type="text" id="username" placeholder="用户名" class="sel" style="width:100%;margin-bottom:8px;">
+        <input type="password" id="password" placeholder="密码" class="sel" style="width:100%;margin-bottom:8px;">
+        <div class="controls" style="justify-content:flex-end;">
+          <button id="loginBtn" class="btn">登录</button>
+          <button id="registerBtn" class="btn">注册</button>
+        </div>
+      </div>
+    </main>
+</div>
+<script>
+document.addEventListener('DOMContentLoaded',()=>{
+  const siteListKey='managedSites';
+  let sites=JSON.parse(localStorage.getItem(siteListKey)||'null');
+  if(!Array.isArray(sites)||!sites.length){sites=['A站','B站','C站'];localStorage.setItem(siteListKey,JSON.stringify(sites));}
+  const menuEl=document.getElementById('managedMenu');
+  if(menuEl){sites.forEach(name=>{const li=document.createElement('li');const a=document.createElement('a');a.href='index.html';a.textContent=name;a.addEventListener('click',e=>{e.preventDefault();localStorage.setItem('currentSite',name);window.location.href='index.html';});li.appendChild(a);menuEl.appendChild(li);});}
+  const userArea=document.getElementById('userArea');
+  if(userArea){const u=localStorage.getItem('username');if(u){userArea.textContent=u;}else{userArea.innerHTML='<a href="login.html">登录</a>';}}
+});
+function handleAuth(){
+  const u=document.getElementById('username').value.trim();
+  if(u){localStorage.setItem('username',u);window.location.href='index.html';}
+}
+document.getElementById('loginBtn').onclick=handleAuth;
+document.getElementById('registerBtn').onclick=handleAuth;
+</script>
+</body>
+</html>

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -34,31 +34,19 @@
     #kpi-new-self-ctrl, #kpi-new-managed-ctrl, .kpi .kpi-ctrl { display: none !important; }
   </style>
 </head>
-<body>
+<body class="fm">
+<header class="top-nav"><div class="nav-inner"><ul class="top-menu"><li><a href="#">速卖通</a><ul class="dropdown"><li class="submenu"><a href="#">全托管</a><ul id="managedMenu"></ul></li><li><a href="self-operated.html">自运营</a></li></ul></li><li><a href="#">亚马逊</a></li><li><a href="#">TikTok Shop</a></li><li><a href="#">Temu</a></li><li><a href="#">Ozon</a></li><li><a href="independent-site.html">独立站</a></li></ul><div id="userArea" class="user-area"></div></div></header>
 <div class="container">
-  <!-- 左侧导航 -->
   <nav class="sidebar" id="sidebar">
-    <h3>产品导航</h3>
-    <ul>
-      <li class="has-submenu">
-        <a href="#">速卖通</a>
-        <ul class="submenu">
-          <li><a href="index.html">全托管</a></li>
-          <li><a href="self-operated.html" class="active">自运营</a></li>
-        </ul>
-      </li>
-      <li><a href="#">TikTok Shop</a></li>
-      <li><a href="#">亚马逊</a></li>
-      <li class="has-submenu">
-        <a href="#">独立站</a>
-        <ul class="submenu">
-          <li><a href="independent-site.html">数据分析</a></li>
-        </ul>
-      </li>
+    <div class="site-header"><span id="currentSite">自运营 A站</span><button id="addSite" class="add-site-btn">+</button></div>
+    <ul class="sub-nav">
+      <li><a href="#" class="active" data-target="detail">详细数据</a></li>
+      <li><a href="#" data-target="analysis">运营分析</a></li>
+      <li><a href="#" data-target="product">产品分析</a></li>
     </ul>
   </nav>
 
-  <div class="main">
+  <main class="main">
     <!-- 顶部：上传 + 全局过滤 -->
     <div class="upload-section">
       <div class="upload-top">
@@ -89,31 +77,35 @@
     </div>
 
     <!-- 顶部 Tabs -->
-    <div class="tabs">
-      <div class="tab active" data-tab="summary">汇总对比</div>
-      <div class="tab" data-tab="detail">明细表</div>
-    </div>
-
     <div class="content">
-      <!-- 汇总对比 -->
-      <section id="summary" class="content-pad">
+      <!-- 明细表 -->
+      <section id="detail" class="content-pad">
         <div class="panel">
-          <h3>周期 A vs 周期 B · 总量曲线（按天）</h3>
-          <div class="controls" style="margin-bottom:8px;">
-            <span>维度：</span>
-            <select id="metricSel" class="sel">
-              <option value="exposure_sum">曝光量总和</option>
-              <option value="visitors_sum">访客数总和</option>
-              <option value="add_people_sum">加购人数总和</option>
-              <option value="fav_sum">收藏总数</option>
-              <option value="orders_sum">下单总数</option>
-            </select>
-            <span class="notice">A = 当前选择；B = 上一周期（向前平移同长度）。</span>
+          <h3>数据明细</h3>
+          <div class="table-wrapper">
+            <table id="report" class="display nowrap" style="width:100%"></table>
           </div>
-          <div id="lineChart" style="width:100%;height:360px;"></div>
         </div>
+      </section>
 
-        <div class="grid grid-2" style="margin-top:16px;">
+      <!-- 汇总对比 -->
+      <section id="analysis" class="content-pad" style="display:none;">
+        <div class="grid grid-2">
+          <div class="panel" style="grid-column:1/-1;">
+            <h3>周期 A vs 周期 B · 总量曲线（按天）</h3>
+            <div class="controls" style="margin-bottom:8px;">
+              <span>维度：</span>
+              <select id="metricSel" class="sel">
+                <option value="exposure_sum">曝光量总和</option>
+                <option value="visitors_sum">访客数总和</option>
+                <option value="add_people_sum">加购人数总和</option>
+                <option value="fav_sum">收藏总数</option>
+                <option value="orders_sum">下单总数</option>
+              </select>
+              <span class="notice">A = 当前选择；B = 上一周期（向前平移同长度）。</span>
+            </div>
+            <div id="lineChart" style="width:100%;height:360px;"></div>
+          </div>
           <div class="panel">
             <h3>平均比率对比（A vs B）</h3>
             <div id="ratioBar" style="width:100%;height:300px;"></div>
@@ -126,27 +118,13 @@
           </div>
         </div>
       </section>
-
-      <!-- 明细表 -->
-      <section id="detail" class="content-pad" style="display:none;">
-        <div class="panel">
-          <h3>数据明细</h3>
-          <div class="table-wrapper">
-            <table id="report" class="display nowrap" style="width:100%"></table>
-          </div>
-        </div>
-      </section>
+      <section id="product" class="content-pad" style="display:none;"><p>产品分析建设中...</p></section>
     </div>
-  </div>
+  </main>
 </div>
 
 <script>
 /* ---------- UI 基础 ---------- */
-(function() { $('.has-submenu > a').on('click', function(e){ e.preventDefault(); $(this).parent().toggleClass('open'); }); })();
-$('.tab').on('click', function(){
-  $('.tab').removeClass('active'); $(this).addClass('active');
-  const id = $(this).data('tab'); $('#summary').toggle(id==='summary'); $('#detail').toggle(id==='detail');
-});
 const toNum = v => { if (v===null||v===undefined) return 0; if (typeof v==='number') return isFinite(v)?v:0; const n=parseFloat(String(v).replace(/,/g,'').trim()); return isNaN(n)?0:n; };
 
 
@@ -573,6 +551,52 @@ $('#metricSel').on('change', fetchAndRenderAll);
     }
   });
 })();
+</script>
+<script>
+document.addEventListener('DOMContentLoaded', ()=>{
+  const siteListKey='managedSites';
+  const currentSiteKey='currentSite';
+  let sites=JSON.parse(localStorage.getItem(siteListKey)||'null');
+  if(!Array.isArray(sites)||!sites.length){sites=['A站','B站','C站'];}
+  const menuEl=document.getElementById('managedMenu');
+  const currentSiteEl=document.getElementById('currentSite');
+  function save(){localStorage.setItem(siteListKey,JSON.stringify(sites));}
+  function renderMenu(){
+    menuEl.innerHTML='';
+    sites.forEach((name,idx)=>{
+      const li=document.createElement('li');
+      const a=document.createElement('a');
+      a.href='index.html';
+      a.textContent=name;
+      a.addEventListener('click',(e)=>{e.preventDefault();localStorage.setItem(currentSiteKey,name);window.location.href='index.html';});
+      a.addEventListener('dblclick',()=>{const n=prompt('修改站点名',name);if(n){sites[idx]=n;save();renderMenu();updateCurrent();}});
+      li.appendChild(a);menuEl.appendChild(li);
+    });
+  }
+  function updateCurrent(){
+    const name=localStorage.getItem(currentSiteKey)||sites[0];
+    currentSiteEl.textContent='自运营 '+name;
+    localStorage.setItem(currentSiteKey,name);
+  }
+  currentSiteEl.addEventListener('dblclick',()=>{
+    const cur=localStorage.getItem(currentSiteKey)||sites[0];
+    const idx=sites.indexOf(cur);
+    const n=prompt('修改站点名',cur);
+    if(n){sites[idx]=n;save();renderMenu();localStorage.setItem(currentSiteKey,n);updateCurrent();}
+  });
+  document.getElementById('addSite').addEventListener('click',()=>{
+    const n=prompt('新增站点名');
+    if(n){sites.push(n);save();renderMenu();updateCurrent();}
+  });
+  renderMenu();updateCurrent();
+  const userArea=document.getElementById('userArea');
+  function refreshUser(){
+    const u=localStorage.getItem('username');
+    if(u){userArea.textContent=u;}else{userArea.innerHTML='<a href="login.html">登录</a>';}
+  }
+  refreshUser();
+document.querySelectorAll('.sub-nav a').forEach(a=>{a.addEventListener('click',e=>{e.preventDefault();const t=a.dataset.target;document.querySelectorAll('.sub-nav a').forEach(x=>x.classList.remove('active'));a.classList.add('active');['detail','analysis','product'].forEach(id=>{const el=document.getElementById(id);if(el)el.style.display=id===t?'':'none';});});});
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add centered top navigation with platform menu and dropdown to switch sites
- simplify sidebar to editable site header and subpage links for analysis, detail and product views
- propagate navigation and login display across full-managed, self-operated, login and independent-site pages
- fix hidden AliExpress menu item and keep global navigation visible while scrolling
- ensure dropdown menus overlay page content and use bold typography for emphasis
- lighten and narrow the sidebar so managed and self-operated pages share the same expanded layout
- keep the self-operated sidebar expanded by default and show the detail view first
- organize analysis charts in responsive grids and adopt self-operated layout for the independent site
- hide native file inputs so each page shows a single “选择文件” button
- match the independent-site page UI to the full-managed layout with shared theme, centered title, stat cards and unified table section

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b2cf40a608325872a74b0b828bd3b