### PR TITLE
Remove refresh buttons and add load status

### DIFF
--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -69,7 +69,7 @@
           <select id="networkSel"><option value="">全部</option></select>
           <label>Campaign：</label>
           <select id="campaignSel"><option value="">全部</option></select>
-          <button id="refreshBtn" class="btn">刷新</button>
+          <span id="status" class="small"></span>
           <button id="uploadBtn" class="btn">上传数据</button>
           <input type="file" id="fileInput" accept=".xlsx,.csv" style="display:none;">
           <span id="uploadStatus" class="small"></span>
@@ -187,6 +187,7 @@
   const columnToggle = document.getElementById('columnToggle');
   const networkSel = document.getElementById('networkSel');
   const campaignSel = document.getElementById('campaignSel');
+  const loadStatusEl = document.getElementById('status');
   const clearBtn = document.getElementById('clearFilter');
   const optionalCols = [
     { idx:1, label:'设备' }
@@ -202,6 +203,9 @@
   let dt;
   let rawTable = [];
   let onlyNew = false;
+  siteInput.addEventListener('change', load);
+  fromInput.addEventListener('change', load);
+  toInput.addEventListener('change', load);
 
   function periodShift(startISO, endISO){
     const start=new Date(startISO+'T00:00:00'); const end=new Date(endISO+'T00:00:00');
@@ -310,8 +314,8 @@
   }
 
   $('#columnMenu').on('change','input[type=checkbox]', buildTable);
-  networkSel.addEventListener('change', buildTable);
-  campaignSel.addEventListener('change', buildTable);
+  networkSel.addEventListener('change', load);
+  campaignSel.addEventListener('change', load);
 
   // 默认站点取 url 参数或从示例取
   siteInput.value = getParam('site') || localStorage.getItem('indepSite') || 'poolsvacuum.com';
@@ -336,6 +340,7 @@
   }
 
   async function load() {
+    loadStatusEl.textContent = '加载中...';
     try {
       const site = siteInput.value.trim();
       localStorage.setItem('indepSite', site);
@@ -419,13 +424,14 @@
         ]
       });
       enhanceMeta(document.getElementById('topTable'));
+      loadStatusEl.textContent = '加载完成';
     } catch(e) {
       console.error(e);
+      loadStatusEl.textContent = '加载失败';
       alert(e.message || '加载失败');
     }
   }
 
-  document.getElementById('refreshBtn').addEventListener('click', load);
   clearBtn.addEventListener('click', () => { onlyNew = false; load(); });
   // 上传逻辑
   const fileInput = document.getElementById('fileInput');

--- a/public/index.html
+++ b/public/index.html
@@ -248,6 +248,7 @@
 
   
   async function loadData(){
+    setStatus('加载中...');
     const period = $('#periodSelect').val();
     localStorage.setItem('fmPeriod', period || '');
     localStorage.setItem('fmGranularity', state.granularity);
@@ -264,10 +265,11 @@
     if (prev) qsB.set('period_end', prev);
 
     // Fetch current (A) and previous (B) in parallel (B optional)
-    const [ra, rb] = await Promise.all([ fetch('/api/stats?'+qsA.toString()), prev? fetch('/api/stats?'+qsB.toString()) : Promise.resolve(null) ]);
-    const ja = await ra.json();
-    const jb = rb ? await rb.json() : { ok:true, rows:[] };
-    if (!ja.ok){ alert(ja.msg||'查询失败'); return; }
+    try{
+      const [ra, rb] = await Promise.all([ fetch('/api/stats?'+qsA.toString()), prev? fetch('/api/stats?'+qsB.toString()) : Promise.resolve(null) ]);
+      const ja = await ra.json();
+      const jb = rb ? await rb.json() : { ok:true, rows:[] };
+      if (!ja.ok) throw new Error(ja.msg||'查询失败');
 
     // render KPI for current period (A)
     try{ renderKPI(ja.kpis || {}, jb.kpis || {}); }catch(e){}
@@ -294,6 +296,11 @@
     populateProductNames(document.getElementById('report'));
     renderAnalysis(window._rowsA, window._rowsB);
     renderProduct(window._rowsA, window._rowsB);
+    setStatus('加载完成');
+    }catch(err){
+      console.error(err);
+      setStatus('加载失败');
+    }
   }
 
   function card(title, cur, prev, isPercent){
@@ -746,7 +753,7 @@
     });
     obs.observe(document.body, { childList:true, subtree:true });
 
-    // Also refresh when table changes (user点击刷新/切换周期导致数据重绘)
+    // Also refresh when table changes (切换周期导致数据重绘)
     const tbody = document.querySelector('#report tbody');
     if (tbody){
       const tObs = new MutationObserver(()=>{ updateForCurrentWeek(); });

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -59,7 +59,6 @@
           <input type="hidden" value="day">
           <span>日期</span>
           <input id="dateFilter" class="date-filter" placeholder="选择日期范围">
-          <button id="refreshBtn" class="btn">刷新</button>
           <label for="file" id="pickLabel" class="upload-btn">选择文件</label>
           <input type="file" id="file" accept=".xlsx,.xls,.csv" />
           <span id="status" class="notice"></span>
@@ -126,6 +125,7 @@
   function setStatus(t){ $('#status').text(t||''); }
 
   async function loadData(){
+    setStatus('加载中...');
     const range = $('#dateFilter').val();
     let startISO, endISO;
     if(range && range.includes(' to ')){
@@ -146,11 +146,12 @@
     }
     currentStart = startISO;
     currentEnd = endISO;
-    const url = `/api/ozon/stats?store_id=${encodeURIComponent(storeId)}&start=${startISO}&end=${endISO}`;
-    const resp = await fetch(url);
-    const json = await resp.json();
-    if(!json.ok) throw new Error(json.msg||'查询失败');
-    const mapped = (json.rows||[]).map(r=>{
+    try{
+      const url = `/api/ozon/stats?store_id=${encodeURIComponent(storeId)}&start=${startISO}&end=${endISO}`;
+      const resp = await fetch(url);
+      const json = await resp.json();
+      if(!json.ok) throw new Error(json.msg||'查询失败');
+      const mapped = (json.rows||[]).map(r=>{
       const impressions = Number(r.exposure)||0;
       const sessions = Number(r.uv)||0;
       const pageviews = Number(r.pv)||0;
@@ -177,9 +178,15 @@
         visitRate
       ];
     });
-    const dt = initTable();
-    dt.clear().rows.add(mapped).draw();
-    loadKpi().catch(err=>console.error(err));
+      const dt = initTable();
+      dt.clear().rows.add(mapped).draw();
+      loadKpi().catch(err=>console.error(err));
+      setStatus('加载完成');
+    }catch(err){
+      console.error(err);
+      setStatus('加载失败');
+      throw err;
+    }
   }
 
   async function upload(file){
@@ -236,9 +243,7 @@
     try{
       setStatus('上传中...');
       await upload(file);
-      setStatus('加载数据...');
       await loadData();
-      setStatus('完成');
     }catch(err){ console.error(err); setStatus('失败: '+err.message); }
     e.target.value='';
   });
@@ -246,7 +251,6 @@
   document.getElementById('newModal').addEventListener('click',e=>{ if(e.target.id==='newModal') e.currentTarget.style.display='none'; });
 
   window.fp = flatpickr('#dateFilter',{ mode:'range', dateFormat:'Y-m-d', onClose:(ds)=>{ if(ds.length===2) loadData().catch(err=>console.error(err)); } });
-  $('#refreshBtn').on('click',()=>loadData().catch(err=>console.error(err)));
   loadData().catch(err=>console.error(err));
 })();
 </script>

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -109,7 +109,7 @@
           <input type="hidden" id="granularity" value="day">
           <span>日期：</span>
           <input id="dateFilter" class="date-filter" placeholder="选择日期范围">
-          <button id="refreshBtn" class="btn">刷新</button>
+          <span id="status" class="notice"></span>
         </div>
       </div>
       <div class="divider"></div>
@@ -277,7 +277,8 @@ $('#fileInput').on('change', function(e) {
       const resp = await fetch('/api/ae_upsert', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ rows: deduped }) });
       const txt = await resp.text(); let j; try { j = JSON.parse(txt); } catch(e) { throw new Error('Upsert API响应不是JSON：' + txt.slice(0,200)); }
       if (!resp.ok || !j.ok) throw new Error(j.error || '入库失败');
-      $('#progress').text('入库完成 ✔'); $('#refreshBtn').click();
+      $('#progress').text('入库完成 ✔');
+      await fetchAndRenderAll();
     } catch(err) {
       console.error(err); alert('处理失败：' + (err.message || err)); $('#progress').text('');
     }
@@ -463,7 +464,9 @@ async function renderTable(rows, granularity) {
   });
   populateProductNames(document.getElementById('report'));
 }
+const statusEl = document.getElementById('status');
 async function fetchAndRenderAll() {
+  statusEl.textContent = '加载中...';
   try {
     const val=$('#dateFilter').val(); let startISO,endISO;
     if (val && val.includes(' to ')) { const [s,e]=val.split(' to '); startISO=s; endISO=e; }
@@ -473,7 +476,7 @@ async function fetchAndRenderAll() {
       $('#dateFilter').val(`${startISO} to ${endISO}`);
     }
     localStorage.setItem('selfPeriod', `${startISO} to ${endISO}`);
-    const g = 'day';$('#progress').text('查询中…');
+    const g = 'day';
 
     const { prevStart, prevEnd, days }=periodShift(startISO,endISO);
     const [rowsNowAgg, rowsPrevAgg, rowsA, rowsB] = await Promise.all([
@@ -489,15 +492,18 @@ async function fetchAndRenderAll() {
     drawRatioBar(rowsA,rowsB);
     await drawTop6Both(rowsA,rowsB);
     renderProductChart(rowsA,rowsB,days,startISO,prevStart);
-
+    refreshFromPageRange();
     $('#progress').text(`A: ${rowsA.length} 条 · B: ${rowsB.length} 条`);
+    statusEl.textContent = '加载完成';
   } catch (err) {
-    console.error(err); alert('查询失败：' + (err.message || err)); $('#progress').text('');
+    console.error(err);
+    statusEl.textContent = '加载失败';
+    alert('查询失败：' + (err.message || err));
+    $('#progress').text('');
   }
 }
 /* ---------- 初始化 ---------- */
 const fp=flatpickr('#dateFilter',{ mode:'range', dateFormat:'Y-m-d', onClose:(ds)=>{ if(ds.length===2) fetchAndRenderAll(); } });
-$('#refreshBtn').on('click', fetchAndRenderAll);
 $('#metricSel').on('change', fetchAndRenderAll);
 
 (async function initDefault(){
@@ -648,21 +654,6 @@ $('#metricSel').on('change', fetchAndRenderAll);
           input._newkpi_hook = true;
           input.addEventListener('change', refreshFromPageRange);
           input.addEventListener('blur', refreshFromPageRange);
-        }
-        const refreshBtn = document.getElementById('refreshBtn');
-        if (refreshBtn && !refreshBtn._newkpi_hook){
-          refreshBtn._newkpi_hook = true;
-          refreshBtn.addEventListener('click', () => {
-            const prog = document.getElementById('progress');
-            if (!prog) return;
-            const pObs = new MutationObserver(()=>{
-              if ((prog.textContent||'').trim().length){
-                pObs.disconnect();
-                refreshFromPageRange();
-              }
-            });
-            pObs.observe(prog, { childList:true, characterData:true, subtree:true });
-          });
         }
       }
     });


### PR DESCRIPTION
## Summary
- remove obsolete manual refresh buttons from data detail pages
- add loading, success, and failure status messages when data is fetched

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a185691ae48325a366774b111b7143