### PR TITLE
fix: relax ozon import constraints

### DIFF
--- a/api/ozon/import/index.js
+++ b/api/ozon/import/index.js
@@ -213,14 +213,14 @@ module.exports = async function handler(req,res){
       return bad(res, 400, 'preflight', pre.error, { table: TABLE, rawTable: RAW_TABLE });
     }
 
-    // upsert（修复：.schema('public').from(TABLE)；不再写 'public.xxx'）
+    // insert（修复：.schema('public').from(TABLE)；不再写 'public.xxx'，且取消 onConflict 主键）
     let attempt = 0;
     let error;
     do{
       const resInsert = await supabase
         .schema('public')
         .from(TABLE) // ✅ 只传裸表名，避免 public.public
-        .upsert(rows, { onConflict: 'tovary,den' });
+        .insert(rows);
       error = resInsert.error;
       if(error && /schema cache/i.test(error.message)){
         await refresh();

--- a/api/ozon/import/index.js
+++ b/api/ozon/import/index.js
@@ -39,7 +39,12 @@ function translit(s){
 }
 const headerAliases = {
   'voronka_prodazh_unikalnye_posetiteli_s_prosmotrom_v_poiske_ili_kataloge': 'voronka_prodazh_uv_s_prosmotrom_v_poiske_ili_kataloge',
-  'voronka_prodazh_unikalnye_posetiteli_s_prosmotrom_kartochki_tovara': 'voronka_prodazh_uv_s_prosmotrom_kartochki_tovara'
+  'voronka_prodazh_unikalnye_posetiteli_s_prosmotrom_kartochki_tovara': 'voronka_prodazh_uv_s_prosmotrom_kartochki_tovara',
+  // Ozon occasionally appends "ASUV" to these headers; map them back to the base column
+  'voronka_prodazh_uv_s_prosmotrom_v_poiske_ili_katalogeasuv': 'voronka_prodazh_uv_s_prosmotrom_v_poiske_ili_kataloge',
+  'voronka_prodazh_unikalnye_posetiteli_s_prosmotrom_v_poiske_ili_katalogeasuv': 'voronka_prodazh_uv_s_prosmotrom_v_poiske_ili_kataloge',
+  'voronka_prodazh_uv_s_prosmotrom_kartochki_tovaraasuv': 'voronka_prodazh_uv_s_prosmotrom_kartochki_tovara',
+  'voronka_prodazh_unikalnye_posetiteli_s_prosmotrom_kartochki_tovaraasuv': 'voronka_prodazh_uv_s_prosmotrom_kartochki_tovara'
 };
 
 function parseSheet(path){

--- a/api/ozon/import/index0817.js
+++ b/api/ozon/import/index0817.js
@@ -28,7 +28,12 @@ function translit(s){
 
 const headerAliases = {
   'voronka_prodazh_unikalnye_posetiteli_s_prosmotrom_v_poiske_ili_kataloge': 'voronka_prodazh_uv_s_prosmotrom_v_poiske_ili_kataloge',
-  'voronka_prodazh_unikalnye_posetiteli_s_prosmotrom_kartochki_tovara': 'voronka_prodazh_uv_s_prosmotrom_kartochki_tovara'
+  'voronka_prodazh_unikalnye_posetiteli_s_prosmotrom_kartochki_tovara': 'voronka_prodazh_uv_s_prosmotrom_kartochki_tovara',
+  // Handle occasional "ASUV" suffixes by mapping them to base columns
+  'voronka_prodazh_uv_s_prosmotrom_v_poiske_ili_katalogeasuv': 'voronka_prodazh_uv_s_prosmotrom_v_poiske_ili_kataloge',
+  'voronka_prodazh_unikalnye_posetiteli_s_prosmotrom_v_poiske_ili_katalogeasuv': 'voronka_prodazh_uv_s_prosmotrom_v_poiske_ili_kataloge',
+  'voronka_prodazh_uv_s_prosmotrom_kartochki_tovaraasuv': 'voronka_prodazh_uv_s_prosmotrom_kartochki_tovara',
+  'voronka_prodazh_unikalnye_posetiteli_s_prosmotrom_kartochki_tovaraasuv': 'voronka_prodazh_uv_s_prosmotrom_kartochki_tovara'
 };
 
 function parseSheet(path){

--- a/api/ozon/kpi/index.js
+++ b/api/ozon/kpi/index.js
@@ -7,10 +7,20 @@ function supa(){
   return createClient(url, key, { auth: { persistSession: false } });
 }
 
+function normalizeTableName(name, fallback = 'ozon_product_report_wide'){
+  let t = (name || fallback).trim();
+  t = t.replace(/^"+|"+$/g, '');
+  t = t.replace(/^public\./i, '');
+  return t;
+}
+
 module.exports = async function handler(req,res){
   try{
     const supabase = supa();
     let { date } = req.query || {};
+
+    const RAW_TABLE = process.env.OZON_TABLE_NAME || 'ozon_product_report_wide';
+    const TABLE = normalizeTableName(RAW_TABLE);
 
     async function refresh(){
       const { error } = await supabase.rpc('refresh_ozon_schema_cache');
@@ -22,7 +32,7 @@ module.exports = async function handler(req,res){
       let colData;
       for(let attempt=0;attempt<2;attempt++){
         const { data, error } = await supabase
-          .rpc('get_public_columns', { table_name: 'ozon_product_report_wide' });
+          .rpc('get_public_columns', { table_name: TABLE });
         if(!error){
           colData = data;
           break;
@@ -46,7 +56,8 @@ module.exports = async function handler(req,res){
     const uvCol = uvCandidates.find(c=>tableCols.includes(c)) || uvCandidates[0];
 
     const datesResp = await supabase
-      .from('public.ozon_product_report_wide')
+      .schema('public')
+      .from(TABLE)
       .select('den')
       .not('den', 'is', null)
       .order('den', { ascending: false });
@@ -66,11 +77,11 @@ module.exports = async function handler(req,res){
     const prevDate = dates[curIndex+1] || null;
 
     const select = `sku,tovary,voronka_prodazh_pokazy_vsego,${uvCol} as uv,voronka_prodazh_dobavleniya_v_korzinu_vsego,voronka_prodazh_vykupleno_tovarov`;
-    const curResp = await supabase.from('public.ozon_product_report_wide').select(select).eq('den', date);
+    const curResp = await supabase.schema('public').from(TABLE).select(select).eq('den', date);
     if(curResp.error) throw curResp.error;
     let prevResp = { data: [] };
     if(prevDate){
-      prevResp = await supabase.from('public.ozon_product_report_wide').select(select).eq('den', prevDate);
+      prevResp = await supabase.schema('public').from(TABLE).select(select).eq('den', prevDate);
       if(prevResp.error) throw prevResp.error;
     }
     function agg(rows){

--- a/api/ozon/kpi/index.js
+++ b/api/ozon/kpi/index.js
@@ -76,7 +76,9 @@ module.exports = async function handler(req,res){
     const curIndex = dates.indexOf(date);
     const prevDate = dates[curIndex+1] || null;
 
-    const select = `sku,tovary,voronka_prodazh_pokazy_vsego,${uvCol} as uv,voronka_prodazh_dobavleniya_v_korzinu_vsego,voronka_prodazh_vykupleno_tovarov`;
+
+ const select = `sku,tovary,voronka_prodazh_pokazy_vsego,uv:${uvCol},voronka_prodazh_dobavleniya_v_korzinu_vsego,voronka_prodazh_vykupleno_tovarov`;
+
     const curResp = await supabase.schema('public').from(TABLE).select(select).eq('den', date);
     if(curResp.error) throw curResp.error;
     let prevResp = { data: [] };

--- a/api/ozon/stats/index.js
+++ b/api/ozon/stats/index.js
@@ -75,7 +75,8 @@ module.exports = async function handler(req,res){
       return res.json({ok:true, rows:[], date:null, dates});
     }
 
-    const selectCols = `sku,tovary,voronka_prodazh_pokazy_vsego,voronka_prodazh_pokazy_v_poiske_i_kataloge,${uvCol} as uv,voronka_prodazh_dobavleniya_v_korzinu_vsego,voronka_prodazh_zakazano_tovarov,voronka_prodazh_vykupleno_tovarov`;
+ 
+    const selectCols = `sku,tovary,voronka_prodazh_pokazy_vsego,voronka_prodazh_pokazy_v_poiske_i_kataloge,uv:${uvCol},voronka_prodazh_dobavleniya_v_korzinu_vsego,voronka_prodazh_zakazano_tovarov,voronka_prodazh_vykupleno_tovarov`;
 
     const { data, error } = await supabase
       .schema('public')

--- a/ozon.sql
+++ b/ozon.sql
@@ -78,8 +78,7 @@ create table public.ozon_product_report_wide (
   faktory_prodazh_skolko_tovarov_postavit numeric null,
   faktory_prodazh_srednee_vremya_dostavki numeric null,
   faktory_prodazh_otzyvy numeric null,
-  faktory_prodazh_reyting_tovara numeric null,
-  primary key (tovary, den)
+  faktory_prodazh_reyting_tovara numeric null
 );
 
 create or replace function public.refresh_ozon_schema_cache()


### PR DESCRIPTION
## Summary
- insert rows into Ozon product report without relying on `tovary,den` primary key
- query Ozon report table through `.schema('public')` with normalized table name

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a16b8e532c8325bcc106dab0066154