### PR TITLE
feat: add preview mode for ozon fetch API

### DIFF
--- a/api/ozon/fetch/index.js
+++ b/api/ozon/fetch/index.js
@@ -102,6 +102,10 @@ module.exports = async function handler(req, res) {
       return res.status(200).json({ ok: true, count: 0, table: TABLE });
     }
 
+    if (req.query && req.query.preview) {
+      return res.status(200).json({ ok: true, count: rows.length, table: TABLE, rows: rows.slice(0, 5) });
+    }
+
     const { error } = await supabase.schema('public').from(TABLE).upsert(rows, { onConflict: 'sku,model,den' });
     if (error) {
       throw new Error(error.message);


### PR DESCRIPTION
## Summary
- add preview option to `/api/ozon/fetch` to show first mapped rows without DB write

## Testing
- `npm test`
- `node - <<'NODE' ...` (preview mode invocation failed due to missing API/network)


------
https://chatgpt.com/codex/tasks/task_e_68a7488947fc8325a535a0c46f31a428