### PR TITLE
Add site logo and favicon

### DIFF
--- a/public/amazon-ads.html
+++ b/public/amazon-ads.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Amazon 广告（建设中）</title>
   <link rel="stylesheet" href="assets/login.css">
@@ -10,7 +11,7 @@
 </head>
 <body class="fm">
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>

--- a/public/amazon-overview.html
+++ b/public/amazon-overview.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Amazon 数据总览</title>
   <link rel="stylesheet" href="assets/login.css">
@@ -10,7 +11,7 @@
 </head>
 <body class="fm">
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>

--- a/public/assets/logo.svg
+++ b/public/assets/logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 100">
+  <rect x="10" y="60" width="25" height="30" fill="#2563eb"/>
+  <rect x="50" y="40" width="25" height="50" fill="#2563eb"/>
+  <rect x="90" y="20" width="25" height="70" fill="#2563eb"/>
+  <path d="M10 60 L50 40 L90 20 L125 30" stroke="#2563eb" stroke-width="8" fill="none"/>
+  <path d="M125 30 L115 25 L115 35 Z" fill="#2563eb"/>
+  <text x="150" y="55" font-size="32" font-family="Arial, sans-serif" fill="#111827">Ecommerce</text>
+  <text x="150" y="85" font-size="32" font-family="Arial, sans-serif" fill="#111827">Analytics</text>
+</svg>

--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -48,7 +48,8 @@ body{
   padding:8px 16px;
   box-shadow:0 1px 2px rgba(0,0,0,.05);
 }
-.logo-title{font-weight:700;font-size:16px;color:var(--text);}
+.logo-title{font-weight:700;font-size:16px;color:var(--text);display:flex;align-items:center;gap:8px;}
+.logo-title .site-logo{height:32px;}
 .header-center{flex:1;display:flex;justify-content:center;}
 .header-center .platform-nav{list-style:none;margin:0;padding:0;display:flex;gap:20px;}
 .header-center .platform-nav>li{position:relative;}

--- a/public/history.html
+++ b/public/history.html
@@ -3,6 +3,7 @@
 <html lang="zh-CN">
 <head>
   <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>历史数据 - fact_daily_metrics</title>
 

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>跨境电商数据分析平台</title>
   <style>
@@ -57,7 +58,7 @@
 </div>
 
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>

--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html lang="zh">
 <head>
   <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
   <title>跨境电商数据分析平台</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- libs -->
@@ -65,7 +66,7 @@
   </div>
 </div>
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali active"><a href="#">速卖通</a>

--- a/public/index未加新产品统计.html
+++ b/public/index未加新产品统计.html
@@ -3,6 +3,7 @@
 <html lang="zh-CN">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>速卖通全托管数据分析</title>
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">

--- a/public/login.html
+++ b/public/login.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
   <title>登录</title>
   <link rel="stylesheet" href="assets/login.css">
   <link rel="stylesheet" href="assets/theme.css">

--- a/public/managed.html
+++ b/public/managed.html
@@ -3,6 +3,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>跨境电商数据分析平台</title>
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
@@ -67,7 +68,7 @@
   </div>
 </div>
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali active"><a href="#">速卖通</a>

--- a/public/operation-analysis.html
+++ b/public/operation-analysis.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>运营分析</title>
   <link rel="stylesheet" href="assets/theme.css?v=20250812-deep">
@@ -13,7 +14,7 @@
 </head>
 <body>
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali active"><a href="#">速卖通</a>

--- a/public/ozon-analysis.html
+++ b/public/ozon-analysis.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Ozon 运营分析</title>
   <link rel="stylesheet" href="assets/login.css">
@@ -14,7 +15,7 @@
 </head>
 <body class="fm">
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Ozon 数据明细</title>
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
@@ -21,7 +22,7 @@
 </head>
 <body class="fm">
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>

--- a/public/ozon-product-insights.html
+++ b/public/ozon-product-insights.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Ozon 产品分析</title>
   <link rel="stylesheet" href="assets/login.css">
@@ -13,7 +14,7 @@
 </head>
 <body class="fm">
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>产品分析</title>
   <link rel="stylesheet" href="assets/theme.css?v=20250812-deep">
@@ -14,7 +15,7 @@
 </head>
 <body>
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>

--- a/public/self-operatedctr计算不正确.html
+++ b/public/self-operatedctr计算不正确.html
@@ -2,6 +2,7 @@
 <html lang="zh">
 <head>
   <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
   <title>自运营数据分析 · 对比增强版</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- libs -->

--- a/public/temu.html
+++ b/public/temu.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Temu 数据分析（建设中）</title>
   <link rel="stylesheet" href="assets/login.css">
@@ -10,7 +11,7 @@
 </head>
 <body class="fm">
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>

--- a/public/tiktok.html
+++ b/public/tiktok.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TikTok Shop 数据分析（建设中）</title>
   <link rel="stylesheet" href="assets/login.css">
@@ -10,7 +11,7 @@
 </head>
 <body class="fm">
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>


### PR DESCRIPTION
## Summary
- Add SVG logo and use it across pages as site branding and favicon.
- Style header to display logo image alongside existing title.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae84f058848325bea41c011843188b