### PR TITLE
feat: add Ozon data sync button with progress

### DIFF
--- a/api/ozon/fetch/index.js
+++ b/api/ozon/fetch/index.js
@@ -69,7 +69,8 @@ module.exports = async function handler(req, res) {
         date_from: dateStr,
         date_to: dateStr,
         dimension: ['sku', 'offer_id', 'title', 'brand', 'category_1', 'category_2', 'category_3'],
-        metrics: ['hits_view', 'hits_view_search', 'hits_view_pdp', 'hits_tocart_search', 'hits_tocart_pdp', 'ordered_units', 'delivered_units', 'revenue', 'cancelled_units', 'returned_units']
+        metrics: ['hits_view', 'hits_view_search', 'hits_view_pdp', 'hits_tocart_search', 'hits_tocart_pdp', 'ordered_units', 'delivered_units', 'revenue', 'cancelled_units', 'returned_units'],
+        limit: 1000
       };
 
       step = 'fetch';
@@ -83,11 +84,18 @@ module.exports = async function handler(req, res) {
         body: JSON.stringify(body)
       });
 
-      const json = await resp.json();
-      if (!resp.ok) {
-        throw new Error(json.message || resp.statusText);
+      const text = await resp.text();
+      let json;
+      try {
+        json = JSON.parse(text);
+      } catch (_) {
+        json = null;
       }
-      const data = json.result?.data || [];
+      if (!resp.ok) {
+        const msg = json?.error?.message || json?.message || text || resp.statusText;
+        throw new Error(msg);
+      }
+      const data = json?.result?.data || [];
       for (const item of data) {
         const row = { den: dateStr };
         for (const d of item.dimensions || []) {

--- a/api/ozon/sync.js
+++ b/api/ozon/sync.js
@@ -1,0 +1,152 @@
+const fetch = require('node-fetch');
+const { createClient } = require('@supabase/supabase-js');
+
+function supa() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
+  if (!url || !key) throw new Error('Missing Supabase env');
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+async function fetchFromOzon(days) {
+  const { OZON_CLIENT_ID, OZON_API_KEY } = process.env;
+  if (!OZON_CLIENT_ID || !OZON_API_KEY) throw new Error('Missing OZON_CLIENT_ID or OZON_API_KEY');
+
+  const dimMap = {
+    sku: 'product_id',
+    offer_id: 'model',
+    title: 'product_title',
+    brand: 'brand',
+    category_1: 'category_1',
+    category_2: 'category_2',
+    category_3: 'category_3'
+  };
+  const metricMap = {
+    hits_view: 'exposure',
+    hits_view_search: 'impressions_search',
+    hits_view_pdp: 'pageviews',
+    hits_tocart_search: 'add_to_cart_from_search',
+    hits_tocart_pdp: 'add_to_cart_from_pdp',
+    ordered_units: 'ordered_units',
+    delivered_units: 'delivered_units',
+    revenue: 'revenue',
+    cancelled_units: 'cancelled_units',
+    returned_units: 'returned_units'
+  };
+
+  const rows = [];
+  const now = new Date();
+  now.setUTCHours(now.getUTCHours() + 8);
+  now.setUTCDate(now.getUTCDate() - 1);
+
+  for (let i = 0; i < days; i++) {
+    const date = new Date(now);
+    date.setUTCDate(now.getUTCDate() - i);
+    const dateStr = date.toISOString().slice(0, 10);
+    const body = {
+      date_from: dateStr,
+      date_to: dateStr,
+      dimension: ['sku', 'offer_id', 'title', 'brand', 'category_1', 'category_2', 'category_3'],
+      metrics: ['hits_view', 'hits_view_search', 'hits_view_pdp', 'hits_tocart_search', 'hits_tocart_pdp', 'ordered_units', 'delivered_units', 'revenue', 'cancelled_units', 'returned_units']
+    };
+
+    const resp = await fetch('https://api-seller.ozon.ru/v1/analytics/data', {
+      method: 'POST',
+      headers: {
+        'Client-Id': OZON_CLIENT_ID,
+        'Api-Key': OZON_API_KEY,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(body)
+    });
+    const json = await resp.json();
+    if (!resp.ok) {
+      throw new Error(json.message || resp.statusText);
+    }
+    const data = json.result?.data || [];
+    for (const item of data) {
+      const row = { stat_date: dateStr };
+      for (const d of item.dimensions || []) {
+        const key = dimMap[d.id] || dimMap[d.name];
+        if (key) row[key] = d.value ?? d.name;
+      }
+      for (const m of item.metrics || []) {
+        const key = metricMap[m.id];
+        if (key) row[key] = Number(m.value);
+      }
+      if (row.product_id) rows.push(row);
+    }
+  }
+  return rows;
+}
+
+function pickCoreFields(row) {
+  return {
+    product_id: row.product_id,
+    stat_date: row.stat_date,
+    platform: row.platform,
+    site_id: row.site_id
+  };
+}
+
+module.exports = async function handler(req, res) {
+  const result = { ok: false, fetched: 0, upserting: 0, upserted: 0, skipped: 0, samples: [], message: '' };
+  if (req.method && req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    result.message = 'method not allowed';
+    return res.status(405).json(result);
+  }
+  try {
+    const days = Math.max(1, parseInt(req.query?.days, 10) || 1);
+    const siteId = req.query?.store_id || req.query?.site_id || 'demo';
+
+    const raw = await fetchFromOzon(days);
+    result.fetched = raw.length;
+
+    const normalized = raw.map(r => ({
+      ...r,
+      site_id: siteId,
+      source: 'ozon',
+      platform: 'ozon'
+    })).filter(r => {
+      const ok = r.product_id && r.stat_date;
+      if (!ok) result.skipped++;
+      return ok;
+    });
+
+    result.upserting = normalized.length;
+    result.samples = normalized.slice(0, 3).map(pickCoreFields);
+
+    if (normalized.length === 0) {
+      result.message = result.fetched === 0 ? 'Ozon 返回 0 条' : '主键缺失';
+      return res.status(400).json(result);
+    }
+
+    const supabase = supa();
+    const TABLE = 'ozon_daily';
+
+    const { error, count } = await supabase
+      .from(TABLE)
+      .upsert(normalized, { onConflict: 'site_id,source,product_id,stat_date', ignoreDuplicates: false })
+      .select('product_id', { count: 'exact', head: true });
+
+    if (error) {
+      const msg = error.message || '';
+      if (/permission denied|rls/i.test(msg)) result.message = 'RLS/权限问题';
+      else if (/column .* does not exist/i.test(msg)) result.message = '表结构不匹配';
+      else result.message = msg;
+      return res.status(500).json(result);
+    }
+
+    result.upserted = count || 0;
+    result.ok = true;
+    if (result.upserted === 0) {
+      result.message = '全为已存在数据（幂等）';
+    }
+    return res.status(200).json(result);
+  } catch (e) {
+    result.message = e?.message || '未知错误';
+    return res.status(500).json(result);
+  }
+};
+

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -267,7 +267,10 @@
       setStatus('加载中...');
       track('start');
       const resp = await fetch(`/api/ozon/sync?days=7&store_id=${encodeURIComponent(storeId)}`,{ method:'POST' });
-      const json = await resp.json();
+      const text = await resp.text();
+      let json;
+      try{ json = JSON.parse(text); }
+      catch{ throw new Error(text); }
 
       setStatus(`已读取到数据 ${json.fetched||0} 条`);
       track('data_fetched');

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -286,7 +286,7 @@
         track('done');
         await loadData();
       }else{
-        const msg = json.message || '未知错误';
+        const msg = (json.step? json.step+': ' : '') + (json.message || '未知错误');
         const samples = JSON.stringify(json.samples||[],null,2);
         alert(msg + (samples? '\n'+samples : ''));
         track('error');

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -269,16 +269,21 @@
       const resp = await fetch('/api/ozon/fetch?days=7');
       const json = await resp.json();
       if(!json.ok) throw new Error(json.msg||'同步失败');
-      setStatus('已读取到数据');
+
+      setStatus(`已读取到数据 ${json.count||0} 条`);
       track('data_fetched');
+      await new Promise(r=>setTimeout(r,500));
+
       setStatus('导入数据库中');
       track('importing');
+      await new Promise(r=>setTimeout(r,500));
+
       setStatus('导入完成');
       track('done');
       await loadData();
     }catch(err){
       console.error(err);
-      setStatus('同步失败');
+      setStatus('同步失败: '+(err.message||err));
       track('error');
     }
   });

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -60,6 +60,7 @@
           <input id="dateFilter" class="date-filter" placeholder="选择日期范围">
           <label for="file" id="pickLabel" class="upload-btn">选择文件</label>
           <input type="file" id="file" accept=".xlsx,.xls,.csv" />
+          <button id="syncBtn" class="upload-btn">同步</button>
           <span id="status" class="notice"></span>
         </div>
       </div>
@@ -108,6 +109,10 @@
   let currentStart = '';
   let currentEnd = '';
   let newProducts = [];
+
+  function track(step){
+    window.dispatchEvent(new CustomEvent('ozonSync', { detail:{ step } }));
+  }
 
   function initTable(){
     if(!table){
@@ -255,6 +260,27 @@
       setStatus(`新增${result.inserted||0}条，重复${result.duplicates||0}条`);
     }catch(err){ console.error(err); setStatus('失败: '+err.message); }
     e.target.value='';
+  });
+
+  $('#syncBtn').on('click', async function(){
+    try{
+      setStatus('加载中...');
+      track('start');
+      const resp = await fetch('/api/ozon/fetch?days=7');
+      const json = await resp.json();
+      if(!json.ok) throw new Error(json.msg||'同步失败');
+      setStatus('已读取到数据');
+      track('data_fetched');
+      setStatus('导入数据库中');
+      track('importing');
+      setStatus('导入完成');
+      track('done');
+      await loadData();
+    }catch(err){
+      console.error(err);
+      setStatus('同步失败');
+      track('error');
+    }
   });
 
   document.getElementById('newModal').addEventListener('click',e=>{ if(e.target.id==='newModal') e.currentTarget.style.display='none'; });

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -266,11 +266,10 @@
     try{
       setStatus('加载中...');
       track('start');
-      const resp = await fetch('/api/ozon/fetch?days=7');
+      const resp = await fetch(`/api/ozon/sync?days=7&store_id=${encodeURIComponent(storeId)}`,{ method:'POST' });
       const json = await resp.json();
-      if(!json.ok) throw new Error(json.msg||'同步失败');
 
-      setStatus(`已读取到数据 ${json.count||0} 条`);
+      setStatus(`已读取到数据 ${json.fetched||0} 条`);
       track('data_fetched');
       await new Promise(r=>setTimeout(r,500));
 
@@ -278,9 +277,17 @@
       track('importing');
       await new Promise(r=>setTimeout(r,500));
 
-      setStatus('导入完成');
-      track('done');
-      await loadData();
+      const ok = json.ok && json.upserted>0;
+      setStatus(`导入完成 ${ok ? '✅' : '⚠️'}`);
+      if(ok){
+        track('done');
+        await loadData();
+      }else{
+        const msg = json.message || '未知错误';
+        const samples = JSON.stringify(json.samples||[],null,2);
+        alert(msg + (samples? '\n'+samples : ''));
+        track('error');
+      }
     }catch(err){
       console.error(err);
       setStatus('同步失败: '+(err.message||err));


### PR DESCRIPTION
## Summary
- add parameterized Ozon fetch endpoint to sync last 7 days of analytics data
- provide Ozon detail page sync button with progress statuses and tracking events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7e34f2c6483259eafc0e688575c23