### PR TITLE
Support currency codes for independent landing metrics

### DIFF
--- a/api/independent/ingest/index.js
+++ b/api/independent/ingest/index.js
@@ -232,6 +232,7 @@ async function handleFile(filePath, filename) {
   return {
     processed: payload.length,
     upserted: data?.length ?? deduped.length,
+    count: payload.length,
   };
 }
 

--- a/api/independent/ingest/index.js
+++ b/api/independent/ingest/index.js
@@ -77,11 +77,12 @@ async function handleFile(filePath, filename) {
   const cAvgCPC = col('avg. cpc', 'cpc', 'cost per click');
   const cCost = col('cost', 'amount spent');
   const cConv = col('conversions', 'results', 'purchases');
-  const cCostPerConv = col('cost / conv.', 'cost/conv.', 'cost/conv', 'cost per result');
+  const cCostPerConv = col('cost / conv.', 'cost/conv.', 'cost/conv', 'cost per result', 'avg. cost');
   const cAllConv = col('all conv.', 'all conv', 'total conv');
   const cConvValue = col('conv. value', 'conv value', 'purchase value');
   const cAllConvRate = col('all conv. rate', 'all conv rate', 'total conv rate');
   const cConvRate = col('conv. rate', 'conv rate', 'conversion rate');
+  const cCurrency = col('currency code', 'currency');
 
   const payload = [];
   for (const r of dataRows) {
@@ -101,17 +102,18 @@ async function handleFile(filePath, filename) {
       day: day.toISOString().slice(0,10),
       network: String(r[cNetwork] || '').trim(),
       device: String(r[cDevice] || '').trim(),
+      currency_code: cCurrency >= 0 ? String(r[cCurrency] || '').trim() : null,
       clicks: coerceNum(r[cClicks]),
       impr: coerceNum(r[cImpr]),
       ctr: coerceNum(r[cCTR]),
       avg_cpc: coerceNum(r[cAvgCPC]),
       cost: coerceNum(r[cCost]),
       conversions: coerceNum(r[cConv]),
-      cost_per_conv: coerceNum(r[cCostPerConv]),
-      all_conv: coerceNum(r[cAllConv]),
-      conv_value: coerceNum(r[cConvValue]),
-      all_conv_rate: coerceNum(r[cAllConvRate]),
-      conv_rate: coerceNum(r[cConvRate])
+      cost_per_conv: cCostPerConv >= 0 ? coerceNum(r[cCostPerConv]) : null,
+      all_conv: cAllConv >= 0 ? coerceNum(r[cAllConv]) : null,
+      conv_value: cConvValue >= 0 ? coerceNum(r[cConvValue]) : null,
+      all_conv_rate: cAllConvRate >= 0 ? coerceNum(r[cAllConvRate]) : null,
+      conv_rate: cConvRate >= 0 ? coerceNum(r[cConvRate]) : null
     });
   }
 

--- a/independent.sql
+++ b/independent.sql
@@ -1,0 +1,15 @@
+-- Add currency_code column and refresh schema cache for independent landing metrics
+alter table if exists public.independent_landing_metrics
+  add column if not exists currency_code text;
+
+create or replace function public.refresh_independent_schema_cache()
+returns void
+language plpgsql
+security definer
+as $$
+begin
+  perform pg_notify('pgrst', 'reload schema');
+end;
+$$;
+
+select public.refresh_independent_schema_cache();


### PR DESCRIPTION
## Summary
- parse optional Currency code column when ingesting landing metrics
- map "Avg. cost" to cost_per_conv and allow missing conversion metrics

## Testing
- `node --check api/independent/ingest/index.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a332e2b95483259cd2aabf2fc07ef7