### PR TITLE
feat: limit upload file size and show progress

### DIFF
--- a/api/independent/ingest/index.js
+++ b/api/independent/ingest/index.js
@@ -3,7 +3,7 @@
 // Env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (recommended) or SUPABASE_ANON_KEY (insert allowed by RLS)
 const { createClient } = require('@supabase/supabase-js');
 // formidable handles multipart/form-data parsing
-const formidable = require('formidable');
+const { formidable } = require('formidable');
 const fs = require('fs');
 const XLSX = require('xlsx');
 

--- a/api/independent/ingest/index.js
+++ b/api/independent/ingest/index.js
@@ -2,7 +2,8 @@
 // Upload Google Ads Landing Pages export (xlsx or csv) and upsert into Supabase
 // Env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (recommended) or SUPABASE_ANON_KEY (insert allowed by RLS)
 const { createClient } = require('@supabase/supabase-js');
-const formidable = require('formidable').default;
+// formidable handles multipart/form-data parsing
+const formidable = require('formidable');
 const fs = require('fs');
 const XLSX = require('xlsx');
 
@@ -181,7 +182,8 @@ async function handler(req, res) {
     return;
   }
 
-  const form = formidable({ multiples: false, keepExtensions: true });
+  // limit file size on the server as a safeguard (5MB)
+  const form = formidable({ multiples: false, keepExtensions: true, maxFileSize: 5 * 1024 * 1024 });
   try {
     const { files } = await new Promise((resolve, reject) => {
       form.parse(req, (err, fields, files) => {
@@ -202,9 +204,10 @@ async function handler(req, res) {
   }
 }
 
-handler.config = {
+module.exports = handler;
+// Disable Next.js default body parsing so formidable can handle the stream
+module.exports.config = {
   api: {
-    bodyParser: false, // we'll parse multipart manually
+    bodyParser: false,
   },
 };
-module.exports = handler;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.45.4",
     "xlsx": "^0.18.5",
-    "multiparty": "^4.2.3",
     "formidable": "^3.5.1",
     "node-fetch": "^2.6.7",
     "cheerio": "^1.0.0-rc.12"

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -472,8 +472,10 @@
       statusEl.textContent = `导入中: ${file.name}`;
       uploadBtn.disabled = true;
       const resp = await fetch('/api/independent/ingest', { method: 'POST', body: fd });
-      const json = await resp.json().catch(() => ({ ok:false, error:`HTTP ${resp.status}` }));
-      if (!resp.ok || !json.ok) throw new Error(json.error || '上传失败');
+      const text = await resp.text();
+      let json;
+      try { json = JSON.parse(text); } catch {}
+      if (!resp.ok || !json?.ok) throw new Error(json?.error || text || `HTTP ${resp.status}`);
       statusEl.textContent = '导入完成，加载中...';
       await load();
       statusEl.textContent = '完成';

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -458,10 +458,18 @@
   uploadBtn.addEventListener('click', () => fileInput.click());
   fileInput.addEventListener('change', async () => {
     if (!fileInput.files.length) return;
+    const file = fileInput.files[0];
+    // 预先检查文件大小，避免超过服务端限制
+    const MAX_SIZE_MB = 5;
+    if (file.size > MAX_SIZE_MB * 1024 * 1024) {
+      alert(`文件大于 ${MAX_SIZE_MB}MB，请分割后再上传`);
+      fileInput.value = '';
+      return;
+    }
     const fd = new FormData();
-    fd.append('file', fileInput.files[0]);
+    fd.append('file', file);
     try {
-      statusEl.textContent = '导入中...';
+      statusEl.textContent = `导入中: ${file.name}`;
       uploadBtn.disabled = true;
       const resp = await fetch('/api/independent/ingest', { method: 'POST', body: fd });
       const json = await resp.json().catch(() => ({ ok:false, error:`HTTP ${resp.status}` }));


### PR DESCRIPTION
## Summary
- validate upload file size before submission and show file name during import on independent site page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a2aaac4ac88325a1d0b0f3105e272e