### PR TITLE
Use progress-bar loading overlay for independent site data fetch

### DIFF
--- a/public/assets/site-nav.js
+++ b/public/assets/site-nav.js
@@ -11,7 +11,9 @@
       try{
         const resp=await fetch('/api/independent/sites');
         const j=await resp.json();
-        const sites=Array.from(new Set((j.sites||[]).filter(Boolean)));
+        const sites=Array.from(new Set((j.sites||[])\
+          .map(s=> (s||'').replace(/\/$/, ''))\
+          .filter(Boolean)));
         sites.forEach(name=>{
           const li=document.createElement('li');
           const a=document.createElement('a');

--- a/public/assets/site-nav.js
+++ b/public/assets/site-nav.js
@@ -33,5 +33,9 @@
     }
   }
   window.renderSiteMenus=render;
-  document.addEventListener('DOMContentLoaded',render);
+  if(document.readyState!=='loading'){
+    render();
+  }else{
+    document.addEventListener('DOMContentLoaded',render);
+  }
 })();

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -488,6 +488,7 @@
 <script src="assets/site-nav.js"></script>
 
 <script>
+renderSiteMenus();
 (async function(){
   const siteSelect=document.getElementById("site");
   const currentEl=document.getElementById("currentSite");

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -21,6 +21,7 @@
   <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
   <script src="https://cdn.jsdelivr.net/npm/echarts/dist/echarts.min.js"></script>
   <script src="assets/product-meta.js"></script>
+  <script src="assets/loading.js"></script>
 </head>
 <body class="fm">
 
@@ -49,7 +50,7 @@
         <div class="demo-account-info">邮箱：demo@example.com<br>密码：demo123</div>
       </div>
     </div>
-  </div>
+</div>
 </div>
 
 <header class="header">
@@ -350,6 +351,7 @@
 
   async function load() {
     loadStatusEl.textContent = '加载中...';
+    showLoading();
     try {
       const site = siteInput.value.trim();
       let from, to;
@@ -445,8 +447,9 @@
       loadStatusEl.textContent = '加载完成';
     } catch(e) {
       console.error(e);
-      loadStatusEl.textContent = '加载失败';
-      alert(e.message || '加载失败');
+      loadStatusEl.textContent = `加载失败: ${e.message || ''}`;
+    } finally {
+      hideLoading();
     }
   }
 
@@ -491,9 +494,11 @@
   try{
     const resp=await fetch("/api/independent/sites");
     const j=await resp.json();
-    const sites=Array.from(new Set((j.sites||[]).filter(Boolean)));
+    const sites=Array.from(new Set((j.sites||[])\
+      .map(s=> (s||'').replace(/\/$/, ''))\
+      .filter(Boolean)));
     siteSelect.innerHTML=sites.map(s=>`<option value="${s}">${s}</option>`).join("");
-    let cur=localStorage.getItem("currentIndepSite");
+    let cur=(localStorage.getItem("currentIndepSite")||'').replace(/\/$/, '');
     if(!cur||!sites.includes(cur)) cur=sites[0]||"";
     if(cur){
       siteSelect.value=cur;

--- a/public/index.html
+++ b/public/index.html
@@ -126,17 +126,17 @@
             <thead>
               <tr>
                 <th>商品ID</th>
+                <th>访客比(%)</th>
+                <th>访客到加购转化率(%)</th>
+                <th>加购到支付转化率(%)</th>
                 <th>搜索曝光量</th>
-                <th>商品访客数</th>
                 <th>商品浏览量</th>
+                <th>商品访客数</th>
                 <th>加购人数</th>
                 <th>加购件数</th>
                 <th>支付件数</th>
                 <th>支付订单数</th>
                 <th>支付买家数</th>
-                <th>访客到加购转化率(%)</th>
-                <th>加购到支付转化率(%)</th>
-                <th>访客比(%)</th>
                 <th>产品详情</th>
               </tr>
             </thead>
@@ -251,12 +251,17 @@
   function mapRow(x){
     return [
       '<a data-pid="'+(x.product_id||'')+'" data-link="'+(x.product_link || ('https://aliexpress.com/item/'+x.product_id+'.html'))+'" href="'+(x.product_link || ('https://aliexpress.com/item/'+x.product_id+'.html'))+'" target="_blank">'+(x.product_id||'')+'</a>',
-      x.search_exposure || 0, x.uv || 0, x.pv || 0,
-      x.add_to_cart_users || 0, x.add_to_cart_qty || 0,
-      x.pay_items || 0, x.pay_orders || 0, x.pay_buyers || 0,
+      (x.search_exposure ? ((x.uv||0)/x.search_exposure*100).toFixed(2) : '0.00'),
       (x.uv ? ((x.add_to_cart_users||0)/x.uv*100).toFixed(2) : '0.00'),
       (x.add_to_cart_users ? ((x.pay_buyers||0)/x.add_to_cart_users*100).toFixed(2) : '0.00'),
-      (x.search_exposure ? ((x.uv||0)/x.search_exposure*100).toFixed(2) : '0.00'),
+      x.search_exposure || 0,
+      x.pv || 0,
+      x.uv || 0,
+      x.add_to_cart_users || 0,
+      x.add_to_cart_qty || 0,
+      x.pay_items || 0,
+      x.pay_orders || 0,
+      x.pay_buyers || 0,
       '<a href="product-analysis.html?mode=fm&pid='+ (x.product_id||'') +'" target="_blank">详情</a>'
     ];
   }
@@ -292,33 +297,25 @@
       window._periodB = prev || '';
 
       if (state.table) { state.table.destroy(); }
+      const data = window._rowsA.map(mapRow);
       state.table = $('#report').DataTable({
-        serverSide:true,
+        data,
         processing:true,
         deferRender:true,
         paging:true,
         searching:true,
         info:true,
-        order:[[2,'desc']],
+        order:[[6,'desc']],
         fixedHeader:true,
         scrollY:'60vh',
         scrollCollapse:true,
         autoWidth:false,
-        ajax:function(data, callback){
-          const qs = new URLSearchParams({ granularity: state.granularity });
-          if(period) qs.set('period_end', period);
-          qs.set('limit', data.length);
-          qs.set('offset', data.start);
-          fetch('/api/stats?'+qs.toString()).then(r=>r.json()).then(j=>{
-            const rows = (j.rows||[]).map(mapRow);
-            callback({ data: rows, recordsTotal:j.total||rows.length, recordsFiltered:j.total||rows.length });
-          });
-        },
+        columnDefs:[{ targets:-1, orderable:false }],
         drawCallback:function(){
           populateProductNames(document.getElementById('report'));
         }
       });
-      $('#report tbody').on('dblclick','td',function(){
+      $('#report tbody').off('dblclick').on('dblclick','td',function(){
         const col = state.table.cell(this).index().column;
         const last = state.table.columns().count()-1;
         if(col===0 || col===last) return;

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -51,7 +51,7 @@
           <div id="expLine" style="width:100%;height:260px;"></div>
           <h3 style="margin-top:24px;">访客比趋势</h3>
           <div id="uvRateLine" style="width:100%;height:260px;"></div>
-          <h3 style="margin-top:24px;">加购比趋势</h3>
+          <h3 id="rate3Title" style="margin-top:24px;">加购比趋势</h3>
           <div id="addRateLine" style="width:100%;height:260px;"></div>
         </div>
       </section>
@@ -288,6 +288,8 @@ function card(title,cur,prev,isPct,avg,share){
 
   function setupSelf(mode, siteParam){
     document.getElementById('lineWrap').style.display='block';
+    const rateTitle=document.getElementById('rate3Title');
+    if(rateTitle) rateTitle.textContent = mode==='indep' ? '转化比趋势' : '加购比趋势';
     const ctrl=document.getElementById('ctrl');
     ctrl.innerHTML='<input id="dateRange" class="date-filter" placeholder="选择日期范围">';
     const input=document.getElementById('dateRange');
@@ -396,26 +398,30 @@ function card(title,cur,prev,isPct,avg,share){
       function line(pid){
         const mapExpA=new Map(), mapExpB=new Map();
         const mapUvRateA=new Map(), mapUvRateB=new Map();
-        const mapAddRateA=new Map(), mapAddRateB=new Map();
+        const mapRate3A=new Map(), mapRate3B=new Map();
         rowsDayA.filter(r=>String(getId(r))===String(pid)).forEach(r=>{
           const d=mode==='indep'?r.day:r.bucket;
           const exp=getExp(r);
           const uv=Number(mode==='indep'?r.clicks||0:r.visitors||0);
-          const add=Number(mode==='indep'?0:r.add_people||0);
+          const add=Number(r.add_people||0);
+          const pay=Number(mode==='indep'?r.conversions||0:r.pay_buyers||0);
           mapExpA.set(d,exp);
           mapUvRateA.set(d,exp?uv/exp:0);
-          mapAddRateA.set(d,uv?add/uv:0);
+          const rate=mode==='indep'?(uv?pay/uv:0):(uv?add/uv:0);
+          mapRate3A.set(d,rate);
         });
         rowsDayB.filter(r=>String(getId(r))===String(pid)).forEach(r=>{
           const d=mode==='indep'?r.day:r.bucket;
           const exp=getExp(r);
           const uv=Number(mode==='indep'?r.clicks||0:r.visitors||0);
-          const add=Number(mode==='indep'?0:r.add_people||0);
+          const add=Number(r.add_people||0);
+          const pay=Number(mode==='indep'?r.conversions||0:r.pay_buyers||0);
           mapExpB.set(d,exp);
           mapUvRateB.set(d,exp?uv/exp:0);
-          mapAddRateB.set(d,uv?add/uv:0);
+          const rate=mode==='indep'?(uv?pay/uv:0):(uv?add/uv:0);
+          mapRate3B.set(d,rate);
         });
-        const labels=[], expA=[], expB=[], uvA=[], uvB=[], addA=[], addB=[];
+        const labels=[], expA=[], expB=[], uvA=[], uvB=[], rate3A=[], rate3B=[];
         for(let i=0;i<days;i++){
           const da=new Date(startA+'T00:00:00'); da.setDate(da.getDate()+i); const isoA=da.toISOString().slice(0,10);
           const db=new Date(startB+'T00:00:00'); db.setDate(db.getDate()+i); const isoB=db.toISOString().slice(0,10);
@@ -424,16 +430,16 @@ function card(title,cur,prev,isPct,avg,share){
           expB.push(mapExpB.get(isoB)||0);
           uvA.push((mapUvRateA.get(isoA)||0)*100);
           uvB.push((mapUvRateB.get(isoB)||0)*100);
-          addA.push((mapAddRateA.get(isoA)||0)*100);
-          addB.push((mapAddRateB.get(isoB)||0)*100);
+          rate3A.push((mapRate3A.get(isoA)||0)*100);
+          rate3B.push((mapRate3B.get(isoB)||0)*100);
         }
         const expChart=echarts.init(document.getElementById('expLine'));
         expChart.setOption({tooltip:{trigger:'axis'},legend:{data:['本周期','上一周期']},xAxis:{type:'category',data:labels},yAxis:{type:'value'},series:[{name:'本周期',type:'line',smooth:true,data:expA},{name:'上一周期',type:'line',smooth:true,data:expB}]});
         const uvChart=echarts.init(document.getElementById('uvRateLine'));
         uvChart.setOption({tooltip:{trigger:'axis',valueFormatter:v=>v+'%'},legend:{data:['本周期','上一周期']},xAxis:{type:'category',data:labels},yAxis:{type:'value',axisLabel:{formatter:'{value}%'}},series:[{name:'本周期',type:'line',smooth:true,data:uvA},{name:'上一周期',type:'line',smooth:true,data:uvB}]});
-        const addChart=echarts.init(document.getElementById('addRateLine'));
-        addChart.setOption({tooltip:{trigger:'axis',valueFormatter:v=>v+'%'},legend:{data:['本周期','上一周期']},xAxis:{type:'category',data:labels},yAxis:{type:'value',axisLabel:{formatter:'{value}%'}},series:[{name:'本周期',type:'line',smooth:true,data:addA},{name:'上一周期',type:'line',smooth:true,data:addB}]});
-        window.addEventListener('resize',()=>{expChart.resize();uvChart.resize();addChart.resize();});
+        const rate3Chart=echarts.init(document.getElementById('addRateLine'));
+        rate3Chart.setOption({tooltip:{trigger:'axis',valueFormatter:v=>v+'%'},legend:{data:['本周期','上一周期']},xAxis:{type:'category',data:labels},yAxis:{type:'value',axisLabel:{formatter:'{value}%'}},series:[{name:'本周期',type:'line',smooth:true,data:rate3A},{name:'上一周期',type:'line',smooth:true,data:rate3B}]});
+        window.addEventListener('resize',()=>{expChart.resize();uvChart.resize();rate3Chart.resize();});
       }
       function update(pid){
         const cur=sum(rowsAggA,pid); const prev=sum(rowsAggB,pid);
@@ -450,15 +456,20 @@ function card(title,cur,prev,isPct,avg,share){
         const shareUv=totalsA.uv?cur.uv/totalsA.uv:0;
         const shareAdd=totalsA.add?cur.add/totalsA.add:0;
         const sharePay=totalsA.pay?cur.pay/totalsA.pay:0;
-        document.getElementById('kpi').innerHTML=[
-          card('平均访客比',curUvRate,prevUvRate,true,avgUvRate),
-          card('平均加购比',curAddRate,prevAddRate,true,avgAddRate),
-          card('平均支付比',curPayRate,prevPayRate,true,avgPayRate),
-          card('总曝光量',cur.exp,prev.exp,false,null,shareExp),
-          card('总访客数',cur.uv,prev.uv,false,null,shareUv),
-          card('总加购人数',cur.add,prev.add,false,null,shareAdd),
-          card('总支付买家数',cur.pay,prev.pay,false,null,sharePay)
-        ].join('');
+        const cards=[
+          card('平均访客比',curUvRate,prevUvRate,true,avgUvRate)
+        ];
+        if(mode==='indep'){
+          cards.push(card('平均转化比',curPayRate,prevPayRate,true,avgPayRate));
+        }else{
+          cards.push(card('平均加购比',curAddRate,prevAddRate,true,avgAddRate));
+          cards.push(card('平均支付比',curPayRate,prevPayRate,true,avgPayRate));
+        }
+        cards.push(card('总曝光量',cur.exp,prev.exp,false,null,shareExp));
+        cards.push(card('总访客数',cur.uv,prev.uv,false,null,shareUv));
+        if(mode!=='indep') cards.push(card('总加购人数',cur.add,prev.add,false,null,shareAdd));
+        cards.push(card(mode==='indep'?'总转化数':'总支付买家数',cur.pay,prev.pay,false,null,sharePay));
+        document.getElementById('kpi').innerHTML=cards.join('');
         line(pid);
         const dates=[...rowsDayA,...rowsDayB].filter(r=>String(getId(r))===String(pid)).map(r=>mode==='indep'?r.day:r.bucket).sort();
         document.getElementById('listingDate').textContent=dates.length?`上架日期：${dates[0]}`:'';


### PR DESCRIPTION
## Summary
- integrate shared `loading.js` progress overlay on independent site page
- show progress bar during `load()` and hide on completion or error
- reorder columns in full-managed detail table to highlight visitor & conversion metrics
- switch full-managed detail table to client-side DataTable to allow on-page sorting
- normalize independent site names to prevent duplicate entries
- chart independent product trends with impressions, CTR and conversion-rate comparisons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a440be3e288325be719c47fc55ba36