### PR TITLE
style: darken KPI cards and color new product card

### DIFF
--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -177,7 +177,7 @@ table.dataTable td{
 
 /* ------ KPI Cards (index.html) ------ */
 .stat-card{
-  background:#fff; border:1px solid var(--panel-border);
+  background:var(--kpi-bg); border:1px solid var(--kpi-border);
   border-radius:14px; padding:12px 14px; box-shadow:var(--shadow);
 }
 .stat-card h4{ margin:0 0 6px; color:#334155; font-size:12px; letter-spacing:.2px }
@@ -274,8 +274,8 @@ table.dataTable thead th.sorting_desc{
 .kpi::-webkit-scrollbar-thumb{ background:#e5e7eb; border-radius:999px }
 
 .kpi .card{
-  background:#fff;
-  border:1px solid var(--panel-border);
+  background:var(--kpi-bg);
+  border:1px solid var(--kpi-border);
   border-radius:14px;
   padding:12px 14px;
   min-width:200px;         /* keep readable width */
@@ -299,8 +299,8 @@ table.dataTable thead th.sorting_desc{
 
 /* New variable for KPI background */
 :root{
-  --kpi-bg: #f8fafc;           /* slightly darker than white */
-  --kpi-border: #e5e7eb;
+  --kpi-bg: #f1f5f9;           /* darker KPI background */
+  --kpi-border: #d1d5db;       /* matching darker border */
 }
 
 /* KPI: full-managed (#kpi .stat-card) */
@@ -315,22 +315,25 @@ table.dataTable thead th.sorting_desc{
 
 /* Gradient backgrounds for KPI cards */
 #kpi .stat-card:nth-child(1), .kpi .card:nth-child(1){
-  background:linear-gradient(135deg,#4f46e5,#7c3aed);
+  background:linear-gradient(135deg,#4338ca,#3730a3);
 }
 #kpi .stat-card:nth-child(2), .kpi .card:nth-child(2){
-  background:linear-gradient(135deg,#1d4ed8,#0e7490);
+  background:linear-gradient(135deg,#1e40af,#0c4a6e);
 }
 #kpi .stat-card:nth-child(3), .kpi .card:nth-child(3){
-  background:linear-gradient(135deg,#0e7490,#047857);
+  background:linear-gradient(135deg,#0f766e,#065f46);
 }
 #kpi .stat-card:nth-child(4), .kpi .card:nth-child(4){
-  background:linear-gradient(135deg,#047857,#3f6212);
+  background:linear-gradient(135deg,#166534,#365314);
 }
 #kpi .stat-card:nth-child(5), .kpi .card:nth-child(5){
-  background:linear-gradient(135deg,#3f6212,#ca8a04);
+  background:linear-gradient(135deg,#365314,#713f12);
 }
 #kpi .stat-card:nth-child(6), .kpi .card:nth-child(6){
-  background:linear-gradient(135deg,#ca8a04,#c2410c);
+  background:linear-gradient(135deg,#713f12,#7f1d1d);
+}
+#kpi .stat-card:nth-child(7), .kpi .card:nth-child(7){
+  background:linear-gradient(135deg,#7f1d1d,#9f1239);
 }
 
 #kpi .stat-card .sub{ margin-top:4px; font-size:12px; color:#f1f5f9; }

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
   <link rel="stylesheet" href="https://cdn.datatables.net/fixedheader/3.3.2/css/fixedHeader.dataTables.min.css">
   <link rel="stylesheet" href="assets/login.css">
-  <link rel="stylesheet" href="assets/theme.css?v=20250811-single">
+  <link rel="stylesheet" href="assets/theme.css?v=20250812-deep">
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
   <script src="https://cdn.datatables.net/fixedheader/3.3.2/js/dataTables.fixedHeader.min.js"></script>

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -19,7 +19,7 @@
 
   <!-- 主题样式（沿用你现有的） -->
   <link rel="stylesheet" href="assets/login.css">
-  <link rel="stylesheet" href="assets/theme.css?v=20250810b">
+  <link rel="stylesheet" href="assets/theme.css?v=20250812-deep">
   <style>
     /* NewKPICtrl */
     .kpi-ctrl{display:flex;gap:.5rem;align-items:center;margin:.25rem 0 .5rem;color:#334155;font:500 13px/1 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif}


### PR DESCRIPTION
## Summary
- darken KPI card backgrounds and apply deeper gradients, including a style for the 7th card to cover new product counts
- bump CSS version references on self-operated and full-managed pages

## Testing
- `npm test` *(fails: Missing script "test" )*


------
https://chatgpt.com/codex/tasks/task_e_689ecc99888483259034b906b8fdd765