### PR TITLE
Add currency code to independent landing metrics ingestion

### DIFF
--- a/api/independent/ingest/index.js
+++ b/api/independent/ingest/index.js
@@ -82,6 +82,7 @@ async function handleFile(filePath, filename) {
   const cConvValue = col('conv. value', 'conv value', 'purchase value');
   const cAllConvRate = col('all conv. rate', 'all conv rate', 'total conv rate');
   const cConvRate = col('conv. rate', 'conv rate', 'conversion rate');
+  const cCurrencyCode = col('currency code');
 
   const payload = [];
   for (const r of dataRows) {
@@ -111,7 +112,8 @@ async function handleFile(filePath, filename) {
       all_conv: coerceNum(r[cAllConv]),
       conv_value: coerceNum(r[cConvValue]),
       all_conv_rate: coerceNum(r[cAllConvRate]),
-      conv_rate: coerceNum(r[cConvRate])
+      conv_rate: coerceNum(r[cConvRate]),
+      currency_code: String(r[cCurrencyCode] || '').trim()
     });
   }
 

--- a/migrations/20240819_add_currency_code_to_independent_landing_metrics.sql
+++ b/migrations/20240819_add_currency_code_to_independent_landing_metrics.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.independent_landing_metrics
+  ADD COLUMN currency_code text NULL;


### PR DESCRIPTION
## Summary
- add migration to include `currency_code` column on `independent_landing_metrics`
- detect "Currency code" in uploads and send along `currency_code`

## Testing
- `npm test` *(fails: Missing script "test")*
- `psql -f migrations/20240819_add_currency_code_to_independent_landing_metrics.sql` *(fails: command not found)*
- `node` script simulating upload shows `currency_code` present in payload

------
https://chatgpt.com/codex/tasks/task_e_68a32fcbbda48325a9d0aff4c047d9ee