### PR TITLE
Fix independent site product links

### DIFF
--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -342,8 +342,9 @@
             const pid = r.landing_path || r.product || '';
             const name = shorten(r.landing_path || '');
             const base = siteInput.value.trim().replace(/\/$/,'');
-            const baseUrl = v && v.startsWith('http') ? v : base + (v || '');
-            const url = baseUrl.replace(/\/$/, '') + (r.landing_path || '');
+            const url = (v && v.startsWith('http'))
+              ? v
+              : base + (r.landing_path || v || '');
             return `<div style="display:flex;align-items:center;" data-url="${url}"><img style="width:40px;height:40px;object-fit:cover;margin-right:4px;display:none;"><a href="${url}" target="_blank" class="name" title="${name}" data-pid="${pid}">${name}</a></div>`;
           }},
         { data:'clicks', render: v => v ?? 0 },

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -363,8 +363,13 @@ function card(title,cur,prev,isPct,avg,share){
         const id=getId(r);
         expMap.set(id,(expMap.get(id)||0)+getExp(r));
         if(mode==='indep'){
-          const baseUrl = r.landing_url && r.landing_url.startsWith('http') ? r.landing_url : base + (r.landing_url || '');
-          const link = (baseUrl || '').replace(/\/$/, '') + (r.landing_path || '');
+          let link='';
+          if(r.landing_url && r.landing_url.startsWith('http')){
+            link=r.landing_url;
+          }else{
+            const path=r.landing_path || r.landing_url || '';
+            link=base+path;
+          }
           if(link) linkMap.set(id,link);
         }
       });


### PR DESCRIPTION
## Summary
- Avoid duplicating product path segments when assembling links in independent-site reports
- Prefer full landing_url when available in product analysis page

## Testing
- `npm test`
- `node -e "const site='https://shop.com';const r={landing_url:'/products/sku123',landing_path:'/products/sku123'};const base=site.replace(/\/$/,'');let url='';if(r.landing_url&&r.landing_url.startsWith('http')){url=r.landing_url;}else{const path=r.landing_path||r.landing_url||'';url=base+path;}console.log(url);console.log(url.includes('/products/sku123/products/sku123'));"`


------
https://chatgpt.com/codex/tasks/task_e_68aa9e5c12008325aa1b22b0b0e12dfe