### PR TITLE
Schedule Ozon analytics fetch for GMT+8 mornings

### DIFF
--- a/api/ozon/fetch/index.js
+++ b/api/ozon/fetch/index.js
@@ -31,8 +31,9 @@ module.exports = async function handler(req, res) {
     const RAW_TABLE = OZON_TABLE_NAME || 'ozon_product_report_wide';
     const TABLE = normalizeTableName(RAW_TABLE);
 
-    // 计算昨天日期（UTC）
+    // 计算昨天日期（GMT+8）
     const d = new Date();
+    d.setUTCHours(d.getUTCHours() + 8); // 转为 GMT+8
     d.setUTCDate(d.getUTCDate() - 1);
     const date = d.toISOString().slice(0, 10);
 

--- a/vercel.json
+++ b/vercel.json
@@ -9,5 +9,5 @@
     { "src": "^/$", "dest": "/public/index.html" },
     { "src": "^(?!/api/)(.*)$", "dest": "/public/$1" }
   ],
-  "crons": [{ "path": "/api/ozon/fetch", "schedule": "0 3 * * *" }]
+  "crons": [{ "path": "/api/ozon/fetch", "schedule": "0 22 * * *" }]
 }


### PR DESCRIPTION
## Summary
- schedule daily Ozon analytics fetch at 22:00 UTC to match 06:00 GMT+8
- compute previous-day date using GMT+8 timezone before querying Ozon API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a741e6d91483258e8fb11ff04d0833