### PR TITLE
fix: robust sku extraction

### DIFF
--- a/api/ozon/sync/index.js
+++ b/api/ozon/sync/index.js
@@ -50,7 +50,11 @@ async function fetchFromOzon() {
   const rows = all.map(item => {
     const row = { stat_date: date };
     for (const d of item.dimensions || []) {
-      if (d.id === 'sku' || d.name === 'sku') row.product_id = d.value || d.name;
+      const key = d.id || d.key || d.name;
+      if (key === 'sku') {
+        row.product_id = d.value ?? d.name ?? d.key;
+        break;
+      }
     }
     return row;
   });


### PR DESCRIPTION
## Summary
- improve dimension parsing in Ozon sync to correctly extract SKU

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7f9bd564c8325ae109a19faeae3cb