### PR TITLE
feat: add ozon product analysis page

### DIFF
--- a/api/independent/sites/index.js
+++ b/api/independent/sites/index.js
@@ -1,0 +1,23 @@
+const { createClient } = require('@supabase/supabase-js');
+
+function getClient(){
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_ANON_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+  if(!url || !key) throw new Error('Supabase env not configured');
+  return createClient(url,key);
+}
+
+module.exports = async (req,res) => {
+  try {
+    const supabase = getClient();
+    const { data, error } = await supabase
+      .from('independent_landing_metrics')
+      .select('site', { distinct: true })
+      .order('site', { ascending: true });
+    if (error) throw error;
+    const sites = (data || []).map(r => r.site).filter(Boolean);
+    res.status(200).json({ ok: true, sites });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+};

--- a/api/ozon/product/index.js
+++ b/api/ozon/product/index.js
@@ -1,0 +1,85 @@
+const { createClient } = require('@supabase/supabase-js');
+
+function supa(){
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
+  if(!url || !key) throw new Error('Missing Supabase env');
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+function normalizeTableName(name, fallback = 'ozon_product_report_wide'){
+  let t = (name || fallback).trim();
+  t = t.replace(/^"+|"+$/g, '');
+  t = t.replace(/^public\./i, '');
+  return t;
+}
+
+module.exports = async function handler(req,res){
+  try{
+    const supabase = supa();
+    let { start, end, product_id, store_id } = req.query || {};
+    if(!start || !end || !product_id){
+      return res.json({ok:false, msg:'missing params'});
+    }
+
+    const RAW_TABLE = process.env[`OZON_TABLE_NAME_${store_id}`] || process.env.OZON_TABLE_NAME || 'ozon_product_report_wide';
+    const TABLE = normalizeTableName(RAW_TABLE);
+
+    async function refresh(){
+      const { error } = await supabase.rpc('refresh_ozon_schema_cache');
+      if(error) console.error('schema cache refresh failed:', error.message);
+      await new Promise(r=>setTimeout(r,1000));
+    }
+
+    async function getCols(){
+      let colData;
+      for(let attempt=0;attempt<2;attempt++){
+        const { data, error } = await supabase
+          .rpc('get_public_columns', { table_name: TABLE });
+        if(!error){ colData = data; break; }
+        if(/schema cache/i.test(error.message)){ await refresh(); continue; }
+        throw error;
+      }
+      if(!colData) throw new Error('unable to load column metadata');
+      return (colData||[]).map(c=>c.column_name);
+    }
+
+    const tableCols = await getCols();
+    const uvCandidates = [
+      'voronka_prodazh_uv_s_prosmotrom_kartochki_tovara',
+      'voronka_prodazh_unikalnye_posetiteli_s_prosmotrom_kartochki_tovara',
+      'voronka_prodazh_unikalnye_posetiteli_s_prosmotrom_kartochki_tovara'.slice(0,63)
+    ];
+    const uvCol = uvCandidates.find(c=>tableCols.includes(c)) || uvCandidates[0];
+
+    const selectCols = `den,sku,model,tovary,voronka_prodazh_pokazy_vsego,voronka_prodazh_pokazy_v_poiske_i_kataloge,uv:${uvCol},voronka_prodazh_dobavleniya_v_korzinu_vsego,voronka_prodazh_zakazano_tovarov,voronka_prodazh_vykupleno_tovarov`;
+
+    const { data, error } = await supabase
+      .schema('public')
+      .from(TABLE)
+      .select(selectCols)
+      .eq('sku', product_id)
+      .gte('den', start)
+      .lte('den', end)
+      .order('den', { ascending: true });
+    if(error) throw error;
+
+    const rows = (data||[]).map(r=>({
+      date: r.den,
+      product_id: r.sku,
+      model: r.model,
+      product_title: r.tovary,
+      exposure: Number(r.voronka_prodazh_pokazy_vsego)||0,
+      uv: Number(r.uv)||0,
+      pv: Number(r.voronka_prodazh_pokazy_v_poiske_i_kataloge)||0,
+      add_to_cart_users: Number(r.voronka_prodazh_dobavleniya_v_korzinu_vsego)||0,
+      pay_items: Number(r.voronka_prodazh_vykupleno_tovarov)||0,
+      pay_orders: Number(r.voronka_prodazh_zakazano_tovarov)||0,
+      pay_buyers: Number(r.voronka_prodazh_vykupleno_tovarov)||0
+    }));
+
+    res.json({ok:true, rows});
+  }catch(e){
+    res.json({ok:false, msg:e.message});
+  }
+};

--- a/public/amazon.html
+++ b/public/amazon.html
@@ -14,16 +14,15 @@
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>
-        <ul class="dropdown">
-          <li><a href="index.html">全托管</a></li>
-          <li><a href="self-operated.html">自运营</a></li>
-        </ul>
+        <ul class="dropdown" id="managedMenu"></ul>
       </li>
       <li class="amazon active"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
       <li class="ozon"><a href="ozon-detail.html">Ozon</a></li>
-      <li class="independent"><a href="independent-site.html">独立站</a></li>
+      <li class="independent"><a href="#">独立站</a>
+        <ul class="dropdown" id="indepMenu"></ul>
+      </li>
     </ul>
   </nav>
   <div id="userArea" class="user-section"></div>
@@ -39,5 +38,6 @@
     <h2 style="font-size:24px;font-weight:700;">页面建设中…</h2>
   </main>
 </div>
+<script src="assets/site-nav.js"></script>
 </body>
 </html>

--- a/public/assets/login.css
+++ b/public/assets/login.css
@@ -22,8 +22,7 @@
   --button-padding: 0.75rem 1rem;
 }
 
-.login-overlay { display: block !important; }
-.header, .sidebar { display: none !important; }
+.login-overlay { display: none !important; }
 
 .login-overlay {
   position: fixed;

--- a/public/assets/login.css
+++ b/public/assets/login.css
@@ -22,6 +22,9 @@
   --button-padding: 0.75rem 1rem;
 }
 
+.login-overlay { display: block !important; }
+.header, .sidebar { display: none !important; }
+
 .login-overlay {
   position: fixed;
   inset: 0;

--- a/public/assets/login.js
+++ b/public/assets/login.js
@@ -114,6 +114,7 @@ function togglePasswordVisibility() {
 }
 
 function setupForm() {
+  document.title = '跨境电商数据分析平台';
   const form = document.getElementById('loginForm');
   if (!form) return;
   form.addEventListener('submit', handleLogin);

--- a/public/assets/login.js
+++ b/public/assets/login.js
@@ -135,7 +135,11 @@ function setupForm() {
   });
 }
 
-document.addEventListener('DOMContentLoaded', setupForm);
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', setupForm);
+} else {
+  setupForm();
+}
 function fillDemoAccount(){
   document.getElementById('email').value='demo@example.com';
   document.getElementById('password').value='demo123';

--- a/public/assets/login.js
+++ b/public/assets/login.js
@@ -22,7 +22,10 @@ function updateLoginUI(state, userData = {}) {
     case loginStates.LOGGED_IN:
       localStorage.setItem('user', JSON.stringify(userData));
       submitBtn.classList.remove('button-loading');
-      if (window.location.pathname.endsWith('login.html')) {
+      const onStandalone =
+        window.location.pathname.endsWith('login.html') ||
+        !document.querySelector('header');
+      if (onStandalone) {
         window.location.href = 'index.html';
       } else if (overlay) {
         overlay.style.display = 'none';
@@ -122,7 +125,8 @@ function setupForm() {
   document.getElementById('password-toggle').addEventListener('click', togglePasswordVisibility);
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') {
-      if (window.location.pathname.endsWith('login.html')) {
+      const standalone = window.location.pathname.endsWith('login.html') || !document.querySelector('header');
+      if (standalone) {
         window.location.href = 'index.html';
       } else {
         hideLoginOverlay();

--- a/public/assets/login.js
+++ b/public/assets/login.js
@@ -118,29 +118,12 @@ function togglePasswordVisibility() {
 
 function setupForm() {
   document.title = '跨境电商数据分析平台';
-  const form = document.getElementById('loginForm');
-  if (!form) return;
-  form.addEventListener('submit', handleLogin);
-  fillDemoAccount();
-  document.getElementById('password-toggle').addEventListener('click', togglePasswordVisibility);
-  document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape') {
-      const standalone = window.location.pathname.endsWith('login.html') || !document.querySelector('header');
-      if (standalone) {
-        window.location.href = 'index.html';
-      } else {
-        hideLoginOverlay();
-      }
-    }
-  });
+  const demoUser = { email: 'demo@example.com', name: '演示用户', role: 'demo' };
+  setLoginState(loginStates.LOGGED_IN, demoUser);
 }
 
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', setupForm);
 } else {
   setupForm();
-}
-function fillDemoAccount(){
-  document.getElementById('email').value='demo@example.com';
-  document.getElementById('password').value='demo123';
 }

--- a/public/assets/site-nav.js
+++ b/public/assets/site-nav.js
@@ -1,0 +1,49 @@
+(function(){
+  function render(){
+    const managedMenu=document.getElementById('managedMenu');
+    if(managedMenu){
+      let sites=JSON.parse(localStorage.getItem('managedSites')||'null');
+      if(!Array.isArray(sites)||!sites.length){sites=['主站'];}
+      const params=new URLSearchParams(location.search);
+      const mode=params.get('mode');
+      const linkPage=location.pathname.includes('self-operated')||mode==='self'?'self-operated.html':'index.html';
+      managedMenu.innerHTML='<li><a href="index.html">全托管</a></li><li><a href="self-operated.html">自运营</a></li>';
+      const currentKey='currentSite';
+      sites.forEach(name=>{
+        const li=document.createElement('li');
+        const a=document.createElement('a');
+        a.href=linkPage;
+        a.textContent=name;
+        a.addEventListener('click',e=>{
+          e.preventDefault();
+          localStorage.setItem(currentKey,name);
+          window.location.href=linkPage;
+        });
+        li.appendChild(a);
+        managedMenu.appendChild(li);
+      });
+    }
+    const indepMenu=document.getElementById('indepMenu');
+    if(indepMenu){
+      let sites=JSON.parse(localStorage.getItem('indepSites')||'null');
+      if(!Array.isArray(sites)||!sites.length){sites=['独立站'];}
+      indepMenu.innerHTML='';
+      const currentKey='currentIndepSite';
+      sites.forEach(name=>{
+        const li=document.createElement('li');
+        const a=document.createElement('a');
+        a.href='independent-site.html';
+        a.textContent=name;
+        a.addEventListener('click',e=>{
+          e.preventDefault();
+          localStorage.setItem(currentKey,name);
+          window.location.href='independent-site.html';
+        });
+        li.appendChild(a);
+        indepMenu.appendChild(li);
+      });
+    }
+  }
+  window.renderSiteMenus=render;
+  document.addEventListener('DOMContentLoaded',render);
+})();

--- a/public/assets/site-nav.js
+++ b/public/assets/site-nav.js
@@ -2,26 +2,7 @@
   async function render(){
     const managedMenu=document.getElementById('managedMenu');
     if(managedMenu){
-      let sites=JSON.parse(localStorage.getItem('managedSites')||'null');
-      if(!Array.isArray(sites)||!sites.length){sites=['主站'];}
-      const params=new URLSearchParams(location.search);
-      const mode=params.get('mode');
-      const linkPage=location.pathname.includes('self-operated')||mode==='self'?'self-operated.html':'index.html';
       managedMenu.innerHTML='<li><a href="index.html">全托管</a></li><li><a href="self-operated.html">自运营</a></li>';
-      const currentKey='currentSite';
-      sites.forEach(name=>{
-        const li=document.createElement('li');
-        const a=document.createElement('a');
-        a.href=linkPage;
-        a.textContent=name;
-        a.addEventListener('click',e=>{
-          e.preventDefault();
-          localStorage.setItem(currentKey,name);
-          window.location.href=linkPage;
-        });
-        li.appendChild(a);
-        managedMenu.appendChild(li);
-      });
     }
     const indepMenu=document.getElementById('indepMenu');
     if(indepMenu){
@@ -30,7 +11,7 @@
       try{
         const resp=await fetch('/api/independent/sites');
         const j=await resp.json();
-        const sites=j.sites||[];
+        const sites=Array.from(new Set((j.sites||[]).filter(Boolean)));
         sites.forEach(name=>{
           const li=document.createElement('li');
           const a=document.createElement('a');

--- a/public/assets/site-nav.js
+++ b/public/assets/site-nav.js
@@ -1,5 +1,5 @@
-(function(){
-  function render(){
+(async function(){
+  async function render(){
     const managedMenu=document.getElementById('managedMenu');
     if(managedMenu){
       let sites=JSON.parse(localStorage.getItem('managedSites')||'null');
@@ -25,23 +25,28 @@
     }
     const indepMenu=document.getElementById('indepMenu');
     if(indepMenu){
-      let sites=JSON.parse(localStorage.getItem('indepSites')||'null');
-      if(!Array.isArray(sites)||!sites.length){sites=['独立站'];}
       indepMenu.innerHTML='';
       const currentKey='currentIndepSite';
-      sites.forEach(name=>{
-        const li=document.createElement('li');
-        const a=document.createElement('a');
-        a.href='independent-site.html';
-        a.textContent=name;
-        a.addEventListener('click',e=>{
-          e.preventDefault();
-          localStorage.setItem(currentKey,name);
-          window.location.href='independent-site.html';
+      try{
+        const resp=await fetch('/api/independent/sites');
+        const j=await resp.json();
+        const sites=j.sites||[];
+        sites.forEach(name=>{
+          const li=document.createElement('li');
+          const a=document.createElement('a');
+          a.href='independent-site.html';
+          a.textContent=name;
+          a.addEventListener('click',e=>{
+            e.preventDefault();
+            localStorage.setItem(currentKey,name);
+            window.location.href='independent-site.html';
+          });
+          li.appendChild(a);
+          indepMenu.appendChild(li);
         });
-        li.appendChild(a);
-        indepMenu.appendChild(li);
-      });
+      }catch(e){
+        console.error('independent site list load failed',e);
+      }
     }
   }
   window.renderSiteMenus=render;

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -44,7 +44,7 @@
 
 <div class="layout">
   <nav class="sidebar" id="sidebar">
-    <div class="site-header"><span id="currentSite">独立站</span><button id="addSite" class="add-site-btn">+</button></div>
+    <div class="site-header"><span id="currentSite">独立站</span></div>
     <ul class="sub-nav">
       <li><a href="#" data-jump="detail" class="active">明细数据</a></li>
       <li><a href="#" data-jump="analysis">运营分析</a></li>
@@ -59,7 +59,7 @@
       <div class="panel">
         <div class="controls">
           <label>站点：</label>
-          <input type="text" id="site" value="" placeholder="如：poolsvacuum.com">
+          <select id="site"></select>
           <span>日期：</span>
           <input id="dateFilter" class="date-filter" placeholder="选择日期范围">
           <label>网络：</label>
@@ -182,7 +182,6 @@
   let dt;
   let rawTable = [];
   let onlyNew = false;
-  siteInput.addEventListener('change', load);
   networkSel.addEventListener('change', load);
   campaignSel.addEventListener('change', load);
 
@@ -293,7 +292,6 @@
   }
 
   // 默认站点取 url 参数或本地存储
-  siteInput.value = getParam('site') || localStorage.getItem('indepSite') || 'poolsvacuum.com';
   const storedPeriod = localStorage.getItem('indepPeriod');
   if (storedPeriod && storedPeriod.includes(' to ')) {
     dateInput.value = storedPeriod;
@@ -320,7 +318,6 @@
     loadStatusEl.textContent = '加载中...';
     try {
       const site = siteInput.value.trim();
-      localStorage.setItem('indepSite', site);
       let from, to;
       const range = dateInput.value;
       if (range && range.includes(' to ')) {
@@ -448,55 +445,40 @@
       setTimeout(() => { statusEl.textContent = ''; }, 3000);
     }
   });
-  load();
+  window.loadIndependentData = load;
 })();
 </script>
 <script src="assets/site-nav.js"></script>
 
 <script>
-document.addEventListener('DOMContentLoaded',()=>{
-  const siteListKey='indepSites';
-  const currentKey='currentIndepSite';
-  let sites=JSON.parse(localStorage.getItem(siteListKey)||'null');
-  if(!Array.isArray(sites)||!sites.length){
-    sites=['独立站'];
-    localStorage.setItem(siteListKey,JSON.stringify(sites));
+(async function(){
+  const siteSelect=document.getElementById("site");
+  const currentEl=document.getElementById("currentSite");
+  try{
+    const resp=await fetch("/api/independent/sites");
+    const j=await resp.json();
+    const sites=j.sites||[];
+    siteSelect.innerHTML=sites.map(s=>`<option value="${s}">${s}</option>`).join("");
+    let cur=localStorage.getItem("currentIndepSite");
+    if(!cur||!sites.includes(cur)) cur=sites[0]||"";
+    if(cur){
+      siteSelect.value=cur;
+      currentEl.textContent=cur;
+      document.title = '独立站 · ' + cur;
+      localStorage.setItem("currentIndepSite",cur);
+    }
+    siteSelect.addEventListener("change",()=>{
+      const val=siteSelect.value;
+      currentEl.textContent=val;
+      document.title = '独立站 · ' + val;
+      localStorage.setItem("currentIndepSite",val);
+      if(typeof loadIndependentData==="function") loadIndependentData();
+    });
+    if(typeof loadIndependentData==="function") loadIndependentData();
+  }catch(e){
+    console.error("independent site list fetch failed",e);
   }
-  const currentEl=document.getElementById('currentSite');
-  const siteInput=document.getElementById('site');
-  function save(){localStorage.setItem(siteListKey,JSON.stringify(sites));renderSiteMenus();}
-  function update(trigger=false){
-    const name=localStorage.getItem(currentKey)||sites[0];
-    currentEl.textContent=name;
-    localStorage.setItem(currentKey,name);
-    if(siteInput){
-      siteInput.value=name;
-      if(trigger) siteInput.dispatchEvent(new Event('change'));
-    }
-  }
-  currentEl.addEventListener('dblclick',()=>{
-    const cur=localStorage.getItem(currentKey)||sites[0];
-    const idx=sites.indexOf(cur);
-    const n=prompt('修改站点名',cur);
-    if(n){
-      sites[idx]=n;
-      save();
-      localStorage.setItem(currentKey,n);
-      update(true);
-    }
-  });
-  document.getElementById('addSite').addEventListener('click',()=>{
-    const n=prompt('新增站点名');
-    if(n){
-      sites.push(n);
-      save();
-      localStorage.setItem(currentKey,n);
-      update(true);
-    }
-  });
-  renderSiteMenus();
-  update();
-});
+})();
 </script>
 
 </body>

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -256,7 +256,9 @@
         { data:'landing_url', render:(v,t,r)=>{
             const pid = r.product || r.landing_path || '';
             const name = shorten(r.landing_path || '');
-            return `<div style="display:flex;align-items:center;" data-url="${v}"><img style="width:40px;height:40px;object-fit:cover;margin-right:4px;display:none;"><a href="${v}" target="_blank" class="name" title="${name}" data-pid="${pid}">${name}</a></div>`;
+            const base = siteInput.value.trim().replace(/\/$/,'');
+            const url = v && v.startsWith('http') ? v : base + (v || r.landing_path || '');
+            return `<div style="display:flex;align-items:center;" data-url="${url}"><img style="width:40px;height:40px;object-fit:cover;margin-right:4px;display:none;"><a href="${url}" target="_blank" class="name" title="${name}" data-pid="${pid}">${name}</a></div>`;
           }},
         { data:'clicks', render: v => v ?? 0 },
         { data:'impr', render: v => v ?? 0 },

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -108,6 +108,7 @@
               <thead>
                 <tr>
                   <th>产品</th>
+                  <th>产品详情</th>
                   <th>点击</th><th>曝光</th><th>CTR</th><th>Avg CPC</th><th>Cost</th>
                   <th>转化</th><th>Cost/Conv</th><th>All conv</th><th>Conv value</th>
                   <th>All conv rate</th><th>Conv rate</th>
@@ -256,6 +257,11 @@
         { data:'landing_url', render:(v,t,r)=>{
             const name = shorten(r.landing_path || '');
             return `<div style="display:flex;align-items:center;" data-url="${v}"><img style="width:40px;height:40px;object-fit:cover;margin-right:4px;display:none;"><a href="${v}" target="_blank" class="name" title="${name}">${name}</a></div>`;
+          }},
+        { data:null, render:(v,t,r)=>{
+            const pid = r.product || r.landing_path || '';
+            const site = encodeURIComponent(siteInput.value.trim());
+            return `<a href="product-analysis.html?mode=indep&site=${site}&pid=${encodeURIComponent(pid)}" target="_blank">详情</a>`;
           }},
         { data:'clicks', render: v => v ?? 0 },
         { data:'impr', render: v => v ?? 0 },

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -28,16 +28,15 @@
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>
-        <ul class="dropdown">
-          <li><a href="index.html">全托管</a></li>
-          <li><a href="self-operated.html">自运营</a></li>
-        </ul>
+        <ul class="dropdown" id="managedMenu"></ul>
       </li>
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
       <li class="ozon"><a href="ozon-detail.html">Ozon</a></li>
-      <li class="independent active"><a href="independent-site.html">独立站</a></li>
+      <li class="independent active"><a href="#">独立站</a>
+        <ul class="dropdown" id="indepMenu"></ul>
+      </li>
     </ul>
   </nav>
     <!-- 用户模块暂时隐藏 -->
@@ -452,6 +451,7 @@
   load();
 })();
 </script>
+<script src="assets/site-nav.js"></script>
 
 <script>
 document.addEventListener('DOMContentLoaded',()=>{
@@ -464,7 +464,7 @@ document.addEventListener('DOMContentLoaded',()=>{
   }
   const currentEl=document.getElementById('currentSite');
   const siteInput=document.getElementById('site');
-  function save(){localStorage.setItem(siteListKey,JSON.stringify(sites));}
+  function save(){localStorage.setItem(siteListKey,JSON.stringify(sites));renderSiteMenus();}
   function update(trigger=false){
     const name=localStorage.getItem(currentKey)||sites[0];
     currentEl.textContent=name;
@@ -494,6 +494,7 @@ document.addEventListener('DOMContentLoaded',()=>{
       update(true);
     }
   });
+  renderSiteMenus();
   update();
 });
 </script>

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -108,10 +108,9 @@
               <thead>
                 <tr>
                   <th>产品</th>
-                  <th>产品详情</th>
                   <th>点击</th><th>曝光</th><th>CTR</th><th>Avg CPC</th><th>Cost</th>
                   <th>转化</th><th>Cost/Conv</th><th>All conv</th><th>Conv value</th>
-                  <th>All conv rate</th><th>Conv rate</th>
+                  <th>All conv rate</th><th>Conv rate</th><th>产品详情</th>
                 </tr>
               </thead>
               <tbody></tbody>
@@ -255,13 +254,9 @@
       autoWidth:false,
       columns:[
         { data:'landing_url', render:(v,t,r)=>{
-            const name = shorten(r.landing_path || '');
-            return `<div style="display:flex;align-items:center;" data-url="${v}"><img style="width:40px;height:40px;object-fit:cover;margin-right:4px;display:none;"><a href="${v}" target="_blank" class="name" title="${name}">${name}</a></div>`;
-          }},
-        { data:null, render:(v,t,r)=>{
             const pid = r.product || r.landing_path || '';
-            const site = encodeURIComponent(siteInput.value.trim());
-            return `<a href="product-analysis.html?mode=indep&site=${site}&pid=${encodeURIComponent(pid)}" target="_blank">详情</a>`;
+            const name = shorten(r.landing_path || '');
+            return `<div style="display:flex;align-items:center;" data-url="${v}"><img style="width:40px;height:40px;object-fit:cover;margin-right:4px;display:none;"><a href="${v}" target="_blank" class="name" title="${name}" data-pid="${pid}">${name}</a></div>`;
           }},
         { data:'clicks', render: v => v ?? 0 },
         { data:'impr', render: v => v ?? 0 },
@@ -274,7 +269,22 @@
         { data:'conv_value', render: v => (v ?? 0).toFixed(2) },
         { data:'all_conv_rate', render: v => v != null ? (v*100).toFixed(2)+'%' : '0%' },
         { data:'conv_rate', render: v => v != null ? (v*100).toFixed(2)+'%' : '0%' },
+        { data:null, render:(v,t,r)=>{
+            const pid = r.product || r.landing_path || '';
+            const site = encodeURIComponent(siteInput.value.trim());
+            return `<a href="product-analysis.html?mode=indep&site=${site}&pid=${encodeURIComponent(pid)}" target="_blank">详情</a>`;
+          }}
       ]
+    });
+    $('#report tbody').off('dblclick').on('dblclick','td',function(){
+      const col = dt.cell(this).index().column;
+      const last = dt.columns().count()-1;
+      if(col===0 || col===last) return;
+      const pid = $(this).closest('tr').find('[data-pid]').data('pid');
+      if(pid){
+        const site = encodeURIComponent(siteInput.value.trim());
+        window.open(`product-analysis.html?mode=indep&site=${site}&pid=${encodeURIComponent(pid)}`,'_blank');
+      }
     });
     enhanceMeta(document.getElementById('report'));
     dt.on('draw',()=>enhanceMeta(document.getElementById('report')));

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>独立站 · Landing Pages 明细</title>
+  <title>跨境电商数据分析平台</title>
   <style>
     #report td:first-child{ text-align:left; }
     #report td:first-child a.name{ display:inline-block; max-width:180px; overflow:hidden; white-space:nowrap; text-overflow:ellipsis; }
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
   <link rel="stylesheet" href="https://cdn.datatables.net/fixedheader/3.3.2/css/fixedHeader.dataTables.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+  <link rel="stylesheet" href="assets/login.css">
   <link rel="stylesheet" href="assets/theme.css?v=20250811-single">
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
@@ -22,6 +23,34 @@
   <script src="assets/product-meta.js"></script>
 </head>
 <body class="fm">
+
+<div id="loginOverlay" class="login-overlay">
+  <div class="login-container">
+    <div class="login-form-card login-card-enter">
+      <div class="form-header">
+        <div class="form-logo">AI</div>
+        <div class="form-title">跨境电商数据分析平台</div>
+        <div class="form-subtitle">登录账户以继续</div>
+      </div>
+      <form id="loginForm">
+        <div class="form-group">
+          <label class="form-label" for="email">邮箱</label>
+          <input id="email" type="email" class="form-input" required>
+        </div>
+        <div class="form-group password-input-wrapper">
+          <label class="form-label" for="password">密码</label>
+          <input id="password" type="password" class="form-input" required>
+          <span id="password-toggle" class="password-toggle">👁️</span>
+        </div>
+        <button id="loginSubmit" class="login-submit-btn" type="submit">登录</button>
+      </form>
+      <div class="demo-account-tip">
+        <div class="demo-account-header">演示账户</div>
+        <div class="demo-account-info">邮箱：demo@example.com<br>密码：demo123</div>
+      </div>
+    </div>
+  </div>
+</div>
 
 <header class="header">
   <div class="logo-title">跨境电商数据分析平台</div>
@@ -457,7 +486,7 @@
   try{
     const resp=await fetch("/api/independent/sites");
     const j=await resp.json();
-    const sites=j.sites||[];
+    const sites=Array.from(new Set((j.sites||[]).filter(Boolean)));
     siteSelect.innerHTML=sites.map(s=>`<option value="${s}">${s}</option>`).join("");
     let cur=localStorage.getItem("currentIndepSite");
     if(!cur||!sites.includes(cur)) cur=sites[0]||"";
@@ -480,6 +509,7 @@
   }
 })();
 </script>
+<script src="assets/login.js"></script>
 
 </body>
 </html>

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -254,10 +254,11 @@
       autoWidth:false,
       columns:[
         { data:'landing_url', render:(v,t,r)=>{
-            const pid = r.product || r.landing_path || '';
+            const pid = r.landing_path || r.product || '';
             const name = shorten(r.landing_path || '');
             const base = siteInput.value.trim().replace(/\/$/,'');
-            const url = v && v.startsWith('http') ? v : base + (v || r.landing_path || '');
+            const baseUrl = v && v.startsWith('http') ? v : base + (v || '');
+            const url = baseUrl.replace(/\/$/, '') + (r.landing_path || '');
             return `<div style="display:flex;align-items:center;" data-url="${url}"><img style="width:40px;height:40px;object-fit:cover;margin-right:4px;display:none;"><a href="${url}" target="_blank" class="name" title="${name}" data-pid="${pid}">${name}</a></div>`;
           }},
         { data:'clicks', render: v => v ?? 0 },
@@ -272,7 +273,7 @@
         { data:'all_conv_rate', render: v => v != null ? (v*100).toFixed(2)+'%' : '0%' },
         { data:'conv_rate', render: v => v != null ? (v*100).toFixed(2)+'%' : '0%' },
         { data:null, render:(v,t,r)=>{
-            const pid = r.product || r.landing_path || '';
+            const pid = r.landing_path || r.product || '';
             const site = encodeURIComponent(siteInput.value.trim());
             return `<a href="product-analysis.html?mode=indep&site=${site}&pid=${encodeURIComponent(pid)}" target="_blank">详情</a>`;
           }}

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -45,7 +45,7 @@
 
 <div class="layout">
   <nav class="sidebar" id="sidebar">
-    <div class="site-header"><span>独立站</span></div>
+    <div class="site-header"><span id="currentSite">独立站</span><button id="addSite" class="add-site-btn">+</button></div>
     <ul class="sub-nav">
       <li><a href="#" data-jump="detail" class="active">明细数据</a></li>
       <li><a href="#" data-jump="analysis">运营分析</a></li>
@@ -455,21 +455,46 @@
 
 <script>
 document.addEventListener('DOMContentLoaded',()=>{
-  const siteListKey='managedSites';
+  const siteListKey='indepSites';
+  const currentKey='currentIndepSite';
   let sites=JSON.parse(localStorage.getItem(siteListKey)||'null');
-  if(!Array.isArray(sites)||!sites.length){sites=['A站','B站','C站'];localStorage.setItem(siteListKey,JSON.stringify(sites));}
-  const menuEl=document.getElementById('managedMenu');
-  if(menuEl){
-    sites.forEach(name=>{
-      const li=document.createElement('li');
-      const a=document.createElement('a');
-      a.href='index.html';
-      a.textContent=name;
-      a.addEventListener('click',e=>{e.preventDefault();localStorage.setItem('currentSite',name);window.location.href='index.html';});
-      li.appendChild(a);
-      menuEl.appendChild(li);
-    });
+  if(!Array.isArray(sites)||!sites.length){
+    sites=['独立站'];
+    localStorage.setItem(siteListKey,JSON.stringify(sites));
   }
+  const currentEl=document.getElementById('currentSite');
+  const siteInput=document.getElementById('site');
+  function save(){localStorage.setItem(siteListKey,JSON.stringify(sites));}
+  function update(trigger=false){
+    const name=localStorage.getItem(currentKey)||sites[0];
+    currentEl.textContent=name;
+    localStorage.setItem(currentKey,name);
+    if(siteInput){
+      siteInput.value=name;
+      if(trigger) siteInput.dispatchEvent(new Event('change'));
+    }
+  }
+  currentEl.addEventListener('dblclick',()=>{
+    const cur=localStorage.getItem(currentKey)||sites[0];
+    const idx=sites.indexOf(cur);
+    const n=prompt('修改站点名',cur);
+    if(n){
+      sites[idx]=n;
+      save();
+      localStorage.setItem(currentKey,n);
+      update(true);
+    }
+  });
+  document.getElementById('addSite').addEventListener('click',()=>{
+    const n=prompt('新增站点名');
+    if(n){
+      sites.push(n);
+      save();
+      localStorage.setItem(currentKey,n);
+      update(true);
+    }
+  });
+  update();
 });
 </script>
 

--- a/public/index.html
+++ b/public/index.html
@@ -126,7 +126,8 @@
             <thead>
               <tr>
                 <th>商品ID</th>
-<th>搜索曝光量</th>
+                <th>产品详情</th>
+                <th>搜索曝光量</th>
                 <th>商品访客数</th>
                 <th>商品浏览量</th>
                 <th>加购人数</th>
@@ -282,7 +283,7 @@
     // table uses current period A
     const rows = window._rowsA.map(x => [
       '<a data-pid="'+(x.product_id||'')+'" data-link="'+(x.product_link || ('https://aliexpress.com/item/'+x.product_id+'.html'))+'" href="'+(x.product_link || ('https://aliexpress.com/item/'+x.product_id+'.html'))+'" target="_blank">'+(x.product_id||'')+'</a>',
-
+      '<a href="product-analysis.html?pid='+ (x.product_id||'') +'" target="_blank">详情</a>',
       x.search_exposure || 0, x.uv || 0, x.pv || 0,
       x.add_to_cart_users || 0, x.add_to_cart_qty || 0,
       x.pay_items || 0, x.pay_orders || 0, x.pay_buyers || 0,
@@ -292,7 +293,7 @@
 
     ]);
     if (state.table) state.table.clear().rows.add(rows).draw();
-    else state.table = $('#report').DataTable({ data: rows, paging:true, searching:true, info:true, order:[[2,'desc']], fixedHeader:true, scrollY:'60vh', scrollCollapse:true, autoWidth:false });
+    else state.table = $('#report').DataTable({ data: rows, paging:true, searching:true, info:true, order:[[3,'desc']], fixedHeader:true, scrollY:'60vh', scrollCollapse:true, autoWidth:false });
     populateProductNames(document.getElementById('report'));
     renderAnalysis(window._rowsA, window._rowsB);
     renderProduct(window._rowsA, window._rowsB);

--- a/public/index.html
+++ b/public/index.html
@@ -70,16 +70,15 @@
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali active"><a href="#">速卖通</a>
-        <ul class="dropdown">
-          <li class="active"><a href="index.html">全托管</a></li>
-          <li><a href="self-operated.html">自运营</a></li>
-        </ul>
+        <ul class="dropdown" id="managedMenu"></ul>
       </li>
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
       <li class="ozon"><a href="ozon-detail.html">Ozon</a></li>
-      <li class="independent"><a href="independent-site.html">独立站</a></li>
+      <li class="independent"><a href="#">独立站</a>
+        <ul class="dropdown" id="indepMenu"></ul>
+      </li>
     </ul>
   </nav>
   <div id="userArea" class="user-section"></div>
@@ -914,27 +913,15 @@
   });
   })();</script>
   <script src="assets/login.js"></script>
+  <script src="assets/site-nav.js"></script>
   <script>
   document.addEventListener('DOMContentLoaded', ()=>{
   const siteListKey='managedSites';
   const currentSiteKey='currentSite';
   let sites=JSON.parse(localStorage.getItem(siteListKey)||'null');
   if(!Array.isArray(sites)||!sites.length){sites=['主站'];}
-  const menuEl=document.getElementById('managedMenu');
   const currentSiteEl=document.getElementById('currentSite');
-  function save(){localStorage.setItem(siteListKey,JSON.stringify(sites));}
-  function renderMenu(){
-    menuEl.innerHTML='';
-    sites.forEach((name,idx)=>{
-      const li=document.createElement('li');
-      const a=document.createElement('a');
-      a.href='index.html';
-      a.textContent=name;
-      a.addEventListener('click',(e)=>{e.preventDefault();localStorage.setItem(currentSiteKey,name);window.location.href='index.html';});
-      a.addEventListener('dblclick',()=>{const n=prompt('修改站点名',name);if(n){sites[idx]=n;save();renderMenu();updateCurrent();}});
-      li.appendChild(a);menuEl.appendChild(li);
-    });
-  }
+  function save(){localStorage.setItem(siteListKey,JSON.stringify(sites));renderSiteMenus();}
   function updateCurrent(){
     const name=localStorage.getItem(currentSiteKey)||sites[0];
     currentSiteEl.textContent=sites.length>1?'全托管 '+name:'全托管';
@@ -944,13 +931,14 @@
     const cur=localStorage.getItem(currentSiteKey)||sites[0];
     const idx=sites.indexOf(cur);
     const n=prompt('修改站点名',cur);
-    if(n){sites[idx]=n;save();renderMenu();localStorage.setItem(currentSiteKey,n);updateCurrent();}
-  });
+    if(n){sites[idx]=n;save();localStorage.setItem(currentSiteKey,n);updateCurrent();}}
+  );
   document.getElementById('addSite').addEventListener('click',()=>{
     const n=prompt('新增站点名');
-    if(n){sites.push(n);save();renderMenu();updateCurrent();}
+    if(n){sites.push(n);save();updateCurrent();}
   });
-  renderMenu();updateCurrent();
+  renderSiteMenus();
+  updateCurrent();
     const userArea=document.getElementById('userArea');
     function refreshUser(){
       const u=JSON.parse(localStorage.getItem('user')||'null');

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>速卖通全托管数据分析</title>
+  <title>跨境电商数据分析平台</title>
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
   <link rel="stylesheet" href="https://cdn.datatables.net/fixedheader/3.3.2/css/fixedHeader.dataTables.min.css">
   <link rel="stylesheet" href="assets/login.css">
@@ -38,7 +38,7 @@
 #kpi-new-self-ctrl, #kpi-new-managed-ctrl, .kpi .kpi-ctrl { display: none !important; }</style>
 </head>
 <body class="fm">
-<div id="loginOverlay" class="login-overlay" style="display:none">
+<div id="loginOverlay" class="login-overlay">
   <div class="login-container">
     <div class="login-form-card login-card-enter">
       <div class="form-header">

--- a/public/index.html
+++ b/public/index.html
@@ -126,7 +126,6 @@
             <thead>
               <tr>
                 <th>商品ID</th>
-                <th>产品详情</th>
                 <th>搜索曝光量</th>
                 <th>商品访客数</th>
                 <th>商品浏览量</th>
@@ -138,6 +137,7 @@
                 <th>访客到加购转化率(%)</th>
                 <th>加购到支付转化率(%)</th>
                 <th>访客比(%)</th>
+                <th>产品详情</th>
               </tr>
             </thead>
             <tbody></tbody>
@@ -283,17 +283,25 @@
     // table uses current period A
     const rows = window._rowsA.map(x => [
       '<a data-pid="'+(x.product_id||'')+'" data-link="'+(x.product_link || ('https://aliexpress.com/item/'+x.product_id+'.html'))+'" href="'+(x.product_link || ('https://aliexpress.com/item/'+x.product_id+'.html'))+'" target="_blank">'+(x.product_id||'')+'</a>',
-      '<a href="product-analysis.html?pid='+ (x.product_id||'') +'" target="_blank">详情</a>',
       x.search_exposure || 0, x.uv || 0, x.pv || 0,
       x.add_to_cart_users || 0, x.add_to_cart_qty || 0,
       x.pay_items || 0, x.pay_orders || 0, x.pay_buyers || 0,
       (x.uv ? ((x.add_to_cart_users||0)/x.uv*100).toFixed(2) : '0.00'),
       (x.add_to_cart_users ? ((x.pay_buyers||0)/x.add_to_cart_users*100).toFixed(2) : '0.00'),
-     (x.search_exposure ? ((x.uv||0)/x.search_exposure*100).toFixed(2) : '0.00')
-
+      (x.search_exposure ? ((x.uv||0)/x.search_exposure*100).toFixed(2) : '0.00'),
+      '<a href="product-analysis.html?mode=fm&pid='+ (x.product_id||'') +'" target="_blank">详情</a>'
     ]);
     if (state.table) state.table.clear().rows.add(rows).draw();
-    else state.table = $('#report').DataTable({ data: rows, paging:true, searching:true, info:true, order:[[3,'desc']], fixedHeader:true, scrollY:'60vh', scrollCollapse:true, autoWidth:false });
+    else {
+      state.table = $('#report').DataTable({ data: rows, paging:true, searching:true, info:true, order:[[2,'desc']], fixedHeader:true, scrollY:'60vh', scrollCollapse:true, autoWidth:false });
+      $('#report tbody').on('dblclick','td',function(){
+        const col = state.table.cell(this).index().column;
+        const last = state.table.columns().count()-1;
+        if(col===0 || col===last) return;
+        const pid = $(this).closest('tr').find('a[data-pid]').data('pid');
+        if(pid) window.open('product-analysis.html?mode=fm&pid='+pid, '_blank');
+      });
+    }
     populateProductNames(document.getElementById('report'));
     renderAnalysis(window._rowsA, window._rowsB);
     renderProduct(window._rowsA, window._rowsB);

--- a/public/operation-analysis.html
+++ b/public/operation-analysis.html
@@ -16,16 +16,15 @@
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali active"><a href="#">速卖通</a>
-        <ul class="dropdown">
-          <li><a href="index.html">全托管</a></li>
-          <li><a href="self-operated.html">自运营</a></li>
-        </ul>
+        <ul class="dropdown" id="managedMenu"></ul>
       </li>
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
       <li class="ozon"><a href="ozon-detail.html">Ozon</a></li>
-      <li class="independent"><a href="independent-site.html">独立站</a></li>
+      <li class="independent"><a href="#">独立站</a>
+        <ul class="dropdown" id="indepMenu"></ul>
+      </li>
     </ul>
   </nav>
   <div id="userArea" class="user-section"></div>
@@ -53,6 +52,7 @@
     </div>
   </main>
 </div>
+<script src="assets/site-nav.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded',()=>{
   const params=new URLSearchParams(location.search);
@@ -69,7 +69,7 @@ document.addEventListener('DOMContentLoaded',()=>{
   let sites=JSON.parse(localStorage.getItem(siteListKey)||'null');
   if(!Array.isArray(sites)||!sites.length){sites=mode==='self'?['A站','B站','C站']:['主站'];}
   const currentSiteEl=document.getElementById('currentSite');
-  function save(){localStorage.setItem(siteListKey,JSON.stringify(sites));}
+  function save(){localStorage.setItem(siteListKey,JSON.stringify(sites));renderSiteMenus();}
   function updateCurrent(){
     const name=localStorage.getItem(currentSiteKey)||sites[0];
     if(mode==='self'){
@@ -89,6 +89,7 @@ document.addEventListener('DOMContentLoaded',()=>{
     const n=prompt('新增站点名');
     if(n){sites.push(n);save();updateCurrent();}
   });
+  renderSiteMenus();
   updateCurrent();
 
   if(mode==='self'){

--- a/public/ozon-analysis.html
+++ b/public/ozon-analysis.html
@@ -14,16 +14,15 @@
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>
-        <ul class="dropdown">
-          <li><a href="index.html">全托管</a></li>
-          <li><a href="self-operated.html">自运营</a></li>
-        </ul>
+        <ul class="dropdown" id="managedMenu"></ul>
       </li>
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
       <li class="ozon active"><a href="ozon-detail.html">Ozon</a></li>
-      <li class="independent"><a href="independent-site.html">独立站</a></li>
+      <li class="independent"><a href="#">独立站</a>
+        <ul class="dropdown" id="indepMenu"></ul>
+      </li>
     </ul>
   </nav>
   <div id="userArea" class="user-section"></div>
@@ -41,5 +40,6 @@
     <h2 style="font-size:24px;font-weight:700;">页面建设中…</h2>
   </main>
 </div>
+<script src="assets/site-nav.js"></script>
 </body>
 </html>

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -76,6 +76,8 @@
               <thead>
                 <tr>
                   <th>产品名</th>
+                  <th>型号</th>
+                  <th>搜索排名</th>
                   <th>曝光量</th>
                   <th>访客数</th>
                   <th>浏览量</th>
@@ -112,7 +114,7 @@
         paging:true,
         searching:true,
         info:true,
-        order:[[2,'desc']],
+          order:[[4,'desc']],
         scrollY:'60vh',
         scrollCollapse:true,
         autoWidth:false,
@@ -155,21 +157,24 @@
       const buyers = Number(r.pay_buyers)||0;
       const v2a = sessions ? (atcUsers/sessions*100).toFixed(2)+'%' : '0%';
       const a2p = atcUsers ? (orders/atcUsers*100).toFixed(2)+'%' : '0%';
-      const visitRate = impressions ? (sessions/impressions*100).toFixed(2)+'%' : '0%';
-      return [
-        `<a href="https://ozon.ru/product/${r.product_id}" target="_blank" rel="noopener">${r.product_title || r.product_id}</a>`,
-        impressions,
-        sessions,
-        pageviews,
-        atcUsers,
-        atcQty,
-        itemsSold,
-        orders,
-        buyers,
-        v2a,
-        a2p,
-        visitRate
-      ];
+        const visitRate = impressions ? (sessions/impressions*100).toFixed(2)+'%' : '0%';
+        const rank = r.search_rank!=null ? Number(r.search_rank).toFixed(2) : '';
+        return [
+          `<a href="https://ozon.ru/product/${r.product_id}" target="_blank" rel="noopener">${r.product_title || r.product_id}</a>`,
+          r.model || '',
+          rank,
+          impressions,
+          sessions,
+          pageviews,
+          atcUsers,
+          atcQty,
+          itemsSold,
+          orders,
+          buyers,
+          v2a,
+          a2p,
+          visitRate
+        ];
     });
       const dt = initTable();
       dt.clear().rows.add(mapped).draw();

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -26,16 +26,15 @@
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>
-        <ul class="dropdown">
-          <li><a href="index.html">全托管</a></li>
-          <li><a href="self-operated.html">自运营</a></li>
-        </ul>
+        <ul class="dropdown" id="managedMenu"></ul>
       </li>
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
       <li class="ozon active"><a href="ozon-detail.html">Ozon</a></li>
-      <li class="independent"><a href="independent-site.html">独立站</a></li>
+      <li class="independent"><a href="#">独立站</a>
+        <ul class="dropdown" id="indepMenu"></ul>
+      </li>
     </ul>
   </nav>
   <div id="userArea" class="user-section"></div>
@@ -101,6 +100,7 @@
   </main>
 </div>
 <div id="newModal"><div class="box"><h4>新品列表</h4><ul id="newItems"></ul></div></div>
+<script src="assets/site-nav.js"></script>
 <script>
 (function(){
   const storeId = 'demo';

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -76,7 +76,6 @@
               <thead>
                 <tr>
                   <th>产品名</th>
-                  <th>产品详情</th>
                   <th>型号</th>
                   <th>搜索排名</th>
                   <th>曝光量</th>
@@ -90,6 +89,7 @@
                   <th>访客→加购</th>
                   <th>加购→支付</th>
                   <th>访客比</th>
+                  <th>产品详情</th>
                 </tr>
               </thead>
               <tbody></tbody>
@@ -115,11 +115,18 @@
         paging:true,
         searching:true,
         info:true,
-          order:[[5,'desc']],
+        order:[[4,'desc']],
         scrollY:'60vh',
         scrollCollapse:true,
         autoWidth:false,
         language:{ emptyTable:'暂无数据' }
+      });
+      $('#report tbody').on('dblclick','td',function(){
+        const col = table.cell(this).index().column;
+        const last = table.columns().count()-1;
+        if(col===0 || col===last) return;
+        const pid = $(this).closest('tr').find('a[data-pid]').data('pid');
+        if(pid) window.open('ozon-product-insights.html?pid='+pid,'_blank');
       });
     }
     return table;
@@ -161,8 +168,7 @@
         const visitRate = impressions ? (sessions/impressions*100).toFixed(2)+'%' : '0%';
         const rank = r.search_rank!=null ? Number(r.search_rank).toFixed(2) : '';
         return [
-          `<a href="https://ozon.ru/product/${r.product_id}" target="_blank" rel="noopener">${r.product_title || r.product_id}</a>`,
-          `<a href="ozon-product-insights.html?pid=${r.product_id}" target="_blank">详情</a>`,
+          `<a data-pid="${r.product_id}" href="https://ozon.ru/product/${r.product_id}" target="_blank" rel="noopener">${r.product_title || r.product_id}</a>`,
           r.model || '',
           rank,
           impressions,
@@ -175,7 +181,8 @@
           buyers,
           v2a,
           a2p,
-          visitRate
+          visitRate,
+          `<a href="ozon-product-insights.html?pid=${r.product_id}" target="_blank">详情</a>`
         ];
     });
       const dt = initTable();

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -76,6 +76,7 @@
               <thead>
                 <tr>
                   <th>产品名</th>
+                  <th>产品详情</th>
                   <th>型号</th>
                   <th>搜索排名</th>
                   <th>曝光量</th>
@@ -114,7 +115,7 @@
         paging:true,
         searching:true,
         info:true,
-          order:[[4,'desc']],
+          order:[[5,'desc']],
         scrollY:'60vh',
         scrollCollapse:true,
         autoWidth:false,
@@ -161,6 +162,7 @@
         const rank = r.search_rank!=null ? Number(r.search_rank).toFixed(2) : '';
         return [
           `<a href="https://ozon.ru/product/${r.product_id}" target="_blank" rel="noopener">${r.product_title || r.product_id}</a>`,
+          `<a href="ozon-product-insights.html?pid=${r.product_id}" target="_blank">详情</a>`,
           r.model || '',
           rank,
           impressions,

--- a/public/ozon-product-insights.html
+++ b/public/ozon-product-insights.html
@@ -17,16 +17,15 @@
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>
-        <ul class="dropdown">
-          <li><a href="index.html">全托管</a></li>
-          <li><a href="self-operated.html">自运营</a></li>
-        </ul>
+        <ul class="dropdown" id="managedMenu"></ul>
       </li>
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
       <li class="ozon active"><a href="ozon-detail.html">Ozon</a></li>
-      <li class="independent"><a href="independent-site.html">独立站</a></li>
+      <li class="independent"><a href="#">独立站</a>
+        <ul class="dropdown" id="indepMenu"></ul>
+      </li>
     </ul>
   </nav>
   <div id="userArea" class="user-section"></div>
@@ -58,6 +57,7 @@
     </div>
   </main>
 </div>
+<script src="assets/site-nav.js"></script>
 <script>
 (function(){
   const storeId='demo';

--- a/public/ozon-product-insights.html
+++ b/public/ozon-product-insights.html
@@ -61,6 +61,8 @@
 <script>
 (function(){
   const storeId='demo';
+  const params=new URLSearchParams(location.search);
+  const pidParam=params.get('pid');
   const input=document.getElementById('dateRange');
   const fp=flatpickr(input,{mode:'range',dateFormat:'Y-m-d',onClose:ds=>{if(ds.length===2)loadData();}});
   const today=new Date();
@@ -140,7 +142,8 @@
     const sel=document.getElementById('productSelect'); sel.innerHTML='';
     ids.forEach(id=>{const o=document.createElement('option');o.value=id;o.textContent=titleMap.get(id)||id;o.dataset.title=titleMap.get(id)||'';sel.appendChild(o);});
     if(!ids.length){document.getElementById('kpi').innerHTML='';document.getElementById('lineWrap').style.display='none';return;}
-    const pid=ids[0]; sel.value=pid; update(pid);
+    const pid=ids.find(id=>String(id)===String(pidParam))||ids[0];
+    sel.value=pid; update(pid);
     sel.onchange=()=>update(sel.value);
   }
 

--- a/public/ozon-product-insights.html
+++ b/public/ozon-product-insights.html
@@ -68,14 +68,35 @@
   const startDef=new Date(today.getTime()-6*86400000).toISOString().slice(0,10);
   input.value=`${startDef} to ${endDef}`;
   let rowsCur=[],rowsPrev=[],curStart='',curEnd='',prevStart='',prevEnd='',days=0;
+  let totalsCur={exp:0,uv:0,add:0,pay:0};
 
-  function card(title,cur,prev,isPct){
+  function card(title,cur,prev,isPct,avg,share){
     const diff=(cur-prev)||0;
     const arrow=diff>=0?'\u2191':'\u2193';
     const cls=diff>=0?'up':'down';
     const fmt=v=>isPct?`${(v*100).toFixed(2)}%`:v;
     const delta=isPct?`${Math.abs(diff*100).toFixed(2)}%`:Math.abs(diff);
-    return `<div class="stat-card"><h4>${title}</h4><p>${fmt(cur)}</p><div class="sub"><span class="delta ${cls}">${arrow} ${delta}</span></div></div>`;
+    const parts=[`<span class="delta ${cls}">${arrow} ${delta}</span>`];
+    if(avg!=null){
+      const diffAvg=(cur-avg)||0;
+      const dir=diffAvg>=0?'高于平均':'低于平均';
+      const clsAvg=diffAvg>=0?'up':'down';
+      const deltaAvg=isPct?`${Math.abs(diffAvg*100).toFixed(2)}%`:Math.abs(diffAvg);
+      parts.push(`<span class="${clsAvg}" style="margin-left:8px;">${dir} ${deltaAvg}</span>`);
+    }
+    if(share!=null){
+      parts.push(`<span style="margin-left:8px;">占比 ${(share*100).toFixed(2)}%</span>`);
+    }
+    return `<div class="stat-card"><h4>${title}</h4><p>${fmt(cur)}</p><div class="sub">${parts.join('')}</div></div>`;
+  }
+
+  function sumAll(rows){
+    return rows.reduce((a,r)=>({
+      exp:a.exp+Number(r.exposure||0),
+      uv:a.uv+Number(r.uv||0),
+      add:a.add+Number(r.add_to_cart_users||0),
+      pay:a.pay+Number(r.pay_buyers||0)
+    }),{exp:0,uv:0,add:0,pay:0});
   }
 
   function periodShift(startISO,endISO){
@@ -108,6 +129,7 @@
       fetchAgg(curStart,curEnd),
       fetchAgg(prevStart,prevEnd)
     ]);
+    totalsCur=sumAll(rowsCur);
     renderProducts();
   }
 
@@ -143,14 +165,21 @@
     const prevAddRate=prev.uv?prev.add/prev.uv:0;
     const curPayRate=cur.uv?cur.pay/cur.uv:0;
     const prevPayRate=prev.uv?prev.pay/prev.uv:0;
+    const avgUvRate=totalsCur.exp?totalsCur.uv/totalsCur.exp:0;
+    const avgAddRate=totalsCur.uv?totalsCur.add/totalsCur.uv:0;
+    const avgPayRate=totalsCur.uv?totalsCur.pay/totalsCur.uv:0;
+    const shareExp=totalsCur.exp?cur.exp/totalsCur.exp:0;
+    const shareUv=totalsCur.uv?cur.uv/totalsCur.uv:0;
+    const shareAdd=totalsCur.add?cur.add/totalsCur.add:0;
+    const sharePay=totalsCur.pay?cur.pay/totalsCur.pay:0;
     document.getElementById('kpi').innerHTML=[
-      card('平均访客比',curUvRate,prevUvRate,true),
-      card('平均加购比',curAddRate,prevAddRate,true),
-      card('平均支付比',curPayRate,prevPayRate,true),
-      card('总曝光量',cur.exp,prev.exp),
-      card('总访客数',cur.uv,prev.uv),
-      card('总加购数',cur.add,prev.add),
-      card('总支付数',cur.pay,prev.pay)
+      card('平均访客比',curUvRate,prevUvRate,true,avgUvRate),
+      card('平均加购比',curAddRate,prevAddRate,true,avgAddRate),
+      card('平均支付比',curPayRate,prevPayRate,true,avgPayRate),
+      card('总曝光量',cur.exp,prev.exp,false,null,shareExp),
+      card('总访客数',cur.uv,prev.uv,false,null,shareUv),
+      card('总加购数',cur.add,prev.add,false,null,shareAdd),
+      card('总支付数',cur.pay,prev.pay,false,null,sharePay)
     ].join('');
 
     const [trendCur,trendPrev]=await Promise.all([

--- a/public/ozon-product-insights.html
+++ b/public/ozon-product-insights.html
@@ -3,9 +3,12 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Ozon 产品分析（建设中）</title>
+  <title>Ozon 产品分析</title>
   <link rel="stylesheet" href="assets/login.css">
   <link rel="stylesheet" href="assets/theme.css?v=20250811-single">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/echarts/dist/echarts.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
   <script>const t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t);</script>
 </head>
 <body class="fm">
@@ -37,9 +40,158 @@
       <li><a href="ozon-product-insights.html" class="active">产品分析</a></li>
     </ul>
   </nav>
-  <main class="main" style="display:flex;align-items:center;justify-content:center;">
-    <h2 style="font-size:24px;font-weight:700;">页面建设中…</h2>
+  <main class="main">
+    <div class="content">
+      <section class="content-pad">
+        <div class="controls" style="margin-bottom:12px;"><input id="dateRange" class="date-filter" placeholder="选择日期范围"></div>
+        <div class="controls" style="margin-bottom:12px;flex-wrap:wrap;"><label>产品</label><select id="productSelect" class="sel" style="width:200px;flex:0 0 200px;"></select><a id="productLink" href="#" target="_blank" style="margin-left:8px;display:none;word-break:break-all;white-space:normal;flex:1 1 auto;"></a><span id="listingDate" style="margin-left:8px;"></span></div>
+        <div id="kpi" class="kpi-row"></div>
+        <div id="lineWrap" class="panel" style="margin-top:16px;display:none;">
+          <h3>曝光趋势</h3>
+          <div id="expLine" style="width:100%;height:260px;"></div>
+          <h3 style="margin-top:24px;">访客比趋势</h3>
+          <div id="uvRateLine" style="width:100%;height:260px;"></div>
+          <h3 style="margin-top:24px;">加购比趋势</h3>
+          <div id="addRateLine" style="width:100%;height:260px;"></div>
+        </div>
+      </section>
+    </div>
   </main>
 </div>
+<script>
+(function(){
+  const storeId='demo';
+  const input=document.getElementById('dateRange');
+  const fp=flatpickr(input,{mode:'range',dateFormat:'Y-m-d',onClose:ds=>{if(ds.length===2)loadData();}});
+  const today=new Date();
+  const endDef=today.toISOString().slice(0,10);
+  const startDef=new Date(today.getTime()-6*86400000).toISOString().slice(0,10);
+  input.value=`${startDef} to ${endDef}`;
+  let rowsCur=[],rowsPrev=[],curStart='',curEnd='',prevStart='',prevEnd='',days=0;
+
+  function card(title,cur,prev,isPct){
+    const diff=(cur-prev)||0;
+    const arrow=diff>=0?'\u2191':'\u2193';
+    const cls=diff>=0?'up':'down';
+    const fmt=v=>isPct?`${(v*100).toFixed(2)}%`:v;
+    const delta=isPct?`${Math.abs(diff*100).toFixed(2)}%`:Math.abs(diff);
+    return `<div class="stat-card"><h4>${title}</h4><p>${fmt(cur)}</p><div class="sub"><span class="delta ${cls}">${arrow} ${delta}</span></div></div>`;
+  }
+
+  function periodShift(startISO,endISO){
+    const start=new Date(startISO+'T00:00:00');
+    const end=new Date(endISO+'T00:00:00');
+    const d=Math.round((end-start)/86400000)+1;
+    const prevEnd=new Date(start.getTime()-86400000);
+    const prevStart=new Date(prevEnd.getTime()-(d-1)*86400000);
+    const fmt=d=>d.toISOString().slice(0,10);
+    return{prevStart:fmt(prevStart),prevEnd:fmt(prevEnd),days:d};
+  }
+
+  async function fetchAgg(start,end){
+    const url=`/api/ozon/stats?store_id=${encodeURIComponent(storeId)}&start=${start}&end=${end}`;
+    const resp=await fetch(url); const json=await resp.json();
+    if(!json.ok) throw new Error(json.msg||'fetch failed');
+    return json.rows||[];
+  }
+
+  function fetchTrend(pid,start,end){
+    const url=`/api/ozon/product?store_id=${encodeURIComponent(storeId)}&product_id=${pid}&start=${start}&end=${end}`;
+    return fetch(url).then(r=>r.json()).then(j=>j.rows||[]);
+  }
+
+  async function loadData(){
+    const val=input.value; if(!val.includes(' to ')) return; const parts=val.split(' to ');
+    curStart=parts[0]; curEnd=parts[1];
+    const shift=periodShift(curStart,curEnd); prevStart=shift.prevStart; prevEnd=shift.prevEnd; days=shift.days;
+    [rowsCur,rowsPrev]=await Promise.all([
+      fetchAgg(curStart,curEnd),
+      fetchAgg(prevStart,prevEnd)
+    ]);
+    renderProducts();
+  }
+
+  function renderProducts(){
+    const expMap=new Map(); const titleMap=new Map();
+    rowsCur.forEach(r=>{expMap.set(r.product_id,(expMap.get(r.product_id)||0)+Number(r.exposure||0)); titleMap.set(r.product_id,r.product_title||r.product_id);});
+    const ids=[...expMap.keys()].sort((a,b)=>expMap.get(b)-expMap.get(a));
+    const sel=document.getElementById('productSelect'); sel.innerHTML='';
+    ids.forEach(id=>{const o=document.createElement('option');o.value=id;o.textContent=titleMap.get(id)||id;o.dataset.title=titleMap.get(id)||'';sel.appendChild(o);});
+    if(!ids.length){document.getElementById('kpi').innerHTML='';document.getElementById('lineWrap').style.display='none';return;}
+    const pid=ids[0]; sel.value=pid; update(pid);
+    sel.onchange=()=>update(sel.value);
+  }
+
+  async function update(pid){
+    const titleOpt=document.querySelector(`#productSelect option[value="${pid}"]`);
+    const title=titleOpt?titleOpt.dataset.title||pid:pid;
+    const link=document.getElementById('productLink');
+    link.textContent=title; link.href=`https://ozon.ru/product/${pid}`; link.style.display='';
+
+    function sum(rows){
+      return rows.filter(r=>String(r.product_id)===String(pid)).reduce((a,r)=>({
+        exp:a.exp+Number(r.exposure||0),
+        uv:a.uv+Number(r.uv||0),
+        add:a.add+Number(r.add_to_cart_users||0),
+        pay:a.pay+Number(r.pay_buyers||0)
+      }),{exp:0,uv:0,add:0,pay:0});
+    }
+    const cur=sum(rowsCur); const prev=sum(rowsPrev);
+    const curUvRate=cur.exp?cur.uv/cur.exp:0;
+    const prevUvRate=prev.exp?prev.uv/prev.exp:0;
+    const curAddRate=cur.uv?cur.add/cur.uv:0;
+    const prevAddRate=prev.uv?prev.add/prev.uv:0;
+    const curPayRate=cur.uv?cur.pay/cur.uv:0;
+    const prevPayRate=prev.uv?prev.pay/prev.uv:0;
+    document.getElementById('kpi').innerHTML=[
+      card('平均访客比',curUvRate,prevUvRate,true),
+      card('平均加购比',curAddRate,prevAddRate,true),
+      card('平均支付比',curPayRate,prevPayRate,true),
+      card('总曝光量',cur.exp,prev.exp),
+      card('总访客数',cur.uv,prev.uv),
+      card('总加购数',cur.add,prev.add),
+      card('总支付数',cur.pay,prev.pay)
+    ].join('');
+
+    const [trendCur,trendPrev]=await Promise.all([
+      fetchTrend(pid,curStart,curEnd),
+      fetchTrend(pid,prevStart,prevEnd)
+    ]);
+    const allDates=[...trendCur,...trendPrev].map(r=>r.date).filter(Boolean).sort();
+    document.getElementById('listingDate').textContent=allDates.length?`上架日期：${allDates[0]}`:'';
+    line(trendCur,trendPrev);
+  }
+
+  function line(trendCur,trendPrev){
+    const mapExpA=new Map(),mapExpB=new Map();
+    const mapUvRateA=new Map(),mapUvRateB=new Map();
+    const mapAddRateA=new Map(),mapAddRateB=new Map();
+    trendCur.forEach(r=>{const d=r.date;const e=Number(r.exposure||0);const u=Number(r.uv||0);const a=Number(r.add_to_cart_users||0);mapExpA.set(d,e);mapUvRateA.set(d,e?u/e:0);mapAddRateA.set(d,u?a/u:0);});
+    trendPrev.forEach(r=>{const d=r.date;const e=Number(r.exposure||0);const u=Number(r.uv||0);const a=Number(r.add_to_cart_users||0);mapExpB.set(d,e);mapUvRateB.set(d,e?u/e:0);mapAddRateB.set(d,u?a/u:0);});
+    const labels=[],expA=[],expB=[],uvA=[],uvB=[],addA=[],addB=[];
+    for(let i=0;i<days;i++){
+      const da=new Date(curStart+'T00:00:00'); da.setDate(da.getDate()+i); const isoA=da.toISOString().slice(0,10);
+      const db=new Date(prevStart+'T00:00:00'); db.setDate(db.getDate()+i); const isoB=db.toISOString().slice(0,10);
+      labels.push(isoA);
+      expA.push(mapExpA.get(isoA)||0);
+      expB.push(mapExpB.get(isoB)||0);
+      uvA.push((mapUvRateA.get(isoA)||0)*100);
+      uvB.push((mapUvRateB.get(isoB)||0)*100);
+      addA.push((mapAddRateA.get(isoA)||0)*100);
+      addB.push((mapAddRateB.get(isoB)||0)*100);
+    }
+    const lineWrap=document.getElementById('lineWrap'); lineWrap.style.display='block';
+    const expChart=echarts.init(document.getElementById('expLine'));
+    expChart.setOption({tooltip:{trigger:'axis'},legend:{data:['本周期','上一周期']},xAxis:{type:'category',data:labels},yAxis:{type:'value'},series:[{name:'本周期',type:'line',smooth:true,data:expA},{name:'上一周期',type:'line',smooth:true,data:expB}]});
+    const uvChart=echarts.init(document.getElementById('uvRateLine'));
+    uvChart.setOption({tooltip:{trigger:'axis',valueFormatter:v=>v+'%'},legend:{data:['本周期','上一周期']},xAxis:{type:'category',data:labels},yAxis:{type:'value',axisLabel:{formatter:'{value}%'}},series:[{name:'本周期',type:'line',smooth:true,data:uvA},{name:'上一周期',type:'line',smooth:true,data:uvB}]});
+    const addChart=echarts.init(document.getElementById('addRateLine'));
+    addChart.setOption({tooltip:{trigger:'axis',valueFormatter:v=>v+'%'},legend:{data:['本周期','上一周期']},xAxis:{type:'category',data:labels},yAxis:{type:'value',axisLabel:{formatter:'{value}%'}},series:[{name:'本周期',type:'line',smooth:true,data:addA},{name:'上一周期',type:'line',smooth:true,data:addB}]});
+    window.addEventListener('resize',()=>{expChart.resize();uvChart.resize();addChart.resize();});
+  }
+
+  loadData().catch(err=>console.error(err));
+})();
+</script>
 </body>
 </html>

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -62,6 +62,7 @@
 document.addEventListener('DOMContentLoaded',()=>{
   const params=new URLSearchParams(location.search);
   const mode=params.get('mode');
+  const pidParam=params.get('pid');
   const detailLink=document.getElementById('detailLink');
   const analysisLink=document.getElementById('analysisLink');
   const prodLink=document.getElementById('productLink');
@@ -215,7 +216,8 @@ document.addEventListener('DOMContentLoaded',()=>{
       ids.forEach(id=>{const o=document.createElement('option');o.value=id;o.textContent=id;o.setAttribute('data-pid',id);sel.appendChild(o);});
       populateProductNames(sel);
       if(!ids.length){document.getElementById('kpi').innerHTML=''; setProdLink('',''); return;}
-      const pid=ids[0]; sel.value=pid; update(pid);
+      const pid=ids.find(id=>String(id)===String(pidParam))||ids[0];
+      sel.value=pid; update(pid);
       sel.onchange=()=>update(sel.value);
       function sum(rows,pid){
         return rows.filter(x=>String(x.product_id)===String(pid)).reduce((a,x)=>({
@@ -328,7 +330,8 @@ document.addEventListener('DOMContentLoaded',()=>{
       });
       populateProductNames(sel);
       if(!ids.length){document.getElementById('kpi').innerHTML=''; setProdLink('', ''); return;}
-      const pid=ids[0]; sel.value=pid; update(pid);
+      const pid=ids.find(id=>String(id)===String(pidParam))||ids[0];
+      sel.value=pid; update(pid);
       sel.onchange=()=>update(sel.value);
       function sum(rows,pid){
         return rows.filter(r=>String(getId(r))===String(pid)).reduce((a,r)=>({

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -306,14 +306,15 @@ document.addEventListener('DOMContentLoaded',()=>{
     function renderProductSelf(rowsA,rowsB,days,startA,startB){
       const expMap=new Map();
       const linkMap=new Map();
-      const getId=r=>mode==='indep'?r.product:r.product_id;
+      const getId=r=>mode==='indep'?(r.landing_path||r.product):r.product_id;
       const getExp=r=>mode==='indep'?Number(r.impr||0):Number(r.exposure||0);
       const base=siteParam.replace(/\/$/,'');
       rowsA.forEach(r=>{
         const id=getId(r);
         expMap.set(id,(expMap.get(id)||0)+getExp(r));
         if(mode==='indep'){
-          const link = r.landing_url && r.landing_url.startsWith('http') ? r.landing_url : base + (r.landing_url || r.landing_path || '');
+          const baseUrl = r.landing_url && r.landing_url.startsWith('http') ? r.landing_url : base + (r.landing_url || '');
+          const link = baseUrl.replace(/\/$/, '') + (r.landing_path || '');
           if(link) linkMap.set(id,link);
         }
       });

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -111,45 +111,56 @@ document.addEventListener('DOMContentLoaded',()=>{
     if(analysisLink)analysisLink.href='operation-analysis.html';
   }
 
+    const currentSiteEl=document.getElementById('currentSite');
+  const addBtn=document.getElementById('addSite');
+  if(mode==='indep'){
+    if(addBtn) addBtn.style.display='none';
+    renderSiteMenus();
+    fetch('/api/independent/sites').then(r=>r.json()).then(j=>{
+      const sites=j.sites||[];
+      const paramSite=params.get('site');
+      const stored=localStorage.getItem('currentIndepSite');
+      let site=sites[0]||'';
+      if(paramSite && sites.includes(paramSite)) site=paramSite;
+      else if(stored && sites.includes(stored)) site=stored;
+      localStorage.setItem('currentIndepSite',site);
+      currentSiteEl.textContent=site;
+      document.title='产品分析 · '+site;
+      setupSelf('indep', site);
+    });
+    return;
+  }
   const siteListKey='managedSites';
   const currentSiteKey='currentSite';
   let sites=JSON.parse(localStorage.getItem(siteListKey)||'null');
   if(!Array.isArray(sites)||!sites.length){sites=mode==='self'?['A站','B站','C站']:['主站'];}
-  const currentSiteEl=document.getElementById('currentSite');
   function save(){localStorage.setItem(siteListKey,JSON.stringify(sites));renderSiteMenus();}
   function updateCurrent(){
     const name=localStorage.getItem(currentSiteKey)||sites[0];
     if(mode==='self'){
       currentSiteEl.textContent='自运营 '+name;
-    }else if(mode==='indep'){
-      currentSiteEl.textContent='独立站';
     }else{
       currentSiteEl.textContent=sites.length>1?'全托管 '+name:'全托管';
     }
     localStorage.setItem(currentSiteKey,name);
   }
   currentSiteEl.addEventListener('dblclick',()=>{
-    if(mode==='indep')return;
     const cur=localStorage.getItem(currentSiteKey)||sites[0];
     const idx=sites.indexOf(cur);
     const n=prompt('修改站点名',cur);
     if(n){sites[idx]=n;save();localStorage.setItem(currentSiteKey,n);updateCurrent();}
   });
-  document.getElementById('addSite').addEventListener('click',()=>{
-    if(mode==='indep')return;
+  addBtn.addEventListener('click',()=>{
     const n=prompt('新增站点名');
     if(n){sites.push(n);save();updateCurrent();}
   });
   renderSiteMenus();
   updateCurrent();
-
-  if(mode==='self' || mode==='indep'){
-    setupSelf(mode);
-  }else{
+  if(mode==='self')
+    setupSelf('self');
+  else
     setupFM();
-  }
-
-  function card(title,cur,prev,isPct,avg,share){
+function card(title,cur,prev,isPct,avg,share){
     const diff=(cur-prev)||0;
     const arrow=diff>=0?'↑':'↓';
     const cls=diff>=0?'up':'down';
@@ -266,20 +277,18 @@ document.addEventListener('DOMContentLoaded',()=>{
     loadPeriods();
   }
 
-  function setupSelf(mode){
+  function setupSelf(mode, siteParam){
     document.getElementById('lineWrap').style.display='block';
     const ctrl=document.getElementById('ctrl');
     ctrl.innerHTML='<input id="dateRange" class="date-filter" placeholder="选择日期范围">';
     const input=document.getElementById('dateRange');
-    const key=mode==='indep'?'indepPeriod':'selfPeriod';
+    const key=mode==='indep'?`indepPeriod_${siteParam}`:'selfPeriod';
     const fp=flatpickr(input,{mode:'range',dateFormat:'Y-m-d',onClose:ds=>{if(ds.length===2)loadData();}});
     const stored=localStorage.getItem(key);
     if(stored && stored.includes(' to ')) input.value=stored; else {
       const today=new Date(); const end=today.toISOString().slice(0,10); const start=new Date(today.getTime()-6*86400000).toISOString().slice(0,10); const def=`${start} to ${end}`; input.value=def; localStorage.setItem(key,def);
     }
-    const siteParam=params.get('site')||localStorage.getItem('indepSite')||'poolsvacuum.com';
-    localStorage.setItem('indepSite',siteParam);
-    async function loadData(){
+        async function loadData(){
       const val=input.value; if(!val.includes(' to '))return; const [startISO,endISO]=val.split(' to '); localStorage.setItem(key,`${startISO} to ${endISO}`);
       const {prevStart,prevEnd,days}=periodShift(startISO,endISO);
       const [rowsA,rowsB]=await Promise.all([

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -147,13 +147,24 @@ document.addEventListener('DOMContentLoaded',()=>{
     setupFM();
   }
 
-  function card(title,cur,prev,isPct){
+  function card(title,cur,prev,isPct,avg,share){
     const diff=(cur-prev)||0;
     const arrow=diff>=0?'↑':'↓';
     const cls=diff>=0?'up':'down';
     const fmt=v=>isPct?`${(v*100).toFixed(2)}%`:v;
     const delta=isPct?`${Math.abs(diff*100).toFixed(2)}%`:Math.abs(diff);
-    return `<div class="stat-card"><h4>${title}</h4><p>${fmt(cur)}</p><div class="sub"><span class="delta ${cls}">${arrow} ${delta}</span></div></div>`;
+    const parts=[`<span class="delta ${cls}">${arrow} ${delta}</span>`];
+    if(avg!=null){
+      const diffAvg=(cur-avg)||0;
+      const dir=diffAvg>=0?'高于平均':'低于平均';
+      const clsAvg=diffAvg>=0?'up':'down';
+      const deltaAvg=isPct?`${Math.abs(diffAvg*100).toFixed(2)}%`:Math.abs(diffAvg);
+      parts.push(`<span class="${clsAvg}" style="margin-left:8px;">${dir} ${deltaAvg}</span>`);
+    }
+    if(share!=null){
+      parts.push(`<span style="margin-left:8px;">占比 ${(share*100).toFixed(2)}%</span>`);
+    }
+    return `<div class="stat-card"><h4>${title}</h4><p>${fmt(cur)}</p><div class="sub">${parts.join('')}</div></div>`;
   }
 
   function setupFM(){
@@ -192,6 +203,12 @@ document.addEventListener('DOMContentLoaded',()=>{
     function renderProductFM(rowsA,rowsB){
       const expMap=new Map();
       rowsA.forEach(r=>expMap.set(r.product_id,(expMap.get(r.product_id)||0)+Number(r.search_exposure||0)));
+      const totalsA=rowsA.reduce((a,x)=>({
+        exp:a.exp+Number(x.search_exposure||0),
+        uv:a.uv+Number(x.uv||0),
+        add:a.add+Number(x.add_to_cart_users||0),
+        pay:a.pay+Number(x.pay_buyers||0)
+      }),{exp:0,uv:0,add:0,pay:0});
       const ids=Array.from(expMap.keys()).sort((a,b)=>expMap.get(b)-expMap.get(a));
       const sel=document.getElementById('productSelect');
       sel.innerHTML='';
@@ -216,14 +233,21 @@ document.addEventListener('DOMContentLoaded',()=>{
         const prevAddRate=prev.uv?prev.add/prev.uv:0;
         const curPayRate=cur.uv?cur.pay/cur.uv:0;
         const prevPayRate=prev.uv?prev.pay/prev.uv:0;
+        const avgUvRate=totalsA.exp?totalsA.uv/totalsA.exp:0;
+        const avgAddRate=totalsA.uv?totalsA.add/totalsA.uv:0;
+        const avgPayRate=totalsA.uv?totalsA.pay/totalsA.uv:0;
+        const shareExp=totalsA.exp?cur.exp/totalsA.exp:0;
+        const shareUv=totalsA.uv?cur.uv/totalsA.uv:0;
+        const shareAdd=totalsA.add?cur.add/totalsA.add:0;
+        const sharePay=totalsA.pay?cur.pay/totalsA.pay:0;
         document.getElementById('kpi').innerHTML=[
-          card('平均访客比',curUvRate,prevUvRate,true),
-          card('平均加购比',curAddRate,prevAddRate,true),
-          card('平均支付比',curPayRate,prevPayRate,true),
-          card('总曝光量',cur.exp,prev.exp),
-          card('总访客数',cur.uv,prev.uv),
-          card('总加购人数',cur.add,prev.add),
-          card('总支付买家数',cur.pay,prev.pay)
+          card('平均访客比',curUvRate,prevUvRate,true,avgUvRate),
+          card('平均加购比',curAddRate,prevAddRate,true,avgAddRate),
+          card('平均支付比',curPayRate,prevPayRate,true,avgPayRate),
+          card('总曝光量',cur.exp,prev.exp,false,null,shareExp),
+          card('总访客数',cur.uv,prev.uv,false,null,shareUv),
+          card('总加购人数',cur.add,prev.add,false,null,shareAdd),
+          card('总支付买家数',cur.pay,prev.pay,false,null,sharePay)
         ].join('');
         const dates=[...rowsA,...rowsB].filter(x=>String(x.product_id)===String(pid)).map(x=>x.period_start||x.period_end||'').filter(Boolean).sort();
         document.getElementById('listingDate').textContent=dates.length?`上架日期：${dates[0]}`:'';
@@ -283,6 +307,12 @@ document.addEventListener('DOMContentLoaded',()=>{
       const getId=r=>mode==='indep'?r.product:r.product_id;
       const getExp=r=>mode==='indep'?Number(r.impr||0):Number(r.exposure||0);
       rowsA.forEach(r=>{const id=getId(r);expMap.set(id,(expMap.get(id)||0)+getExp(r)); if(mode==='indep' && r.landing_url) linkMap.set(id,r.landing_url);});
+      const totalsA=rowsA.reduce((a,r)=>({
+        exp:a.exp+getExp(r),
+        uv:a.uv+Number(mode==='indep'?r.clicks||0:r.visitors||0),
+        add:a.add+Number(mode==='indep'?0:r.add_people||0),
+        pay:a.pay+Number(mode==='indep'?r.conversions||0:r.pay_buyers||0)
+      }),{exp:0,uv:0,add:0,pay:0});
       const ids=Array.from(expMap.keys()).sort((a,b)=>expMap.get(b)-expMap.get(a));
       const sel=document.getElementById('productSelect'); sel.innerHTML='';
       ids.forEach(id=>{
@@ -358,14 +388,21 @@ document.addEventListener('DOMContentLoaded',()=>{
         const prevAddRate=prev.uv?prev.add/prev.uv:0;
         const curPayRate=cur.uv?cur.pay/cur.uv:0;
         const prevPayRate=prev.uv?prev.pay/prev.uv:0;
+        const avgUvRate=totalsA.exp?totalsA.uv/totalsA.exp:0;
+        const avgAddRate=totalsA.uv?totalsA.add/totalsA.uv:0;
+        const avgPayRate=totalsA.uv?totalsA.pay/totalsA.uv:0;
+        const shareExp=totalsA.exp?cur.exp/totalsA.exp:0;
+        const shareUv=totalsA.uv?cur.uv/totalsA.uv:0;
+        const shareAdd=totalsA.add?cur.add/totalsA.add:0;
+        const sharePay=totalsA.pay?cur.pay/totalsA.pay:0;
         document.getElementById('kpi').innerHTML=[
-          card('平均访客比',curUvRate,prevUvRate,true),
-          card('平均加购比',curAddRate,prevAddRate,true),
-          card('平均支付比',curPayRate,prevPayRate,true),
-          card('总曝光量',cur.exp,prev.exp),
-          card('总访客数',cur.uv,prev.uv),
-          card('总加购人数',cur.add,prev.add),
-          card('总支付买家数',cur.pay,prev.pay)
+          card('平均访客比',curUvRate,prevUvRate,true,avgUvRate),
+          card('平均加购比',curAddRate,prevAddRate,true,avgAddRate),
+          card('平均支付比',curPayRate,prevPayRate,true,avgPayRate),
+          card('总曝光量',cur.exp,prev.exp,false,null,shareExp),
+          card('总访客数',cur.uv,prev.uv,false,null,shareUv),
+          card('总加购人数',cur.add,prev.add,false,null,shareAdd),
+          card('总支付买家数',cur.pay,prev.pay,false,null,sharePay)
         ].join('');
         line(pid);
         const dates=[...rowsA,...rowsB].filter(r=>String(getId(r))===String(pid)).map(r=>mode==='indep'?r.day:r.bucket).sort();

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -276,6 +276,8 @@ document.addEventListener('DOMContentLoaded',()=>{
     if(stored && stored.includes(' to ')) input.value=stored; else {
       const today=new Date(); const end=today.toISOString().slice(0,10); const start=new Date(today.getTime()-6*86400000).toISOString().slice(0,10); const def=`${start} to ${end}`; input.value=def; localStorage.setItem(key,def);
     }
+    const siteParam=params.get('site')||localStorage.getItem('indepSite')||'poolsvacuum.com';
+    localStorage.setItem('indepSite',siteParam);
     async function loadData(){
       const val=input.value; if(!val.includes(' to '))return; const [startISO,endISO]=val.split(' to '); localStorage.setItem(key,`${startISO} to ${endISO}`);
       const {prevStart,prevEnd,days}=periodShift(startISO,endISO);
@@ -287,9 +289,7 @@ document.addEventListener('DOMContentLoaded',()=>{
     }
     function fetchAgg(start,end){
       if(mode==='indep'){
-        const site=params.get('site')||localStorage.getItem('indepSite')||'poolsvacuum.com';
-        localStorage.setItem('indepSite',site);
-        const url=`/api/independent/stats?site=${encodeURIComponent(site)}&from=${start}&to=${end}`;
+        const url=`/api/independent/stats?site=${encodeURIComponent(siteParam)}&from=${start}&to=${end}`;
         return fetch(url).then(r=>r.json()).then(j=>j.table||[]);
       }
       const url=`/api/ae_query?start=${start}&end=${end}&granularity=day`;
@@ -308,7 +308,15 @@ document.addEventListener('DOMContentLoaded',()=>{
       const linkMap=new Map();
       const getId=r=>mode==='indep'?r.product:r.product_id;
       const getExp=r=>mode==='indep'?Number(r.impr||0):Number(r.exposure||0);
-      rowsA.forEach(r=>{const id=getId(r);expMap.set(id,(expMap.get(id)||0)+getExp(r)); if(mode==='indep' && r.landing_url) linkMap.set(id,r.landing_url);});
+      const base=siteParam.replace(/\/$/,'');
+      rowsA.forEach(r=>{
+        const id=getId(r);
+        expMap.set(id,(expMap.get(id)||0)+getExp(r));
+        if(mode==='indep'){
+          const link = r.landing_url && r.landing_url.startsWith('http') ? r.landing_url : base + (r.landing_url || r.landing_path || '');
+          if(link) linkMap.set(id,link);
+        }
+      });
       const totalsA=rowsA.reduce((a,r)=>({
         exp:a.exp+getExp(r),
         uv:a.uv+Number(mode==='indep'?r.clicks||0:r.visitors||0),

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -17,16 +17,15 @@
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>
-        <ul class="dropdown">
-          <li><a href="index.html">全托管</a></li>
-          <li><a href="self-operated.html">自运营</a></li>
-        </ul>
+        <ul class="dropdown" id="managedMenu"></ul>
       </li>
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
       <li class="ozon"><a href="ozon-detail.html">Ozon</a></li>
-      <li class="independent"><a href="independent-site.html">独立站</a></li>
+      <li class="independent"><a href="#">独立站</a>
+        <ul class="dropdown" id="indepMenu"></ul>
+      </li>
     </ul>
   </nav>
   <div id="userArea" class="user-section"></div>
@@ -58,6 +57,7 @@
     </div>
   </main>
 </div>
+<script src="assets/site-nav.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded',()=>{
   const params=new URLSearchParams(location.search);
@@ -116,7 +116,7 @@ document.addEventListener('DOMContentLoaded',()=>{
   let sites=JSON.parse(localStorage.getItem(siteListKey)||'null');
   if(!Array.isArray(sites)||!sites.length){sites=mode==='self'?['A站','B站','C站']:['主站'];}
   const currentSiteEl=document.getElementById('currentSite');
-  function save(){localStorage.setItem(siteListKey,JSON.stringify(sites));}
+  function save(){localStorage.setItem(siteListKey,JSON.stringify(sites));renderSiteMenus();}
   function updateCurrent(){
     const name=localStorage.getItem(currentSiteKey)||sites[0];
     if(mode==='self'){
@@ -140,6 +140,7 @@ document.addEventListener('DOMContentLoaded',()=>{
     const n=prompt('新增站点名');
     if(n){sites.push(n);save();updateCurrent();}
   });
+  renderSiteMenus();
   updateCurrent();
 
   if(mode==='self' || mode==='indep'){

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -490,13 +490,12 @@ async function renderTable(rows, granularity) {
     const ctr = formatCtr(r.search_ctr);
     const stay = (r.avg_stay_seconds==null || r.avg_stay_seconds===undefined) ? '' : Math.round(r.avg_stay_seconds);
     const detailLink = '<a href="product-analysis.html?mode=self&pid='+ (r.product_id||'') +'" target="_blank">详情</a>';
-    return [link, detailLink, r.bucket_label || r.bucket, conv1 + '%', conv2 + '%', conv3 + '%', r.exposure, r.visitors, r.views, r.add_people, r.order_items, r.pay_items, r.pay_buyers, ctr, stay];
+    return [link, r.bucket_label || r.bucket, conv1 + '%', conv2 + '%', conv3 + '%', r.exposure, r.visitors, r.views, r.add_people, r.order_items, r.pay_items, r.pay_buyers, ctr, stay, detailLink];
   });
   window.dataTable = $('#report').DataTable({
     data,
     columns: [
       { title: '商品（ID）' },
-      { title: '产品详情' },
       { title: granularity==='day' ? '日期' : (granularity==='week' ? '周范围' : (granularity==='period' ? '周期' : '月份范围')) },
       { title: '访客比(%)' }, { title: '加购比(%)' }, { title: '支付比(%)' },
       { title: '曝光量' }, { title: '访客数' }, { title: '浏览量' },
@@ -506,9 +505,17 @@ async function renderTable(rows, granularity) {
       { title: '支付件数' },
       { title: '支付买家数' },
       { title: '搜索点击率(%)' },
-      { title: '平均停留时长(秒)' }
+      { title: '平均停留时长(秒)' },
+      { title: '产品详情' }
     ],
-    order: [[2,'desc']], scrollX:true, scrollY:'calc(100vh - 420px)', scrollCollapse:true, fixedHeader:true, fixedColumns:{leftColumns:1}
+    order: [[1,'desc']], scrollX:true, scrollY:'calc(100vh - 420px)', scrollCollapse:true, fixedHeader:true, fixedColumns:{leftColumns:1}
+  });
+  $('#report tbody').on('dblclick','td',function(){
+    const col = window.dataTable.cell(this).index().column;
+    const last = window.dataTable.columns().count()-1;
+    if(col===0 || col===last) return;
+    const pid = $(this).closest('tr').find('a[data-pid]').data('pid');
+    if(pid) window.open('product-analysis.html?mode=self&pid='+pid, '_blank');
   });
   populateProductNames(document.getElementById('report'));
 }

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -69,16 +69,15 @@
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali active"><a href="#">速卖通</a>
-        <ul class="dropdown">
-          <li><a href="index.html">全托管</a></li>
-          <li class="active"><a href="self-operated.html">自运营</a></li>
-        </ul>
+        <ul class="dropdown" id="managedMenu"></ul>
       </li>
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
       <li class="ozon"><a href="ozon-detail.html">Ozon</a></li>
-      <li class="independent"><a href="independent-site.html">独立站</a></li>
+      <li class="independent"><a href="#">独立站</a>
+        <ul class="dropdown" id="indepMenu"></ul>
+      </li>
     </ul>
   </nav>
   <div id="userArea" class="user-section"></div>
@@ -726,27 +725,15 @@ $('#metricSel').on('change', fetchAndRenderAll);
 })();
 </script>
 <script src="assets/login.js"></script>
+<script src="assets/site-nav.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', ()=>{
   const siteListKey='managedSites';
   const currentSiteKey='currentSite';
   let sites=JSON.parse(localStorage.getItem(siteListKey)||'null');
   if(!Array.isArray(sites)||!sites.length){sites=['A站','B站','C站'];}
-  const menuEl=document.getElementById('managedMenu');
   const currentSiteEl=document.getElementById('currentSite');
-  function save(){localStorage.setItem(siteListKey,JSON.stringify(sites));}
-  function renderMenu(){
-    menuEl.innerHTML='';
-    sites.forEach((name,idx)=>{
-      const li=document.createElement('li');
-      const a=document.createElement('a');
-      a.href='index.html';
-      a.textContent=name;
-      a.addEventListener('click',(e)=>{e.preventDefault();localStorage.setItem(currentSiteKey,name);window.location.href='index.html';});
-      a.addEventListener('dblclick',()=>{const n=prompt('修改站点名',name);if(n){sites[idx]=n;save();renderMenu();updateCurrent();}});
-      li.appendChild(a);menuEl.appendChild(li);
-    });
-  }
+  function save(){localStorage.setItem(siteListKey,JSON.stringify(sites));renderSiteMenus();}
   function updateCurrent(){
     const name=localStorage.getItem(currentSiteKey)||sites[0];
     currentSiteEl.textContent='自运营 '+name;
@@ -756,13 +743,14 @@ document.addEventListener('DOMContentLoaded', ()=>{
     const cur=localStorage.getItem(currentSiteKey)||sites[0];
     const idx=sites.indexOf(cur);
     const n=prompt('修改站点名',cur);
-    if(n){sites[idx]=n;save();renderMenu();localStorage.setItem(currentSiteKey,n);updateCurrent();}
+    if(n){sites[idx]=n;save();localStorage.setItem(currentSiteKey,n);updateCurrent();}
   });
   document.getElementById('addSite').addEventListener('click',()=>{
     const n=prompt('新增站点名');
-    if(n){sites.push(n);save();renderMenu();updateCurrent();}
+    if(n){sites.push(n);save();updateCurrent();}
   });
-  renderMenu();updateCurrent();
+  renderSiteMenus();
+  updateCurrent();
   const userArea=document.getElementById('userArea');
   function refreshUser(){
     const u=JSON.parse(localStorage.getItem('user')||'null');

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -489,12 +489,14 @@ async function renderTable(rows, granularity) {
     const conv3 = r.add_people>0 ? ((r.pay_buyers/r.add_people)*100).toFixed(2) : '0.00';
     const ctr = formatCtr(r.search_ctr);
     const stay = (r.avg_stay_seconds==null || r.avg_stay_seconds===undefined) ? '' : Math.round(r.avg_stay_seconds);
-    return [link, r.bucket_label || r.bucket, conv1 + '%', conv2 + '%', conv3 + '%', r.exposure, r.visitors, r.views, r.add_people, r.order_items, r.pay_items, r.pay_buyers, ctr, stay];
+    const detailLink = '<a href="product-analysis.html?mode=self&pid='+ (r.product_id||'') +'" target="_blank">详情</a>';
+    return [link, detailLink, r.bucket_label || r.bucket, conv1 + '%', conv2 + '%', conv3 + '%', r.exposure, r.visitors, r.views, r.add_people, r.order_items, r.pay_items, r.pay_buyers, ctr, stay];
   });
   window.dataTable = $('#report').DataTable({
     data,
     columns: [
       { title: '商品（ID）' },
+      { title: '产品详情' },
       { title: granularity==='day' ? '日期' : (granularity==='week' ? '周范围' : (granularity==='period' ? '周期' : '月份范围')) },
       { title: '访客比(%)' }, { title: '加购比(%)' }, { title: '支付比(%)' },
       { title: '曝光量' }, { title: '访客数' }, { title: '浏览量' },
@@ -506,7 +508,7 @@ async function renderTable(rows, granularity) {
       { title: '搜索点击率(%)' },
       { title: '平均停留时长(秒)' }
     ],
-    order: [[1,'desc']], scrollX:true, scrollY:'calc(100vh - 420px)', scrollCollapse:true, fixedHeader:true, fixedColumns:{leftColumns:1}
+    order: [[2,'desc']], scrollX:true, scrollY:'calc(100vh - 420px)', scrollCollapse:true, fixedHeader:true, fixedColumns:{leftColumns:1}
   });
   populateProductNames(document.getElementById('report'));
 }

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -2,7 +2,7 @@
 <html lang="zh">
 <head>
   <meta charset="UTF-8" />
-  <title>自运营数据分析 · 对比增强版</title>
+  <title>跨境电商数据分析平台</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- libs -->
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
@@ -37,7 +37,7 @@
   </style>
 </head>
 <body class="fm">
-<div id="loginOverlay" class="login-overlay" style="display:none">
+<div id="loginOverlay" class="login-overlay">
   <div class="login-container">
     <div class="login-form-card login-card-enter">
       <div class="form-header">

--- a/public/temu.html
+++ b/public/temu.html
@@ -14,16 +14,15 @@
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>
-        <ul class="dropdown">
-          <li><a href="index.html">全托管</a></li>
-          <li><a href="self-operated.html">自运营</a></li>
-        </ul>
+        <ul class="dropdown" id="managedMenu"></ul>
       </li>
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu active"><a href="temu.html">Temu</a></li>
       <li class="ozon"><a href="ozon-detail.html">Ozon</a></li>
-      <li class="independent"><a href="independent-site.html">独立站</a></li>
+      <li class="independent"><a href="#">独立站</a>
+        <ul class="dropdown" id="indepMenu"></ul>
+      </li>
     </ul>
   </nav>
   <div id="userArea" class="user-section"></div>
@@ -39,5 +38,6 @@
     <h2 style="font-size:24px;font-weight:700;">页面建设中…</h2>
   </main>
 </div>
+<script src="assets/site-nav.js"></script>
 </body>
 </html>

--- a/public/tiktok.html
+++ b/public/tiktok.html
@@ -14,16 +14,15 @@
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>
-        <ul class="dropdown">
-          <li><a href="index.html">全托管</a></li>
-          <li><a href="self-operated.html">自运营</a></li>
-        </ul>
+        <ul class="dropdown" id="managedMenu"></ul>
       </li>
       <li class="amazon"><a href="amazon.html">亚马逊</a></li>
       <li class="tiktok active"><a href="tiktok.html">TikTok Shop</a></li>
       <li class="temu"><a href="temu.html">Temu</a></li>
       <li class="ozon"><a href="ozon-detail.html">Ozon</a></li>
-      <li class="independent"><a href="independent-site.html">独立站</a></li>
+      <li class="independent"><a href="#">独立站</a>
+        <ul class="dropdown" id="indepMenu"></ul>
+      </li>
     </ul>
   </nav>
   <div id="userArea" class="user-section"></div>
@@ -39,5 +38,6 @@
     <h2 style="font-size:24px;font-weight:700;">页面建设中…</h2>
   </main>
 </div>
+<script src="assets/site-nav.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- build ozon product analysis page with KPI cards, product selection, and trend charts
- add API endpoint to fetch daily product metrics for charting

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a1a5423fb0832591182bb2a91348f1