### PR TITLE
Fix independent-site product link assembly

### DIFF
--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -342,8 +342,13 @@
             const pid = r.landing_path || r.product || '';
             const name = shorten(r.landing_path || '');
             const base = siteInput.value.trim().replace(/\/$/,'');
-            const baseUrl = v && v.startsWith('http') ? v : base + (v || '');
-            const url = baseUrl.replace(/\/$/, '') + (r.landing_path || '');
+            let url = '';
+            if(v && v.startsWith('http')){
+              url = v;
+            }else{
+              const path = r.landing_path || v || '';
+              url = base + path;
+            }
             return `<div style="display:flex;align-items:center;" data-url="${url}"><img style="width:40px;height:40px;object-fit:cover;margin-right:4px;display:none;"><a href="${url}" target="_blank" class="name" title="${name}" data-pid="${pid}">${name}</a></div>`;
           }},
         { data:'clicks', render: v => v ?? 0 },

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -363,8 +363,12 @@ function card(title,cur,prev,isPct,avg,share){
         const id=getId(r);
         expMap.set(id,(expMap.get(id)||0)+getExp(r));
         if(mode==='indep'){
-          const baseUrl = r.landing_url && r.landing_url.startsWith('http') ? r.landing_url : base + (r.landing_url || '');
-          const link = (baseUrl || '').replace(/\/$/, '') + (r.landing_path || '');
+          let link = '';
+          if(r.landing_url && r.landing_url.startsWith('http')){
+            link = r.landing_url;
+          }else if(r.landing_path){
+            link = base + r.landing_path;
+          }
           if(link) linkMap.set(id,link);
         }
       });


### PR DESCRIPTION
## Summary
- Use `landing_url` directly when absolute in product analysis and independent site reports
- Fallback to base site plus `landing_path` to avoid duplicated `products/...` segments

## Testing
- `npm test`
- `node -e "const site='https://shop.com';const row={landing_url:'/products/sku123',landing_path:'/products/sku123'};const base=site.replace(/\\/$/,'');let url='';if(row.landing_url&&row.landing_url.startsWith('http')){url=row.landing_url;}else{const path=row.landing_path||row.landing_url||'';url=base+path;}console.log(url);console.log(url.includes('/products/sku123/products/sku123'));"`


------
https://chatgpt.com/codex/tasks/task_e_68aa9d258cec832582cc5b5db7a74e2c