### PR TITLE
feat(ingest): support avg cost per conversion

### DIFF
--- a/api/independent/ingest/index.js
+++ b/api/independent/ingest/index.js
@@ -77,7 +77,7 @@ async function handleFile(filePath, filename) {
   const cAvgCPC = col('avg. cpc', 'cpc', 'cost per click');
   const cCost = col('cost', 'amount spent');
   const cConv = col('conversions', 'results', 'purchases');
-  const cCostPerConv = col('cost / conv.', 'cost/conv.', 'cost/conv', 'cost per result');
+  const cCostPerConv = col('cost / conv.', 'cost/conv.', 'cost/conv', 'cost per result', 'avg. cost');
   const cAllConv = col('all conv.', 'all conv', 'total conv');
   const cConvValue = col('conv. value', 'conv value', 'purchase value');
   const cAllConvRate = col('all conv. rate', 'all conv rate', 'total conv rate');


### PR DESCRIPTION
## Summary
- expand cost-per-conversion header lookup to recognise "Avg. cost"

## Testing
- `npm test` *(fails: Missing script: "test")*
- Parsed sample CSV with stubbed Supabase client to confirm `cost_per_conv` is populated from the "Avg. cost" column


------
https://chatgpt.com/codex/tasks/task_e_68a330a3461c83258118217afedb9f7c