### PR TITLE
Align AE query and self operated API table name

### DIFF
--- a/api/ae_query/index.js
+++ b/api/ae_query/index.js
@@ -16,7 +16,9 @@ export default async function handler(req, res) {
 
   const SUPABASE_URL = process.env.SUPABASE_URL;
   const SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  const TABLE = process.env.AE_TABLE_NAME || 'ae_self_operated_daily';
+  // Allow overriding the analytics table via AE_TABLE_NAME env var
+  // Default to the same table used by self_operated_api.js
+  const TABLE = process.env.AE_TABLE_NAME || 'self_operated_data';
   if (!SUPABASE_URL || !SERVICE_ROLE) {
     return res.status(500).json({ error: 'Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables.' });
   }

--- a/api/self_operated_api.js
+++ b/api/self_operated_api.js
@@ -7,6 +7,9 @@ const supabase = createClient(
   process.env.SUPABASE_KEY
 );
 
+// Use same table name as analytics query; allow override via AE_TABLE_NAME
+const TABLE = process.env.AE_TABLE_NAME || 'self_operated_data';
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).send('Only POST method allowed');
@@ -20,7 +23,7 @@ export default async function handler(req, res) {
     const { product_id, stat_date } = record;
 
     const { data: exists, error: queryErr } = await supabase
-      .from('self_operated_data')
+      .from(TABLE)
       .select('id')
       .eq('product_id', product_id)
       .eq('stat_date', stat_date)
@@ -32,7 +35,7 @@ export default async function handler(req, res) {
     }
 
     const { error: insertErr } = await supabase
-      .from('self_operated_data')
+      .from(TABLE)
       .insert(record);
 
     if (insertErr) {
@@ -44,7 +47,7 @@ export default async function handler(req, res) {
 
   // ✅ 新增：上传完成后直接返回当前数据库的所有记录
   const { data: allData, error: fetchErr } = await supabase
-    .from('self_operated_data')
+    .from(TABLE)
     .select('*')
     .order('stat_date', { ascending: false })
     .order('product_id');


### PR DESCRIPTION
## Summary
- Default AE analytics query to `self_operated_data` and allow overriding via `AE_TABLE_NAME`
- Apply the same configurable table name in `self_operated_api`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a312c20ab08325bec7eab14566f22e