### PR TITLE
chore: scaffold ozon module

### DIFF
--- a/Ozon_Product_Metrics_Update.md
+++ b/Ozon_Product_Metrics_Update.md
@@ -1,0 +1,49 @@
+# Ozon Product Metrics Update（for Codex）
+
+## 1. 数据库调整
+```sql
+-- 确保有 product_title 列
+ALTER TABLE public.ozon_daily_product_metrics
+  ADD COLUMN IF NOT EXISTS product_title text;
+
+-- 回填：优先已有的通用列；其次把之前的俄/中列合并（如果存在）
+UPDATE public.ozon_daily_product_metrics m
+SET product_title = COALESCE(
+  NULLIF(m.product_title, ''),
+  NULLIF(m.product_title_ru, ''),
+  NULLIF(m.product_title_zh, '')
+)
+WHERE m.product_title IS NULL OR m.product_title = '';
+
+-- 可选：清理旧列（如需）
+-- ALTER TABLE public.ozon_daily_product_metrics DROP COLUMN IF EXISTS product_title_ru;
+-- ALTER TABLE public.ozon_daily_product_metrics DROP COLUMN IF EXISTS product_title_zh;
+
+-- 索引建议（已有可略）
+CREATE INDEX IF NOT EXISTS idx_ozon_dpm_store_day   ON public.ozon_daily_product_metrics (store_id, day);
+CREATE INDEX IF NOT EXISTS idx_ozon_dpm_store_prod  ON public.ozon_daily_product_metrics (store_id, product_id);
+```
+
+## 2. 产品 URL 拼接
+不在数据库层生成 URL，避免 PG 托管兼容性问题。**前端拼接即可**：
+```js
+const productUrl = `https://ozon.ru/product/${product_id}`;
+```
+
+## 3. 前端展示规范
+- 明细表/分析页 **产品名列**：
+  - 文本：`product_title`（保持原文，俄文/英文均可）
+  - 超链接：点击跳转到 Ozon 落地页
+  - 示例：
+    ```html
+    <a href={"https://ozon.ru/product/" + product_id} target="_blank" rel="noopener">
+      {product_title || product_id}
+    </a>
+    ```
+- 若 `product_title` 为空，回退展示 `product_id`。
+
+## 4. 给 Codex 的开发指导
+1. 使用现有的 `product_id` + `product_title` 字段，不再额外生成 `product_url` 列。
+2. 前端在渲染时拼接 URL，点击跳转至 Ozon 商品页。
+3. 产品名保持原文（UTF-8 俄文/英文），不做翻译。
+4. 确保 DataTable 筛选和 KPI 卡片展示时，产品名均为可点击的跳转链接。

--- a/api/ozon/periods/index.js
+++ b/api/ozon/periods/index.js
@@ -1,0 +1,36 @@
+const { createClient } = require("@supabase/supabase-js");
+
+function supa() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
+  if (!url || !key) throw new Error("Missing Supabase env");
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+function weekEnd(iso) {
+  const d = new Date(iso + "T00:00:00Z");
+  d.setUTCDate(d.getUTCDate() - d.getUTCDay() + 6); // Sunday week end
+  return d.toISOString().slice(0, 10);
+}
+function monthEnd(iso) {
+  const d = new Date(iso + "T00:00:00Z");
+  d.setUTCMonth(d.getUTCMonth() + 1, 0); // last day of month
+  return d.toISOString().slice(0, 10);
+}
+
+module.exports = async (req, res) => {
+  try {
+    const supabase = supa();
+    const { data, error } = await supabase
+      .from("ozon_daily_product_metrics")
+      .select("day")
+      .order("day", { ascending: false });
+    if (error) throw error;
+    const days = (data || []).map(r => r.day);
+    const weeks = Array.from(new Set(days.map(weekEnd))).sort().reverse();
+    const months = Array.from(new Set(days.map(monthEnd))).sort().reverse();
+    res.status(200).json({ ok: true, weeks, months });
+  } catch (e) {
+    res.status(500).json({ ok: false, msg: e.message });
+  }
+};

--- a/api/ozon/stats/index.js
+++ b/api/ozon/stats/index.js
@@ -1,0 +1,22 @@
+const { createClient } = require("@supabase/supabase-js");
+
+function supa() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
+  if (!url || !key) throw new Error("Missing Supabase env");
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+module.exports = async (req, res) => {
+  if (req.method !== "GET") {
+    return res.status(405).json({ ok: false, msg: "Only GET" });
+  }
+  try {
+    const supabase = supa();
+    const { store_id, start_date, end_date, only_new } = req.query;
+    // TODO: 查询 ozon_daily_product_metrics 与 ozon_first_seen 计算 KPI
+    res.status(200).json({ ok: true, kpis: {}, rows: [] });
+  } catch (e) {
+    res.status(500).json({ ok: false, msg: e.message });
+  }
+};

--- a/public/amazon.html
+++ b/public/amazon.html
@@ -22,7 +22,7 @@
       <li class="amazon active"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
-      <li class="ozon"><a href="ozon.html">Ozon</a></li>
+      <li class="ozon"><a href="ozon-detail.html">Ozon</a></li>
       <li class="independent"><a href="independent-site.html">独立站</a></li>
     </ul>
   </nav>

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -37,7 +37,7 @@
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
-      <li class="ozon"><a href="ozon.html">Ozon</a></li>
+      <li class="ozon"><a href="ozon-detail.html">Ozon</a></li>
       <li class="independent active"><a href="independent-site.html">独立站</a></li>
     </ul>
   </nav>

--- a/public/index.html
+++ b/public/index.html
@@ -78,7 +78,7 @@
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
-      <li class="ozon"><a href="ozon.html">Ozon</a></li>
+      <li class="ozon"><a href="ozon-detail.html">Ozon</a></li>
       <li class="independent"><a href="independent-site.html">独立站</a></li>
     </ul>
   </nav>

--- a/public/operation-analysis.html
+++ b/public/operation-analysis.html
@@ -24,7 +24,7 @@
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
-      <li class="ozon"><a href="ozon.html">Ozon</a></li>
+      <li class="ozon"><a href="ozon-detail.html">Ozon</a></li>
       <li class="independent"><a href="independent-site.html">独立站</a></li>
     </ul>
   </nav>

--- a/public/ozon-analysis.html
+++ b/public/ozon-analysis.html
@@ -22,7 +22,7 @@
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
-      <li class="ozon active"><a href="ozon.html">Ozon</a></li>
+      <li class="ozon active"><a href="ozon-detail.html">Ozon</a></li>
       <li class="independent"><a href="independent-site.html">独立站</a></li>
     </ul>
   </nav>
@@ -32,9 +32,9 @@
   <nav class="sidebar" id="sidebar">
     <div class="site-header"><span>Ozon</span></div>
     <ul class="sub-nav">
-      <li><a href="ozon.html">详细数据</a></li>
-      <li><a href="ozon-operation-analysis.html" class="active">运营分析</a></li>
-      <li><a href="ozon-product-analysis.html">产品分析</a></li>
+      <li><a href="ozon-detail.html">数据明细</a></li>
+      <li><a href="ozon-analysis.html" class="active">运营分析</a></li>
+      <li><a href="ozon-product-insights.html">产品分析</a></li>
     </ul>
   </nav>
   <main class="main" style="display:flex;align-items:center;justify-content:center;">

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Ozon 产品分析（建设中）</title>
+  <title>Ozon 数据明细（建设中）</title>
   <link rel="stylesheet" href="assets/login.css">
   <link rel="stylesheet" href="assets/theme.css?v=20250811-single">
   <script>const t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t);</script>
@@ -22,7 +22,7 @@
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
-      <li class="ozon active"><a href="ozon.html">Ozon</a></li>
+      <li class="ozon active"><a href="ozon-detail.html">Ozon</a></li>
       <li class="independent"><a href="independent-site.html">独立站</a></li>
     </ul>
   </nav>
@@ -32,9 +32,9 @@
   <nav class="sidebar" id="sidebar">
     <div class="site-header"><span>Ozon</span></div>
     <ul class="sub-nav">
-      <li><a href="ozon.html">详细数据</a></li>
-      <li><a href="ozon-operation-analysis.html">运营分析</a></li>
-      <li><a href="ozon-product-analysis.html" class="active">产品分析</a></li>
+      <li><a href="ozon-detail.html" class="active">数据明细</a></li>
+      <li><a href="ozon-analysis.html">运营分析</a></li>
+      <li><a href="ozon-product-insights.html">产品分析</a></li>
     </ul>
   </nav>
   <main class="main" style="display:flex;align-items:center;justify-content:center;">

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -45,6 +45,9 @@
           <span class="badge">时间粒度</span>
           <span class="sel" style="background:#1f2937;color:#fff;border-color:#334155;cursor:not-allowed">按日</span>
           <input type="hidden" value="day">
+          <label for="file" id="pickLabel" class="upload-btn">选择文件</label>
+          <input type="file" id="file" accept=".xlsx,.xls,.csv" />
+          <span id="status" class="notice"></span>
         </div>
       </div>
     </div>

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Ozon 数据明细（建设中）</title>
+  <title>Ozon 数据明细</title>
   <link rel="stylesheet" href="assets/login.css">
   <link rel="stylesheet" href="assets/theme.css?v=20250811-single">
   <script>const t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t);</script>
@@ -37,8 +37,44 @@
       <li><a href="ozon-product-insights.html">产品分析</a></li>
     </ul>
   </nav>
-  <main class="main" style="display:flex;align-items:center;justify-content:center;">
-    <h2 style="font-size:24px;font-weight:700;">页面建设中…</h2>
+  <main class="main">
+    <div class="upload-section">
+      <div class="upload-top">
+        <div style="font-size:28px;font-weight:800;">Ozon 数据明细</div>
+        <div class="controls">
+          <span class="badge">时间粒度</span>
+          <span class="sel" style="background:#1f2937;color:#fff;border-color:#334155;cursor:not-allowed">按日</span>
+          <input type="hidden" value="day">
+        </div>
+      </div>
+    </div>
+
+    <div class="content">
+      <section id="detail" class="content-pad">
+        <div class="panel">
+          <h3>数据明细</h3>
+          <div class="table-wrapper">
+            <table id="report" class="display" style="width:100%">
+              <thead>
+                <tr>
+                  <th>商品ID</th>
+                  <th>曝光量</th>
+                  <th>访客数</th>
+                  <th>浏览量</th>
+                  <th>加购人数</th>
+                  <th>加购件数</th>
+                  <th>支付件数</th>
+                  <th>支付订单数</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td colspan="8" style="text-align:center;">暂无数据</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+    </div>
   </main>
 </div>
 </body>

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -65,18 +65,18 @@
               <thead>
                 <tr>
                   <th>商品ID</th>
+                  <th>日期</th>
                   <th>曝光量</th>
                   <th>访客数</th>
                   <th>浏览量</th>
                   <th>加购人数</th>
-                  <th>加购件数</th>
-                  <th>支付件数</th>
-                  <th>支付订单数</th>
+                  <th>订单数</th>
+                  <th>买家数</th>
+                  <th>GMV</th>
+                  <th>新品标记</th>
                 </tr>
               </thead>
-              <tbody>
-                <tr><td colspan="8" style="text-align:center;">暂无数据</td></tr>
-              </tbody>
+              <tbody></tbody>
             </table>
           </div>
         </div>
@@ -93,10 +93,13 @@
         paging:true,
         searching:true,
         info:true,
-        order:[[2,'desc']],
+        order:[[3,'desc']],
         scrollY:'60vh',
         scrollCollapse:true,
-        autoWidth:false
+        autoWidth:false,
+        language:{
+          emptyTable:'暂无数据'
+        }
       });
     }
     return table;
@@ -115,8 +118,16 @@
         const rows = arr.slice(1).filter(r=>r&&r.length);
         if(!rows.length){ setStatus('文件无数据'); return; }
         const mapped = rows.map(r=>[
-          r[0]||'', r[1]||0, r[2]||0, r[3]||0,
-          r[4]||0, r[5]||0, r[6]||0, r[7]||0
+          r[0]||'',             // 商品ID
+          r[1]||'',             // 日期
+          r[2]||0,              // 曝光量
+          r[3]||0,              // 访客数
+          r[4]||0,              // 浏览量
+          r[5]||0,              // 加购人数
+          r[6]||0,              // 订单数
+          r[7]||0,              // 买家数
+          r[8]||0,              // GMV
+          r[9] ? '是' : ''      // 新品标记
         ]);
         const dt = initTable();
         dt.clear().rows.add(mapped).draw();

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -4,8 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Ozon 数据明细</title>
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
   <link rel="stylesheet" href="assets/login.css">
   <link rel="stylesheet" href="assets/theme.css?v=20250811-single">
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
   <script>const t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t);</script>
 </head>
 <body class="fm">
@@ -80,5 +84,50 @@
     </div>
   </main>
 </div>
+<script>
+(function(){
+  let table = null;
+  function initTable(){
+    if(!table){
+      table = $('#report').DataTable({
+        paging:true,
+        searching:true,
+        info:true,
+        order:[[2,'desc']],
+        scrollY:'60vh',
+        scrollCollapse:true,
+        autoWidth:false
+      });
+    }
+    return table;
+  }
+  function setStatus(t){ $('#status').text(t||''); }
+  $('#file').on('change', function(e){
+    const file = e.target.files[0];
+    if(!file) return;
+    const reader = new FileReader();
+    reader.onload = function(ev){
+      try{
+        const data = new Uint8Array(ev.target.result);
+        const wb = XLSX.read(data, { type:'array' });
+        const ws = wb.Sheets[wb.SheetNames[0]];
+        const arr = XLSX.utils.sheet_to_json(ws, { header:1 });
+        const rows = arr.slice(1).filter(r=>r&&r.length);
+        if(!rows.length){ setStatus('文件无数据'); return; }
+        const mapped = rows.map(r=>[
+          r[0]||'', r[1]||0, r[2]||0, r[3]||0,
+          r[4]||0, r[5]||0, r[6]||0, r[7]||0
+        ]);
+        const dt = initTable();
+        dt.clear().rows.add(mapped).draw();
+        setStatus('已加载 '+rows.length+' 行');
+      }catch(err){ console.error(err); setStatus('解析失败'); }
+    };
+    reader.onerror = ()=> setStatus('读取失败');
+    reader.readAsArrayBuffer(file);
+    e.target.value='';
+  });
+})();
+</script>
 </body>
 </html>

--- a/public/ozon-product-insights.html
+++ b/public/ozon-product-insights.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Ozon 数据分析（建设中）</title>
+  <title>Ozon 产品分析（建设中）</title>
   <link rel="stylesheet" href="assets/login.css">
   <link rel="stylesheet" href="assets/theme.css?v=20250811-single">
   <script>const t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t);</script>
@@ -22,7 +22,7 @@
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
-      <li class="ozon active"><a href="ozon.html">Ozon</a></li>
+      <li class="ozon active"><a href="ozon-detail.html">Ozon</a></li>
       <li class="independent"><a href="independent-site.html">独立站</a></li>
     </ul>
   </nav>
@@ -32,9 +32,9 @@
   <nav class="sidebar" id="sidebar">
     <div class="site-header"><span>Ozon</span></div>
     <ul class="sub-nav">
-      <li><a href="ozon.html" class="active">详细数据</a></li>
-      <li><a href="ozon-operation-analysis.html">运营分析</a></li>
-      <li><a href="ozon-product-analysis.html">产品分析</a></li>
+      <li><a href="ozon-detail.html">数据明细</a></li>
+      <li><a href="ozon-analysis.html">运营分析</a></li>
+      <li><a href="ozon-product-insights.html" class="active">产品分析</a></li>
     </ul>
   </nav>
   <main class="main" style="display:flex;align-items:center;justify-content:center;">

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -25,7 +25,7 @@
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
-      <li class="ozon"><a href="ozon.html">Ozon</a></li>
+      <li class="ozon"><a href="ozon-detail.html">Ozon</a></li>
       <li class="independent"><a href="independent-site.html">独立站</a></li>
     </ul>
   </nav>
@@ -100,8 +100,8 @@ document.addEventListener('DOMContentLoaded',()=>{
     if(detailLink)detailLink.href='independent-site.html';
     if(analysisLink)analysisLink.removeAttribute('href');
   }else if(mode==='ozon'){
-    if(detailLink)detailLink.href='ozon.html';
-    if(analysisLink)analysisLink.href='ozon-operation-analysis.html';
+    if(detailLink)detailLink.href='ozon-detail.html';
+    if(analysisLink)analysisLink.href='ozon-analysis.html';
   }else{
     if(analysisLink)analysisLink.href='operation-analysis.html';
   }

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -77,7 +77,7 @@
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
-      <li class="ozon"><a href="ozon.html">Ozon</a></li>
+      <li class="ozon"><a href="ozon-detail.html">Ozon</a></li>
       <li class="independent"><a href="independent-site.html">独立站</a></li>
     </ul>
   </nav>

--- a/public/temu.html
+++ b/public/temu.html
@@ -22,7 +22,7 @@
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu active"><a href="temu.html">Temu</a></li>
-      <li class="ozon"><a href="ozon.html">Ozon</a></li>
+      <li class="ozon"><a href="ozon-detail.html">Ozon</a></li>
       <li class="independent"><a href="independent-site.html">独立站</a></li>
     </ul>
   </nav>

--- a/public/tiktok.html
+++ b/public/tiktok.html
@@ -22,7 +22,7 @@
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok active"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
-      <li class="ozon"><a href="ozon.html">Ozon</a></li>
+      <li class="ozon"><a href="ozon-detail.html">Ozon</a></li>
       <li class="independent"><a href="independent-site.html">独立站</a></li>
     </ul>
   </nav>

--- a/supabase_schema (1).sql
+++ b/supabase_schema (1).sql
@@ -92,3 +92,47 @@ drop policy if exists p_upd_all on public.ae_self_operated_daily;
 -- 2) 如需 authenticated 可读：将上面的 'to anon' 改为 'to authenticated' 或同时保留两者。
 -- 3) 所有写入仅经由 Vercel Serverless（service role）完成，RLS 会被绕过（admin）。
 */
+
+-- Ozon 数据表
+create table if not exists public.ozon_daily_product_metrics (
+  store_id text not null,
+  day date not null,
+  product_id text not null,
+  impressions numeric default 0,
+  sessions numeric default 0,
+  pageviews numeric default 0,
+  add_to_cart_users numeric default 0,
+  add_to_cart_qty numeric default 0,
+  orders numeric default 0,
+  buyers numeric default 0,
+  items_sold numeric default 0,
+  revenue numeric default 0,
+  campaign text,
+  traffic_source text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (store_id, day, product_id)
+);
+create index if not exists idx_ozon_daily_store_day on public.ozon_daily_product_metrics(store_id, day);
+create index if not exists idx_ozon_daily_store_product on public.ozon_daily_product_metrics(store_id, product_id);
+
+create table if not exists public.ozon_first_seen (
+  store_id text not null,
+  product_id text not null,
+  first_seen_date date not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (store_id, product_id)
+);
+
+create table if not exists public.ozon_order_items (
+  order_id text not null,
+  store_id text not null,
+  product_id text not null,
+  day date not null,
+  quantity numeric default 0,
+  price numeric default 0,
+  revenue numeric default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);


### PR DESCRIPTION
## Summary
- add placeholder Ozon HTML pages and navigation
- introduce stub API endpoints for Ozon periods and stats
- extend Supabase schema with Ozon tables

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a02151600c8325ab689f708a5835c0