### PR TITLE
feat: add self-operated period comparison charts

### DIFF
--- a/public/operation-analysis.html
+++ b/public/operation-analysis.html
@@ -97,6 +97,13 @@ document.addEventListener('DOMContentLoaded',()=>{
   renderSiteMenus();
   updateCurrent();
 
+  if(mode!=='self'){
+    ['uvRateChart','cartRateChart','payRateChart'].forEach(id=>{
+      const panel=document.getElementById(id)?.parentElement;
+      if(panel) panel.remove();
+    });
+  }
+
   if(mode==='self'){
     setupSelf();
   }else{
@@ -177,9 +184,10 @@ document.addEventListener('DOMContentLoaded',()=>{
       renderBar('uvChart',{cur:sum(rowsA,'uv'),prev:sum(rowsB,'uv')});
       renderBar('cartChart',{cur:sum(rowsA,'add_to_cart_users'),prev:sum(rowsB,'add_to_cart_users')});
       renderBar('payChart',{cur:sum(rowsA,'pay_buyers'),prev:sum(rowsB,'pay_buyers')});
-      // placeholder for self-mode specific charts
-      renderBar('cartProdChart',{cur:0,prev:0});
-      renderBar('payProdChart',{cur:0,prev:0});
+      const prodAdd=rows=>{const set=new Set();rows.forEach(r=>{if(Number(r.add_to_cart_users||0)>0)set.add(r.product_id);});return set.size;};
+      const prodPay=rows=>{const set=new Set();rows.forEach(r=>{if(Number(r.pay_buyers||0)>0)set.add(r.product_id);});return set.size;};
+      renderBar('cartProdChart',{cur:prodAdd(rowsA),prev:prodAdd(rowsB)});
+      renderBar('payProdChart',{cur:prodPay(rowsA),prev:prodPay(rowsB)});
     }
 
     loadPeriods();

--- a/public/operation-analysis.html
+++ b/public/operation-analysis.html
@@ -49,6 +49,9 @@
           <div class="panel"><h3>支付订单数</h3><div id="payChart" style="width:100%;height:260px;"></div></div>
           <div class="panel"><h3>加购商品数</h3><div id="cartProdChart" style="width:100%;height:260px;"></div></div>
           <div class="panel"><h3>支付商品数</h3><div id="payProdChart" style="width:100%;height:260px;"></div></div>
+          <div class="panel"><h3>访客比</h3><div id="uvRateChart" style="width:100%;height:260px;"></div></div>
+          <div class="panel"><h3>加购比</h3><div id="cartRateChart" style="width:100%;height:260px;"></div></div>
+          <div class="panel"><h3>支付比</h3><div id="payRateChart" style="width:100%;height:260px;"></div></div>
         </div>
       </section>
     </div>
@@ -111,6 +114,20 @@ document.addEventListener('DOMContentLoaded',()=>{
         data:[{value:m.cur,itemStyle:{color:'#3b82f6'}},{value:m.prev,itemStyle:{color:'#94a3b8'}}],
         label:{show:true,position:'top'}
       }]
+    });
+    window.addEventListener('resize',()=>chart.resize());
+  }
+
+  function renderLine(id,series){
+    const chart=echarts.init(document.getElementById(id));
+    chart.setOption({
+      tooltip:{trigger:'axis',formatter:p=>p.map(x=>`${x.seriesName}: ${x.data.toFixed(2)}%`).join('<br>')},
+      xAxis:{type:'category',data:series.labels},
+      yAxis:{type:'value',axisLabel:{formatter:'{value}%'}},
+      series:[
+        {name:'本周期',type:'line',smooth:true,data:series.cur},
+        {name:'上一周期',type:'line',smooth:true,data:series.prev}
+      ]
     });
     window.addEventListener('resize',()=>chart.resize());
   }
@@ -188,22 +205,56 @@ document.addEventListener('DOMContentLoaded',()=>{
       const val=input.value; if(!val.includes(' to '))return; const [startISO,endISO]=val.split(' to ');
       localStorage.setItem('selfPeriod', `${startISO} to ${endISO}`);
       const {prevStart,prevEnd}=periodShift(startISO,endISO);
-      const [rowsCur,rowsPrev]=await Promise.all([
-        fetchAgg(startISO,endISO),
-        fetchAgg(prevStart,prevEnd)
+      const [rowsCur,rowsPrev,rowsCurDay,rowsPrevDay]=await Promise.all([
+        fetchAgg(startISO,endISO,'period'),
+        fetchAgg(prevStart,prevEnd,'period'),
+        fetchAgg(startISO,endISO,'day'),
+        fetchAgg(prevStart,prevEnd,'day')
       ]);
       const sum=(rows,key)=>rows.reduce((s,r)=>s+Number(r[key]||0),0);
-      const prod=(rows,key)=>{const set=new Set();rows.forEach(r=>{if(Number(r[key])>0)set.add(r.product_id);});return set.size;};
+      const pickAdd=r=>Number(r.add_count)||Number(r.add_people)||0;
+      const pickPay=r=>Number(r.pay_orders)||Number(r.pay_buyers)||Number(r.pay_items)||0;
+      const sumAdd=rows=>rows.reduce((s,r)=>s+pickAdd(r),0);
+      const sumPay=rows=>rows.reduce((s,r)=>s+pickPay(r),0);
       renderBar('expChart',{cur:sum(rowsCur,'exposure'),prev:sum(rowsPrev,'exposure')});
       renderBar('uvChart',{cur:sum(rowsCur,'visitors'),prev:sum(rowsPrev,'visitors')});
-      renderBar('cartChart',{cur:sum(rowsCur,'add_count'),prev:sum(rowsPrev,'add_count')});
-      renderBar('payChart',{cur:sum(rowsCur,'pay_orders'),prev:sum(rowsPrev,'pay_orders')});
-      renderBar('cartProdChart',{cur:prod(rowsCur,'add_count'),prev:prod(rowsPrev,'add_count')});
-      renderBar('payProdChart',{cur:prod(rowsCur,'pay_orders'),prev:prod(rowsPrev,'pay_orders')});
+      renderBar('cartChart',{cur:sumAdd(rowsCur),prev:sumAdd(rowsPrev)});
+      renderBar('payChart',{cur:sumPay(rowsCur),prev:sumPay(rowsPrev)});
+      const prodAdd=(rows)=>{const set=new Set();rows.forEach(r=>{if(pickAdd(r)>0)set.add(r.product_id);});return set.size;};
+      const prodPay=(rows)=>{const set=new Set();rows.forEach(r=>{if(pickPay(r)>0)set.add(r.product_id);});return set.size;};
+      renderBar('cartProdChart',{cur:prodAdd(rowsCur),prev:prodAdd(rowsPrev)});
+      renderBar('payProdChart',{cur:prodPay(rowsCur),prev:prodPay(rowsPrev)});
+
+      const dailyAgg=rows=>{
+        const map=new Map();
+        rows.forEach(r=>{
+          const d=r.bucket||r.stat_date; if(!d) return;
+          if(!map.has(d)) map.set(d,{exposure:0,visitors:0,add_count:0,add_people:0,pay_orders:0,pay_buyers:0,pay_items:0});
+          const obj=map.get(d);
+          obj.exposure+=Number(r.exposure)||0;
+          obj.visitors+=Number(r.visitors)||0;
+          obj.add_count+=Number(r.add_count)||0;
+          obj.add_people+=Number(r.add_people)||0;
+          obj.pay_orders+=Number(r.pay_orders)||0;
+          obj.pay_buyers+=Number(r.pay_buyers)||0;
+          obj.pay_items+=Number(r.pay_items)||0;
+        });
+        return Array.from(map.entries()).sort(([a],[b])=>a.localeCompare(b)).map(([date,val])=>({date,...val}));
+      };
+      const curDay=dailyAgg(rowsCurDay);
+      const prevDay=dailyAgg(rowsPrevDay);
+      const labels=curDay.map(r=>r.date.slice(5));
+      const build=(arr,fn)=>labels.map((_,i)=>arr[i]?fn(arr[i]):0);
+      const uvRate=r=>r.exposure>0?(r.visitors/r.exposure*100):0;
+      const cartRate=r=>{const a=pickAdd(r);return r.visitors>0?(a/r.visitors*100):0;};
+      const payRate=r=>{const p=pickPay(r);return r.visitors>0?(p/r.visitors*100):0;};
+      renderLine('uvRateChart',{labels,cur:build(curDay,uvRate),prev:build(prevDay,uvRate)});
+      renderLine('cartRateChart',{labels,cur:build(curDay,cartRate),prev:build(prevDay,cartRate)});
+      renderLine('payRateChart',{labels,cur:build(curDay,payRate),prev:build(prevDay,payRate)});
     }
 
-    function fetchAgg(start,end){
-      const url=`/api/ae_query?start=${start}&end=${end}&granularity=period`;
+    function fetchAgg(start,end,gran='period'){
+      const url=`/api/ae_query?start=${start}&end=${end}&granularity=${gran}`;
       return fetch(url).then(r=>r.json()).then(j=>j.rows||[]);
     }
     function periodShift(startISO,endISO){

--- a/public/operation-analysis.html
+++ b/public/operation-analysis.html
@@ -49,6 +49,7 @@
           <div class="panel"><h3>访客数</h3><div id="uvChart" style="width:100%;height:260px;"></div></div>
           <div class="panel"><h3>加购次数</h3><div id="cartChart" style="width:100%;height:260px;"></div></div>
           <div class="panel"><h3>支付订单数</h3><div id="payChart" style="width:100%;height:260px;"></div></div>
+          <div class="panel"><h3>曝光商品数</h3><div id="expProdChart" style="width:100%;height:260px;"></div></div>
           <div class="panel"><h3>加购商品数</h3><div id="cartProdChart" style="width:100%;height:260px;"></div></div>
           <div class="panel"><h3>支付商品数</h3><div id="payProdChart" style="width:100%;height:260px;"></div></div>
           <div class="panel"><h3>访客比</h3><div id="uvRateChart" style="width:100%;height:260px;"></div></div>
@@ -195,14 +196,16 @@ document.addEventListener('DOMContentLoaded',()=>{
       const ja=await ra.json();
       const jb=rb?await rb.json():{rows:[]};
       const rowsA=ja.rows||[]; const rowsB=jb.rows||[];
-      function sumExp(rows){return rows.reduce((s,r)=>s+Number(r.search_exposure||r.exposure||r.pv||0),0);} 
+      function sumExp(rows){return rows.reduce((s,r)=>s+Number(r.search_exposure||r.exposure||r.pv||0),0);}
       const sum= (rows,key)=>rows.reduce((s,r)=>s+Number(r[key]||0),0);
       renderBar('expChart',{cur:sumExp(rowsA),prev:sumExp(rowsB)});
       renderBar('uvChart',{cur:sum(rowsA,'uv'),prev:sum(rowsB,'uv')});
       renderBar('cartChart',{cur:sum(rowsA,'add_to_cart_users'),prev:sum(rowsB,'add_to_cart_users')});
       renderBar('payChart',{cur:sum(rowsA,'pay_buyers'),prev:sum(rowsB,'pay_buyers')});
+      const prodExp=rows=>{const set=new Set();rows.forEach(r=>{if(Number(r.search_exposure||r.exposure||r.pv||0)>0)set.add(r.product_id);});return set.size;};
       const prodAdd=rows=>{const set=new Set();rows.forEach(r=>{if(Number(r.add_to_cart_users||0)>0)set.add(r.product_id);});return set.size;};
       const prodPay=rows=>{const set=new Set();rows.forEach(r=>{if(Number(r.pay_buyers||0)>0)set.add(r.product_id);});return set.size;};
+      renderBar('expProdChart',{cur:prodExp(rowsA),prev:prodExp(rowsB)});
       renderBar('cartProdChart',{cur:prodAdd(rowsA),prev:prodAdd(rowsB)});
       renderBar('payProdChart',{cur:prodPay(rowsA),prev:prodPay(rowsB)});
     }
@@ -245,8 +248,10 @@ document.addEventListener('DOMContentLoaded',()=>{
       renderBar('uvChart',{cur:sum(rowsCur,'visitors'),prev:sum(rowsPrev,'visitors')});
       renderBar('cartChart',{cur:sumAdd(rowsCur),prev:sumAdd(rowsPrev)});
       renderBar('payChart',{cur:sumPay(rowsCur),prev:sumPay(rowsPrev)});
+      const prodExp=(rows)=>{const set=new Set();rows.forEach(r=>{if(Number(r.exposure||0)>0)set.add(r.product_id);});return set.size;};
       const prodAdd=(rows)=>{const set=new Set();rows.forEach(r=>{if(pickAdd(r)>0)set.add(r.product_id);});return set.size;};
       const prodPay=(rows)=>{const set=new Set();rows.forEach(r=>{if(pickPay(r)>0)set.add(r.product_id);});return set.size;};
+      renderBar('expProdChart',{cur:prodExp(rowsCur),prev:prodExp(rowsPrev)});
       renderBar('cartProdChart',{cur:prodAdd(rowsCur),prev:prodAdd(rowsPrev)});
       renderBar('payProdChart',{cur:prodPay(rowsCur),prev:prodPay(rowsPrev)});
 

--- a/public/operation-analysis.html
+++ b/public/operation-analysis.html
@@ -45,8 +45,10 @@
         <div class="grid grid-2">
           <div class="panel"><h3>曝光量</h3><div id="expChart" style="width:100%;height:260px;"></div></div>
           <div class="panel"><h3>访客数</h3><div id="uvChart" style="width:100%;height:260px;"></div></div>
-          <div class="panel"><h3>加购人数</h3><div id="atcChart" style="width:100%;height:260px;"></div></div>
-          <div class="panel"><h3>支付买家数</h3><div id="payChart" style="width:100%;height:260px;"></div></div>
+          <div class="panel"><h3>加购次数</h3><div id="cartChart" style="width:100%;height:260px;"></div></div>
+          <div class="panel"><h3>支付订单数</h3><div id="payChart" style="width:100%;height:260px;"></div></div>
+          <div class="panel"><h3>加购商品数</h3><div id="cartProdChart" style="width:100%;height:260px;"></div></div>
+          <div class="panel"><h3>支付商品数</h3><div id="payProdChart" style="width:100%;height:260px;"></div></div>
         </div>
       </section>
     </div>
@@ -98,6 +100,21 @@ document.addEventListener('DOMContentLoaded',()=>{
     setupFM();
   }
 
+  function renderBar(id,m){
+    const chart=echarts.init(document.getElementById(id));
+    chart.setOption({
+      tooltip:{trigger:'axis',axisPointer:{type:'shadow'}},
+      xAxis:{type:'category',data:['本周期','上一周期']},
+      yAxis:{type:'value'},
+      series:[{
+        type:'bar',
+        data:[{value:m.cur,itemStyle:{color:'#3b82f6'}},{value:m.prev,itemStyle:{color:'#94a3b8'}}],
+        label:{show:true,position:'top'}
+      }]
+    });
+    window.addEventListener('resize',()=>chart.resize());
+  }
+
   function setupFM(){
     const ctrl=document.getElementById('ctrl');
     ctrl.innerHTML='<label>粒度</label><label><input type="radio" name="gran" value="week"> 周</label><label><input type="radio" name="gran" value="month"> 月</label><select id="periodSelect" class="sel"></select>';
@@ -141,23 +158,11 @@ document.addEventListener('DOMContentLoaded',()=>{
       const sum= (rows,key)=>rows.reduce((s,r)=>s+Number(r[key]||0),0);
       renderBar('expChart',{cur:sumExp(rowsA),prev:sumExp(rowsB)});
       renderBar('uvChart',{cur:sum(rowsA,'uv'),prev:sum(rowsB,'uv')});
-      renderBar('atcChart',{cur:sum(rowsA,'add_to_cart_users'),prev:sum(rowsB,'add_to_cart_users')});
+      renderBar('cartChart',{cur:sum(rowsA,'add_to_cart_users'),prev:sum(rowsB,'add_to_cart_users')});
       renderBar('payChart',{cur:sum(rowsA,'pay_buyers'),prev:sum(rowsB,'pay_buyers')});
-    }
-
-    function renderBar(id,m){
-      const chart=echarts.init(document.getElementById(id));
-      chart.setOption({
-        tooltip:{trigger:'axis',axisPointer:{type:'shadow'}},
-        xAxis:{type:'category',data:['本周期','上一周期']},
-        yAxis:{type:'value'},
-        series:[{
-          type:'bar',
-          data:[{value:m.cur,itemStyle:{color:'#3b82f6'}},{value:m.prev,itemStyle:{color:'#94a3b8'}}],
-          label:{show:true,position:'top'}
-        }]
-      });
-      window.addEventListener('resize',()=>chart.resize());
+      // placeholder for self-mode specific charts
+      renderBar('cartProdChart',{cur:0,prev:0});
+      renderBar('payProdChart',{cur:0,prev:0});
     }
 
     loadPeriods();
@@ -165,9 +170,9 @@ document.addEventListener('DOMContentLoaded',()=>{
 
   function setupSelf(){
     const ctrl=document.getElementById('ctrl');
-    ctrl.innerHTML='<input id="dateRange" class="date-filter" placeholder="选择日期范围">';
-    const input=document.getElementById('dateRange');
-    const fp=flatpickr(input,{mode:'range',dateFormat:'Y-m-d',onClose:ds=>{if(ds.length===2)loadData();}});
+    ctrl.innerHTML='<input id="dateFilter" class="date-filter" placeholder="选择日期范围">';
+    const input=document.getElementById('dateFilter');
+    flatpickr(input,{mode:'range',dateFormat:'Y-m-d',onClose:ds=>{if(ds.length===2)loadData();}});
     const stored=localStorage.getItem('selfPeriod');
     if(stored && stored.includes(' to ')){
       input.value=stored;
@@ -182,35 +187,23 @@ document.addEventListener('DOMContentLoaded',()=>{
     async function loadData(){
       const val=input.value; if(!val.includes(' to '))return; const [startISO,endISO]=val.split(' to ');
       localStorage.setItem('selfPeriod', `${startISO} to ${endISO}`);
-      const {prevStart,prevEnd,days}=periodShift(startISO,endISO);
+      const {prevStart,prevEnd}=periodShift(startISO,endISO);
       const [rowsCur,rowsPrev]=await Promise.all([
         fetchAgg(startISO,endISO),
         fetchAgg(prevStart,prevEnd)
       ]);
-      const agg=rows=>({
-        exp:aggregate(rows,'exposure'),
-        uv:aggregate(rows,'visitors'),
-        atc:aggregate(rows,'add_people'),
-        pay:aggregate(rows,'pay_buyers')
-      });
-      const curAgg=agg(rowsCur); const prevAgg=agg(rowsPrev);
-      const labels=[], expCur=[], expPrev=[], uvCur=[], uvPrev=[], atcCur=[], atcPrev=[], payCur=[], payPrev=[];
-      for(let i=0;i<days;i++){
-        const d=addDays(startISO,i); const dp=addDays(prevStart,i);
-        labels.push(formatMD(d));
-        expCur.push(curAgg.exp[d]||0); expPrev.push(prevAgg.exp[dp]||0);
-        uvCur.push(curAgg.uv[d]||0); uvPrev.push(prevAgg.uv[dp]||0);
-        atcCur.push(curAgg.atc[d]||0); atcPrev.push(prevAgg.atc[dp]||0);
-        payCur.push(curAgg.pay[d]||0); payPrev.push(prevAgg.pay[dp]||0);
-      }
-      renderLine('expChart',labels,expCur,expPrev);
-      renderLine('uvChart',labels,uvCur,uvPrev);
-      renderLine('atcChart',labels,atcCur,atcPrev);
-      renderLine('payChart',labels,payCur,payPrev);
+      const sum=(rows,key)=>rows.reduce((s,r)=>s+Number(r[key]||0),0);
+      const prod=(rows,key)=>{const set=new Set();rows.forEach(r=>{if(Number(r[key])>0)set.add(r.product_id);});return set.size;};
+      renderBar('expChart',{cur:sum(rowsCur,'exposure'),prev:sum(rowsPrev,'exposure')});
+      renderBar('uvChart',{cur:sum(rowsCur,'visitors'),prev:sum(rowsPrev,'visitors')});
+      renderBar('cartChart',{cur:sum(rowsCur,'add_count'),prev:sum(rowsPrev,'add_count')});
+      renderBar('payChart',{cur:sum(rowsCur,'pay_orders'),prev:sum(rowsPrev,'pay_orders')});
+      renderBar('cartProdChart',{cur:prod(rowsCur,'add_count'),prev:prod(rowsPrev,'add_count')});
+      renderBar('payProdChart',{cur:prod(rowsCur,'pay_orders'),prev:prod(rowsPrev,'pay_orders')});
     }
 
     function fetchAgg(start,end){
-      const url=`/api/ae_query?start=${start}&end=${end}&granularity=day`;
+      const url=`/api/ae_query?start=${start}&end=${end}&granularity=period`;
       return fetch(url).then(r=>r.json()).then(j=>j.rows||[]);
     }
     function periodShift(startISO,endISO){
@@ -219,23 +212,7 @@ document.addEventListener('DOMContentLoaded',()=>{
       const prevEnd=new Date(start.getTime()-86400000);
       const prevStart=new Date(prevEnd.getTime()-(days-1)*86400000);
       const fmt=d=>d.toISOString().slice(0,10);
-      return{prevStart:fmt(prevStart),prevEnd:fmt(prevEnd),days};
-    }
-    function aggregate(rows,key){
-      const m={}; rows.forEach(r=>{const d=r.bucket; m[d]=(m[d]||0)+Number(r[key]||0);}); return m;
-    }
-    function addDays(startISO,n){const d=new Date(startISO); d.setDate(d.getDate()+n); return d.toISOString().slice(0,10);} 
-    function formatMD(iso){const d=new Date(iso); return (d.getMonth()+1)+'/'+d.getDate();}
-    function renderLine(id,labels,cur,prev){
-      const chart=echarts.init(document.getElementById(id));
-      chart.setOption({
-        tooltip:{trigger:'axis'},
-        legend:{data:['本周期','上一周期']},
-        xAxis:{type:'category',data:labels},
-        yAxis:{type:'value'},
-        series:[{name:'本周期',type:'line',smooth:true,data:cur},{name:'上一周期',type:'line',smooth:true,data:prev}]
-      });
-      window.addEventListener('resize',()=>chart.resize());
+      return{prevStart:fmt(prevStart),prevEnd:fmt(prevEnd)};
     }
   }
 });

--- a/public/operation-analysis.html
+++ b/public/operation-analysis.html
@@ -9,6 +9,7 @@
   <script src="https://cdn.jsdelivr.net/npm/echarts/dist/echarts.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
   <script>const t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t);</script>
+  <style>.kpi-row{display:flex;gap:.75rem;flex-wrap:wrap;margin-bottom:12px}</style>
 </head>
 <body>
 <header class="header">
@@ -42,6 +43,7 @@
     <div class="content">
       <section class="content-pad">
         <div id="ctrl" class="controls" style="margin-bottom:12px;"></div>
+        <div class="kpi-row"><div class="stat-card"><h4>产品总数</h4><p id="prodTotal">--</p></div></div>
         <div class="grid grid-2">
           <div class="panel"><h3>曝光量</h3><div id="expChart" style="width:100%;height:260px;"></div></div>
           <div class="panel"><h3>访客数</h3><div id="uvChart" style="width:100%;height:260px;"></div></div>
@@ -109,6 +111,21 @@ document.addEventListener('DOMContentLoaded',()=>{
   }else{
     setupFM();
   }
+
+  async function loadProdTotal(){
+    const platform=mode==='self'?'self':'managed';
+    const today=new Date().toISOString().slice(0,10);
+    const qs=new URLSearchParams({platform,from:'2000-01-01',to:today,limit:'5000'});
+    try{
+      const r=await fetch('/api/new-products?'+qs.toString());
+      const j=await r.json();
+      document.getElementById('prodTotal').textContent=j.new_count||0;
+    }catch(e){
+      console.error(e);
+      document.getElementById('prodTotal').textContent='0';
+    }
+  }
+  loadProdTotal();
 
   function renderBar(id,m){
     const chart=echarts.init(document.getElementById(id));

--- a/public/ozon-analysis.html
+++ b/public/ozon-analysis.html
@@ -50,6 +50,7 @@
           <div class="panel"><h3>详情页访客数</h3><div id="uvChart" style="width:100%;height:260px;"></div></div>
           <div class="panel"><h3>加购次数</h3><div id="cartChart" style="width:100%;height:260px;"></div></div>
           <div class="panel"><h3>订购商品数</h3><div id="orderChart" style="width:100%;height:260px;"></div></div>
+          <div class="panel"><h3>有曝光商品数</h3><div id="expProdChart" style="width:100%;height:260px;"></div></div>
           <div class="panel"><h3>有加购商品数</h3><div id="cartProdChart" style="width:100%;height:260px;"></div></div>
           <div class="panel"><h3>有支付商品数</h3><div id="payProdChart" style="width:100%;height:260px;"></div></div>
         </div>
@@ -111,16 +112,17 @@
     return j.rows||[];
   }
   function sum(rows){
+    const expSet=new Set();
     const cartSet=new Set();
     const paySet=new Set();
     let exposure=0,uv=0,cart=0,pay=0;
     rows.forEach(r=>{
-      exposure+=Number(r.voronka_prodazh_pokazy_vsego)||0;
+      const e=Number(r.voronka_prodazh_pokazy_vsego)||0; exposure+=e; if(e>0) expSet.add(r.product_id||r.sku+'@@'+(r.model||''));
       const u=Number(r.voronka_prodazh_uv_s_prosmotrom_kartochki_tovara)||0; uv+=u;
       const c=Number(r.voronka_prodazh_dobavleniya_v_korzinu_vsego)||0; cart+=c; if(c>0) cartSet.add(r.product_id||r.sku+'@@'+(r.model||''));
       const p=Number(r.voronka_prodazh_zakazano_tovarov)||0; pay+=p; if(p>0) paySet.add(r.product_id||r.sku+'@@'+(r.model||''));
     });
-    return {exposure,uv,cart,pay,cartProds:cartSet.size,payProds:paySet.size};
+    return {exposure,uv,cart,pay,expProds:expSet.size,cartProds:cartSet.size,payProds:paySet.size};
   }
 
   async function loadProdTotal(){
@@ -150,6 +152,7 @@
     renderBar('uvChart',{cur:cur.uv,prev:prev.uv});
     renderBar('cartChart',{cur:cur.cart,prev:prev.cart});
     renderBar('orderChart',{cur:cur.pay,prev:prev.pay});
+    renderBar('expProdChart',{cur:cur.expProds,prev:prev.expProds});
     renderBar('cartProdChart',{cur:cur.cartProds,prev:prev.cartProds});
     renderBar('payProdChart',{cur:cur.payProds,prev:prev.payProds});
 

--- a/public/ozon-analysis.html
+++ b/public/ozon-analysis.html
@@ -10,6 +10,7 @@
   <script src="https://cdn.jsdelivr.net/npm/echarts/dist/echarts.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
   <script>const t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t);</script>
+  <style>.kpi-row{display:flex;gap:.75rem;flex-wrap:wrap;margin-bottom:12px}</style>
 </head>
 <body class="fm">
 <header class="header">
@@ -43,6 +44,7 @@
     <div class="content">
       <section class="content-pad">
         <div class="controls" style="margin-bottom:12px;"><input id="dateRange" class="date-filter" placeholder="选择日期范围"></div>
+        <div class="kpi-row"><div class="stat-card"><h4>产品总数</h4><p id="prodTotal">--</p></div></div>
         <div class="grid grid-2">
           <div class="panel"><h3>总展示数</h3><div id="expChart" style="width:100%;height:260px;"></div></div>
           <div class="panel"><h3>详情页访客数</h3><div id="uvChart" style="width:100%;height:260px;"></div></div>
@@ -121,6 +123,19 @@
     return {exposure,uv,cart,pay,cartProds:cartSet.size,payProds:paySet.size};
   }
 
+  async function loadProdTotal(){
+    try{
+      const today=new Date().toISOString().slice(0,10);
+      const url=`/api/ozon/kpi?store_id=${encodeURIComponent(storeId)}&start=2000-01-01&end=${today}`;
+      const r=await fetch(url); const j=await r.json();
+      const val=j.metrics?.product_total?.current||0;
+      document.getElementById('prodTotal').textContent=val;
+    }catch(e){
+      console.error(e);
+      document.getElementById('prodTotal').textContent='0';
+    }
+  }
+
   async function loadData(){
     const val=input.value; if(!val.includes(' to ')) return;
     const [start,end]=val.split(' to ');
@@ -187,6 +202,7 @@
     window.addEventListener('resize',()=>chart.resize());
   }
 
+  loadProdTotal();
   loadData();
 })();
 </script>


### PR DESCRIPTION
## Summary
- expand operation analysis with unified date range control
- show period-over-period bar charts for exposure, visitors, cart actions, payments, and product counts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad1fdd5fb08325992068027f8f5fa6