### PR TITLE
Fix previous period comparison and scaffold Ozon pages

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -258,7 +258,7 @@
     let prev = '';
     if (state.periods && period){
       const idx = state.periods.indexOf(period);
-      if (idx > 0) prev = state.periods[idx-1];
+      if (idx >= 0 && idx < state.periods.length - 1) prev = state.periods[idx + 1];
     }
     const qsB = new URLSearchParams({ granularity: state.granularity });
     if (prev) qsB.set('period_end', prev);

--- a/public/operation-analysis.html
+++ b/public/operation-analysis.html
@@ -124,7 +124,7 @@ document.addEventListener('DOMContentLoaded',()=>{
       const period=document.getElementById('periodSelect').value;
       localStorage.setItem('fmPeriod', period || '');
       const idx=state.periods.indexOf(period);
-      const prev=idx>0?state.periods[idx-1]:'';
+      const prev=(idx>=0 && idx<state.periods.length-1)?state.periods[idx+1]:'';
       const qsA=new URLSearchParams({granularity:state.granularity});
       if(period)qsA.set('period_end',period);
       const qsB=new URLSearchParams({granularity:state.granularity});

--- a/public/ozon-operation-analysis.html
+++ b/public/ozon-operation-analysis.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Ozon 数据分析（建设中）</title>
+  <title>Ozon 运营分析（建设中）</title>
   <link rel="stylesheet" href="assets/login.css">
   <link rel="stylesheet" href="assets/theme.css?v=20250811-single">
   <script>const t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t);</script>
@@ -32,8 +32,8 @@
   <nav class="sidebar" id="sidebar">
     <div class="site-header"><span>Ozon</span></div>
     <ul class="sub-nav">
-      <li><a href="ozon.html" class="active">详细数据</a></li>
-      <li><a href="ozon-operation-analysis.html">运营分析</a></li>
+      <li><a href="ozon.html">详细数据</a></li>
+      <li><a href="ozon-operation-analysis.html" class="active">运营分析</a></li>
       <li><a href="ozon-product-analysis.html">产品分析</a></li>
     </ul>
   </nav>

--- a/public/ozon-product-analysis.html
+++ b/public/ozon-product-analysis.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Ozon 数据分析（建设中）</title>
+  <title>Ozon 产品分析（建设中）</title>
   <link rel="stylesheet" href="assets/login.css">
   <link rel="stylesheet" href="assets/theme.css?v=20250811-single">
   <script>const t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t);</script>
@@ -32,9 +32,9 @@
   <nav class="sidebar" id="sidebar">
     <div class="site-header"><span>Ozon</span></div>
     <ul class="sub-nav">
-      <li><a href="ozon.html" class="active">详细数据</a></li>
+      <li><a href="ozon.html">详细数据</a></li>
       <li><a href="ozon-operation-analysis.html">运营分析</a></li>
-      <li><a href="ozon-product-analysis.html">产品分析</a></li>
+      <li><a href="ozon-product-analysis.html" class="active">产品分析</a></li>
     </ul>
   </nav>
   <main class="main" style="display:flex;align-items:center;justify-content:center;">

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -63,8 +63,16 @@ document.addEventListener('DOMContentLoaded',()=>{
   const prodLink=document.getElementById('productLink');
   const platformNav=document.querySelector('.platform-nav');
   platformNav.querySelectorAll('li').forEach(li=>li.classList.remove('active'));
-  if(mode==='indep'){
-    platformNav.querySelector('li.independent')?.classList.add('active');
+  const platformMap={
+    indep:'li.independent',
+    ozon:'li.ozon',
+    amazon:'li.amazon',
+    tiktok:'li.tiktok',
+    temu:'li.temu'
+  };
+  const selector=platformMap[mode];
+  if(selector){
+    platformNav.querySelector(selector)?.classList.add('active');
   }else{
     const aliLi=platformNav.querySelector('li.ali');
     aliLi?.classList.add('active');
@@ -91,6 +99,9 @@ document.addEventListener('DOMContentLoaded',()=>{
   }else if(mode==='indep'){
     if(detailLink)detailLink.href='independent-site.html';
     if(analysisLink)analysisLink.removeAttribute('href');
+  }else if(mode==='ozon'){
+    if(detailLink)detailLink.href='ozon.html';
+    if(analysisLink)analysisLink.href='ozon-operation-analysis.html';
   }else{
     if(analysisLink)analysisLink.href='operation-analysis.html';
   }

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -149,7 +149,7 @@ document.addEventListener('DOMContentLoaded',()=>{
     async function loadData(){
       const period=document.getElementById('periodSelect').value;
       localStorage.setItem('fmPeriod',period||'');
-      const idx=state.periods.indexOf(period); const prev=idx>0?state.periods[idx-1]:'';
+        const idx=state.periods.indexOf(period); const prev=(idx>=0 && idx<state.periods.length-1)?state.periods[idx+1]:'';
       const qsA=new URLSearchParams({granularity:state.granularity}); if(period)qsA.set('period_end',period);
       const qsB=new URLSearchParams({granularity:state.granularity}); if(prev)qsB.set('period_end',prev);
       const [ja,jb]=await Promise.all([

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -16,7 +16,7 @@
   <div class="logo-title">跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
-      <li class="ali active"><a href="#">速卖通</a>
+      <li class="ali"><a href="#">速卖通</a>
         <ul class="dropdown">
           <li><a href="index.html">全托管</a></li>
           <li><a href="self-operated.html">自运营</a></li>
@@ -61,6 +61,20 @@ document.addEventListener('DOMContentLoaded',()=>{
   const detailLink=document.getElementById('detailLink');
   const analysisLink=document.getElementById('analysisLink');
   const prodLink=document.getElementById('productLink');
+  const platformNav=document.querySelector('.platform-nav');
+  platformNav.querySelectorAll('li').forEach(li=>li.classList.remove('active'));
+  if(mode==='indep'){
+    platformNav.querySelector('li.independent')?.classList.add('active');
+  }else{
+    const aliLi=platformNav.querySelector('li.ali');
+    aliLi?.classList.add('active');
+    aliLi?.querySelectorAll('.dropdown li').forEach(li=>li.classList.remove('active'));
+    if(mode==='self'){
+      aliLi?.querySelector('a[href="self-operated.html"]')?.parentElement.classList.add('active');
+    }else{
+      aliLi?.querySelector('a[href="index.html"]')?.parentElement.classList.add('active');
+    }
+  }
   function setProdLink(text,url){
     if(text && url){
       prodLink.textContent=text;


### PR DESCRIPTION
## Summary
- Correct previous period lookup for KPI comparisons to use chronological order
- Add placeholder Ozon detail, operation analysis, and product analysis pages styled like self-operated pages

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f2b18a8188325afb20778f40c1a14