### PR TITLE
Handle non-JSON responses in independent stats fetch

### DIFF
--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -328,14 +328,18 @@ function card(title,cur,prev,isPct,avg,share){
       if(mode==='indep'){
         const url=`/api/independent/stats?site=${encodeURIComponent(siteParam)}&from=${start}&to=${end}`;
         const resp=await fetch(url);
-        const txt=await resp.text(); let j; try{ j=JSON.parse(txt);} catch(e){ throw new Error('Query API响应不是JSON：'+txt.slice(0,200)); }
-        if(!resp.ok || (j.ok!==undefined && !j.ok)) throw new Error(j.error||'查询失败');
+        const txt=await resp.text();
+        if(!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        let j; try{ j=JSON.parse(txt);} catch(e){ throw new Error('Query API响应不是JSON'); }
+        if(j.ok!==undefined && !j.ok) throw new Error(j.error||'查询失败');
         return j.table||j.rows||[];
       }
       const url=`/api/ae_query?start=${start}&end=${end}&granularity=${gran}`;
       const resp=await fetch(url);
-      const txt=await resp.text(); let j; try{ j=JSON.parse(txt);} catch(e){ throw new Error('Query API响应不是JSON：'+txt.slice(0,200)); }
-      if(!resp.ok || (j.ok!==undefined && !j.ok)) throw new Error(j.error||'查询失败');
+      const txt=await resp.text();
+      if(!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      let j; try{ j=JSON.parse(txt);} catch(e){ throw new Error('Query API响应不是JSON'); }
+      if(j.ok!==undefined && !j.ok) throw new Error(j.error||'查询失败');
       return j.rows||[];
     }
     function periodShift(startISO,endISO){


### PR DESCRIPTION
## Summary
- Improve product analysis page to stop parsing non-JSON responses for independent site stats
- Report HTTP status errors instead of dumping HTML when the API call fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a43738d34c832596fa58000d3660ce