### PR TITLE
feat: add preview mode for ozon fetch

### DIFF
--- a/api/ozon/fetch/index.js
+++ b/api/ozon/fetch/index.js
@@ -109,7 +109,8 @@ module.exports = async function handler(req, res) {
       return row;
     }).filter(r => r.sku);
 
-    if (req.query?.preview) {
+    const preview = ['1', 'true', 'yes'].includes(String(req.query.preview).toLowerCase());
+    if (preview) {
       return res
         .status(200)
         .json({ ok: true, count: rows.length, table: TABLE, rows: rows.slice(0, 5) });

--- a/api/ozon/fetch/index.js
+++ b/api/ozon/fetch/index.js
@@ -109,6 +109,12 @@ module.exports = async function handler(req, res) {
       return row;
     }).filter(r => r.sku);
 
+    if (req.query?.preview) {
+      return res
+        .status(200)
+        .json({ ok: true, count: rows.length, table: TABLE, rows: rows.slice(0, 5) });
+    }
+
     if (rows.length === 0) {
       return res.status(200).json({ ok: true, count: 0, table: TABLE });
     }


### PR DESCRIPTION
## Summary
- allow previewing mapped rows in `/api/ozon/fetch` without writing to DB

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a74a162e3083258387b514a27db38a