### PR TITLE
fix: handle invalid landing path decoding

### DIFF
--- a/api/independent/stats/index.js
+++ b/api/independent/stats/index.js
@@ -16,16 +16,24 @@ function parseDate(s, fallback) {
   return fallback;
 }
 
-function extractName(path) {
-  const p = path || '';
-  const seg = p.split('/').filter(Boolean).pop();
+function decodeSafe(s) {
   try {
-    const name = seg ? decodeURIComponent(seg) : '';
-    return name || decodeURIComponent(p);
+    return decodeURIComponent(s);
   } catch (e) {
-    console.warn('Failed to decode landing_path', p, e.message);
-    return p;
+    console.warn('Failed to decode landing_path', s, e.message);
+    return s;
   }
+}
+
+function extractName(path) {
+  const p = typeof path === 'string' ? path : String(path || '');
+  const seg = p.split('/').filter(Boolean).pop() || '';
+  const name = seg ? decodeSafe(seg) : '';
+  if (name && name !== seg) return name;
+  const full = decodeSafe(p);
+  if (full !== p) return full;
+  if (/%(?![0-9A-Fa-f]{2})/.test(p)) console.warn('Invalid landing_path encoding', p);
+  return p;
 }
 
 function safeNum(v){

--- a/api/independent/stats/index.js
+++ b/api/independent/stats/index.js
@@ -19,8 +19,13 @@ function parseDate(s, fallback) {
 function extractName(path) {
   const p = path || '';
   const seg = p.split('/').filter(Boolean).pop();
-  const name = seg ? decodeURIComponent(seg) : '';
-  return name || decodeURIComponent(p);
+  try {
+    const name = seg ? decodeURIComponent(seg) : '';
+    return name || decodeURIComponent(p);
+  } catch (e) {
+    console.warn('Failed to decode landing_path', p, e.message);
+    return p;
+  }
 }
 
 function safeNum(v){


### PR DESCRIPTION
## Summary
- avoid decodeURIComponent crashes in stats API when landing_path is malformed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9385a5a6883258d733c743edb72ec