### PR TITLE
Adjust independent stats date range to available data

### DIFF
--- a/api/independent/stats/index.js
+++ b/api/independent/stats/index.js
@@ -241,6 +241,16 @@ module.exports = async (req, res) => {
       new_clicks: newClicks,
       new_conversions: newConv
     };
+    // adjust date range to match available data
+    const days = Array.from(new Set([
+      ...table.map(r => r.day),
+      ...series.map(r => r.day)
+    ]));
+    if (days.length) {
+      days.sort();
+      fromDate = days[0];
+      toDate = days[days.length - 1];
+    }
 
     res.status(200).json({ ok: true, from: fromDate, to: toDate, table, series, topList, kpis });
   } catch (e) {


### PR DESCRIPTION
## Summary
- clip independent stats `from`/`to` dates to the actual available days so reports reflect only existing data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a543c2aeb0832589ce2d8cf15ec039