### PR TITLE
Normalize percentage fields during independent ingest

### DIFF
--- a/api/independent/ingest/index.js
+++ b/api/independent/ingest/index.js
@@ -175,6 +175,13 @@ async function handleFile(filePath, filename) {
 }
 
 async function handler(req, res) {
+  console.log('[independent ingest] request start', {
+    method: req.method,
+    url: req.url,
+    urlLength: (req.url || '').length,
+    contentType: req.headers['content-type'],
+    contentLength: req.headers['content-length'],
+  });
   if (req.method === 'GET') {
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     res.status(200).end(`<!doctype html><html><body>
@@ -202,12 +209,19 @@ async function handler(req, res) {
     if (!uploaded) throw new Error('No file uploaded. Use form-data field name "file".');
     const filePath = uploaded.filepath || uploaded.path;
     if (!filePath) throw new Error('Upload failed: file path missing.');
+    console.log('[independent ingest] uploaded file', {
+      name: uploaded.originalFilename || uploaded.newFilename || uploaded.name,
+      type: uploaded.mimetype,
+      size: uploaded.size,
+    });
     const result = await handleFile(
       filePath,
       uploaded.originalFilename || uploaded.newFilename || uploaded.name
     );
+    console.log('[independent ingest] handleFile result', result);
     res.status(200).json({ ok: true, ...result });
   } catch (e) {
+    console.error('[independent ingest] handler error', e);
     res.status(500).json({ ok: false, error: e.message });
   }
 }

--- a/api/independent/ingest/index.js
+++ b/api/independent/ingest/index.js
@@ -31,6 +31,16 @@ function coerceNum(x) {
   return Number.isFinite(n) ? n : 0;
 }
 
+function coerceRate(x) {
+  if (x === null || x === undefined || x === '' || x === '--') return 0;
+  const s = String(x).trim();
+  const hasPct = s.includes('%');
+  const n = Number(s.replace(/[^0-9.-]/g, ''));
+  if (!Number.isFinite(n)) return 0;
+  if (hasPct) return n / 100;
+  return n > 1 ? n / 100 : n;
+}
+
 async function handleFile(filePath, filename) {
   const ext = (filename || '').toLowerCase();
   let rows = [];
@@ -103,15 +113,15 @@ async function handleFile(filePath, filename) {
       device: String(r[cDevice] || '').trim(),
       clicks: coerceNum(r[cClicks]),
       impr: coerceNum(r[cImpr]),
-      ctr: coerceNum(r[cCTR]),
+      ctr: coerceRate(r[cCTR]),
       avg_cpc: coerceNum(r[cAvgCPC]),
       cost: coerceNum(r[cCost]),
       conversions: coerceNum(r[cConv]),
       cost_per_conv: coerceNum(r[cCostPerConv]),
       all_conv: coerceNum(r[cAllConv]),
       conv_value: coerceNum(r[cConvValue]),
-      all_conv_rate: coerceNum(r[cAllConvRate]),
-      conv_rate: coerceNum(r[cConvRate])
+      all_conv_rate: coerceRate(r[cAllConvRate]),
+      conv_rate: coerceRate(r[cConvRate])
     });
   }
 

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -458,19 +458,33 @@
   uploadBtn.addEventListener('click', () => fileInput.click());
   fileInput.addEventListener('change', async () => {
     if (!fileInput.files.length) return;
+    const file = fileInput.files[0];
     const fd = new FormData();
-    fd.append('file', fileInput.files[0]);
+    fd.append('file', file);
     try {
       statusEl.textContent = '导入中...';
       uploadBtn.disabled = true;
+      console.log('[independent-site] upload start', {
+        name: file.name,
+        size: file.size,
+        type: file.type
+      });
       const resp = await fetch('/api/independent/ingest', { method: 'POST', body: fd });
-      const json = await resp.json().catch(() => ({ ok:false, error:`HTTP ${resp.status}` }));
-      if (!resp.ok || !json.ok) throw new Error(json.error || '上传失败');
+      let json;
+      try {
+        json = await resp.json();
+      } catch(err) {
+        console.warn('[independent-site] response not JSON', err);
+        json = { ok: false, error: `HTTP ${resp.status}` };
+      }
+      console.log('[independent-site] upload response', { status: resp.status, body: json });
+      if (!resp.ok || !json.ok) throw new Error(json.error || `上传失败(${resp.status})`);
       statusEl.textContent = '导入完成，加载中...';
       await load();
       statusEl.textContent = '完成';
       alert(`上传成功，记录数: ${json.inserted}`);
     } catch(e) {
+      console.error('[independent-site] upload failed', e);
       statusEl.textContent = `上传失败: ${e.message}`;
       alert(`上传失败: ${e.message}`);
     } finally {


### PR DESCRIPTION
## Summary
- parse percentage metrics in independent ingest as decimals via new `coerceRate`

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check api/independent/ingest/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68a31f9163648325b8cb53c361ec24ce