### PR TITLE
Add site logo and favicon

### DIFF
--- a/public/amazon-ads.html
+++ b/public/amazon-ads.html
@@ -30,7 +30,7 @@
 </header>
 <div class="layout container">
   <nav class="sidebar" id="sidebar">
-    <div class="site-header"><span>Amazon</span></div>
+    <div class="site-header"><div class="site-name"><img src="assets/site-icon.svg" class="site-icon" alt=""><span>Amazon</span></div></div>
     <ul class="sub-nav">
       <li><a href="amazon-overview.html">总览</a></li>
       <li><a href="amazon-ads.html" class="active">广告</a></li>

--- a/public/amazon-ads.html
+++ b/public/amazon-ads.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Amazon 广告（建设中）</title>
   <link rel="stylesheet" href="assets/login.css">
@@ -10,7 +11,7 @@
 </head>
 <body class="fm">
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>

--- a/public/amazon-overview.html
+++ b/public/amazon-overview.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Amazon 数据总览</title>
   <link rel="stylesheet" href="assets/login.css">
@@ -10,7 +11,7 @@
 </head>
 <body class="fm">
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>

--- a/public/amazon-overview.html
+++ b/public/amazon-overview.html
@@ -30,7 +30,7 @@
 </header>
 <div class="layout container">
   <nav class="sidebar" id="sidebar">
-    <div class="site-header"><span>数据总览</span></div>
+    <div class="site-header"><div class="site-name"><img src="assets/site-icon.svg" class="site-icon" alt=""><span>数据总览</span></div></div>
     <ul class="sub-nav">
       <li><a href="amazon-overview.html" class="active">总览</a></li>
       <li><a href="amazon-ads.html">广告</a></li>

--- a/public/assets/favicon.svg
+++ b/public/assets/favicon.svg
@@ -1,6 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <circle cx="32" cy="32" r="28" fill="#1e40af"/>
-  <path d="M4 32h56" stroke="#fff" stroke-width="4"/>
-  <ellipse cx="32" cy="32" rx="12" ry="28" stroke="#fff" stroke-width="4" fill="none"/>
-  <ellipse cx="32" cy="32" rx="4" ry="28" stroke="#fff" stroke-width="4" fill="none"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="2" y="18" width="6" height="12" fill="#1e40af"/>
+  <rect x="12" y="14" width="6" height="16" fill="#1e40af"/>
+  <rect x="22" y="10" width="6" height="20" fill="#1e40af"/>
+  <polyline points="2,22 12,12 18,18 30,6" stroke="#1e40af" stroke-width="3" fill="none"/>
+  <polyline points="26,6 30,6 30,10" stroke="#1e40af" stroke-width="3" fill="none"/>
 </svg>

--- a/public/assets/favicon.svg
+++ b/public/assets/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="4" y="36" width="10" height="24" fill="#2563eb"/>
+  <rect x="18" y="26" width="10" height="34" fill="#2563eb"/>
+  <rect x="32" y="16" width="10" height="44" fill="#2563eb"/>
+  <path d="M4 36 L18 26 L32 16 L52 20" stroke="#2563eb" stroke-width="4" fill="none"/>
+  <path d="M52 20 L46 16 L46 24 Z" fill="#2563eb"/>
+</svg>

--- a/public/assets/favicon.svg
+++ b/public/assets/favicon.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect x="4" y="36" width="10" height="24" fill="#2563eb"/>
-  <rect x="18" y="26" width="10" height="34" fill="#2563eb"/>
-  <rect x="32" y="16" width="10" height="44" fill="#2563eb"/>
-  <path d="M4 36 L18 26 L32 16 L52 20" stroke="#2563eb" stroke-width="4" fill="none"/>
-  <path d="M52 20 L46 16 L46 24 Z" fill="#2563eb"/>
+  <circle cx="32" cy="32" r="28" fill="#1e40af"/>
+  <path d="M4 32h56" stroke="#fff" stroke-width="4"/>
+  <ellipse cx="32" cy="32" rx="12" ry="28" stroke="#fff" stroke-width="4" fill="none"/>
+  <ellipse cx="32" cy="32" rx="4" ry="28" stroke="#fff" stroke-width="4" fill="none"/>
 </svg>

--- a/public/assets/logo.svg
+++ b/public/assets/logo.svg
@@ -1,9 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 100">
-  <rect x="10" y="60" width="25" height="30" fill="#2563eb"/>
-  <rect x="50" y="40" width="25" height="50" fill="#2563eb"/>
-  <rect x="90" y="20" width="25" height="70" fill="#2563eb"/>
-  <path d="M10 60 L50 40 L90 20 L125 30" stroke="#2563eb" stroke-width="8" fill="none"/>
-  <path d="M125 30 L115 25 L115 35 Z" fill="#2563eb"/>
-  <text x="150" y="55" font-size="32" font-family="Arial, sans-serif" fill="#111827">Ecommerce</text>
-  <text x="150" y="85" font-size="32" font-family="Arial, sans-serif" fill="#111827">Analytics</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#1e40af"/>
+  <path d="M2 16h28" stroke="#fff" stroke-width="2"/>
+  <ellipse cx="16" cy="16" rx="6" ry="14" stroke="#fff" stroke-width="2" fill="none"/>
+  <ellipse cx="16" cy="16" rx="2" ry="14" stroke="#fff" stroke-width="2" fill="none"/>
 </svg>

--- a/public/assets/logo.svg
+++ b/public/assets/logo.svg
@@ -1,6 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <circle cx="16" cy="16" r="14" fill="#1e40af"/>
-  <path d="M2 16h28" stroke="#fff" stroke-width="2"/>
-  <ellipse cx="16" cy="16" rx="6" ry="14" stroke="#fff" stroke-width="2" fill="none"/>
-  <ellipse cx="16" cy="16" rx="2" ry="14" stroke="#fff" stroke-width="2" fill="none"/>
+  <rect x="2" y="18" width="6" height="12" fill="#1e40af"/>
+  <rect x="12" y="14" width="6" height="16" fill="#1e40af"/>
+  <rect x="22" y="10" width="6" height="20" fill="#1e40af"/>
+  <polyline points="2,22 12,12 18,18 30,6" stroke="#1e40af" stroke-width="3" fill="none"/>
+  <polyline points="26,6 30,6 30,10" stroke="#1e40af" stroke-width="3" fill="none"/>
 </svg>

--- a/public/assets/logo.svg
+++ b/public/assets/logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 100">
+  <rect x="10" y="60" width="25" height="30" fill="#2563eb"/>
+  <rect x="50" y="40" width="25" height="50" fill="#2563eb"/>
+  <rect x="90" y="20" width="25" height="70" fill="#2563eb"/>
+  <path d="M10 60 L50 40 L90 20 L125 30" stroke="#2563eb" stroke-width="8" fill="none"/>
+  <path d="M125 30 L115 25 L115 35 Z" fill="#2563eb"/>
+  <text x="150" y="55" font-size="32" font-family="Arial, sans-serif" fill="#111827">Ecommerce</text>
+  <text x="150" y="85" font-size="32" font-family="Arial, sans-serif" fill="#111827">Analytics</text>
+</svg>

--- a/public/assets/nav-analysis.svg
+++ b/public/assets/nav-analysis.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+  <polyline points="3 17 3 21 21 21"/>
+  <rect x="5" y="13" width="2" height="4" fill="currentColor" stroke="none"/>
+  <rect x="10" y="9" width="2" height="8" fill="currentColor" stroke="none"/>
+  <rect x="15" y="5" width="2" height="12" fill="currentColor" stroke="none"/>
+  <polyline points="3 11 9 7 13 11 21 3"/>
+  <polyline points="17 3 21 3 21 7"/>
+</svg>

--- a/public/assets/nav-analysis.svg
+++ b/public/assets/nav-analysis.svg
@@ -1,8 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2">
   <polyline points="3 17 3 21 21 21"/>
-  <rect x="5" y="13" width="2" height="4" fill="currentColor" stroke="none"/>
-  <rect x="10" y="9" width="2" height="8" fill="currentColor" stroke="none"/>
-  <rect x="15" y="5" width="2" height="12" fill="currentColor" stroke="none"/>
+  <rect x="5" y="13" width="2" height="4" fill="#94a3b8" stroke="none"/>
+  <rect x="10" y="9" width="2" height="8" fill="#94a3b8" stroke="none"/>
+  <rect x="15" y="5" width="2" height="12" fill="#94a3b8" stroke="none"/>
   <polyline points="3 11 9 7 13 11 21 3"/>
   <polyline points="17 3 21 3 21 7"/>
 </svg>

--- a/public/assets/nav-analysis.svg
+++ b/public/assets/nav-analysis.svg
@@ -1,8 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2">
   <polyline points="3 17 3 21 21 21"/>
-  <rect x="5" y="13" width="2" height="4" fill="#94a3b8" stroke="none"/>
-  <rect x="10" y="9" width="2" height="8" fill="#94a3b8" stroke="none"/>
-  <rect x="15" y="5" width="2" height="12" fill="#94a3b8" stroke="none"/>
+  <rect x="5" y="13" width="2" height="4" fill="#fff" stroke="none"/>
+  <rect x="10" y="9" width="2" height="8" fill="#fff" stroke="none"/>
+  <rect x="15" y="5" width="2" height="12" fill="#fff" stroke="none"/>
   <polyline points="3 11 9 7 13 11 21 3"/>
   <polyline points="17 3 21 3 21 7"/>
 </svg>

--- a/public/assets/nav-detail.svg
+++ b/public/assets/nav-detail.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+  <line x1="3" y1="9" x2="21" y2="9"/>
+  <line x1="3" y1="15" x2="21" y2="15"/>
+  <line x1="9" y1="3" x2="9" y2="21"/>
+  <line x1="15" y1="3" x2="15" y2="21"/>
+</svg>

--- a/public/assets/nav-detail.svg
+++ b/public/assets/nav-detail.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2">
   <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
   <line x1="3" y1="9" x2="21" y2="9"/>
   <line x1="3" y1="15" x2="21" y2="15"/>

--- a/public/assets/nav-detail.svg
+++ b/public/assets/nav-detail.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2">
   <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
   <line x1="3" y1="9" x2="21" y2="9"/>
   <line x1="3" y1="15" x2="21" y2="15"/>

--- a/public/assets/nav-product.svg
+++ b/public/assets/nav-product.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-  <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2" fill="none"/>
-  <path d="M12 12V3a9 9 0 0 1 9 9h-9z" fill="currentColor"/>
+  <circle cx="12" cy="12" r="9" stroke="#94a3b8" stroke-width="2" fill="none"/>
+  <path d="M12 12V3a9 9 0 0 1 9 9h-9z" fill="#94a3b8"/>
 </svg>

--- a/public/assets/nav-product.svg
+++ b/public/assets/nav-product.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-  <circle cx="12" cy="12" r="9" stroke="#94a3b8" stroke-width="2" fill="none"/>
-  <path d="M12 12V3a9 9 0 0 1 9 9h-9z" fill="#94a3b8"/>
+  <circle cx="12" cy="12" r="9" stroke="#fff" stroke-width="2" fill="none"/>
+  <path d="M12 12V3a9 9 0 0 1 9 9h-9z" fill="#fff"/>
 </svg>

--- a/public/assets/nav-product.svg
+++ b/public/assets/nav-product.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2" fill="none"/>
+  <path d="M12 12V3a9 9 0 0 1 9 9h-9z" fill="currentColor"/>
+</svg>

--- a/public/assets/site-icon.svg
+++ b/public/assets/site-icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#1e40af"/>
+  <path d="M2 16h28" stroke="#fff" stroke-width="2"/>
+  <ellipse cx="16" cy="16" rx="6" ry="14" stroke="#fff" stroke-width="2" fill="none"/>
+  <ellipse cx="16" cy="16" rx="2" ry="14" stroke="#fff" stroke-width="2" fill="none"/>
+</svg>

--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -48,7 +48,8 @@ body{
   padding:8px 16px;
   box-shadow:0 1px 2px rgba(0,0,0,.05);
 }
-.logo-title{font-weight:700;font-size:16px;color:var(--text);}
+.logo-title{font-weight:700;font-size:16px;color:var(--text);display:flex;align-items:center;gap:8px;}
+.logo-title .site-logo{height:32px;}
 .header-center{flex:1;display:flex;justify-content:center;}
 .header-center .platform-nav{list-style:none;margin:0;padding:0;display:flex;gap:20px;}
 .header-center .platform-nav>li{position:relative;}

--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -123,9 +123,9 @@ body{
 .sidebar .sub-nav{ list-style:none; padding-left:0; margin:0 }
 .sidebar .sub-nav li{ margin-bottom:6px }
 .sidebar .sub-nav a{ display:flex; align-items:center }
-.sidebar .sub-nav .nav-icon{ width:16px; height:16px; margin-right:6px; flex-shrink:0 }
+.sidebar .sub-nav .nav-icon{ width:16px; height:16px; margin-right:6px; flex-shrink:0; opacity:.8 }
 .sidebar .sub-nav a:hover .nav-icon,
-.sidebar .sub-nav a.active .nav-icon{ filter:brightness(0) invert(1); }
+.sidebar .sub-nav a.active .nav-icon{ opacity:1 }
 .sidebar .sub-nav a.active{ color:#fff; background:var(--brand) }
 
 /* ------ Layout ------ */

--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -107,6 +107,8 @@ body{
 }
 .sidebar h3{ margin:0 0 10px; font-size:16px }
 .site-header{ display:flex; align-items:center; justify-content:space-between; margin-bottom:8px; }
+.site-header .site-name{display:flex;align-items:center;gap:4px}
+.site-header .site-icon{width:16px;height:16px}
 .add-site-btn{ background:var(--brand); color:#fff; border:none; border-radius:4px; width:20px; height:20px; cursor:pointer; line-height:20px; text-align:center; }
 .add-site-btn:hover{ background:#2563eb; }
 .sidebar ul{ list-style:none; padding-left:0; margin:0 }

--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -123,7 +123,9 @@ body{
 .sidebar .sub-nav{ list-style:none; padding-left:0; margin:0 }
 .sidebar .sub-nav li{ margin-bottom:6px }
 .sidebar .sub-nav a{ display:flex; align-items:center }
-.sidebar .sub-nav .nav-icon{ width:16px; height:16px; margin-right:6px }
+.sidebar .sub-nav .nav-icon{ width:16px; height:16px; margin-right:6px; flex-shrink:0 }
+.sidebar .sub-nav a:hover .nav-icon,
+.sidebar .sub-nav a.active .nav-icon{ filter:brightness(0) invert(1); }
 .sidebar .sub-nav a.active{ color:#fff; background:var(--brand) }
 
 /* ------ Layout ------ */

--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -122,6 +122,8 @@ body{
 .sidebar .submenu a.active{ color:#fff; background:var(--brand) }
 .sidebar .sub-nav{ list-style:none; padding-left:0; margin:0 }
 .sidebar .sub-nav li{ margin-bottom:6px }
+.sidebar .sub-nav a{ display:flex; align-items:center }
+.sidebar .sub-nav .nav-icon{ width:16px; height:16px; margin-right:6px }
 .sidebar .sub-nav a.active{ color:#fff; background:var(--brand) }
 
 /* ------ Layout ------ */

--- a/public/history.html
+++ b/public/history.html
@@ -3,6 +3,7 @@
 <html lang="zh-CN">
 <head>
   <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>历史数据 - fact_daily_metrics</title>
 

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>跨境电商数据分析平台</title>
   <style>
@@ -57,7 +58,7 @@
 </div>
 
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -78,7 +78,7 @@
 
 <div class="layout">
   <nav class="sidebar" id="sidebar">
-    <div class="site-header"><span id="currentSite">独立站</span></div>
+    <div class="site-header"><div class="site-name"><img src="assets/site-icon.svg" class="site-icon" alt=""><span id="currentSite">独立站</span></div></div>
     <ul class="sub-nav">
       <li><a href="#" data-jump="detail" class="active"><img src="assets/nav-detail.svg" class="nav-icon" alt="">明细数据</a></li>
       <li><a href="#" data-jump="analysis"><img src="assets/nav-analysis.svg" class="nav-icon" alt="">运营分析</a></li>

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -80,9 +80,9 @@
   <nav class="sidebar" id="sidebar">
     <div class="site-header"><span id="currentSite">独立站</span></div>
     <ul class="sub-nav">
-      <li><a href="#" data-jump="detail" class="active">明细数据</a></li>
-      <li><a href="#" data-jump="analysis">运营分析</a></li>
-      <li><a href="product-analysis.html?mode=indep">产品分析</a></li>
+      <li><a href="#" data-jump="detail" class="active"><img src="assets/nav-detail.svg" class="nav-icon" alt="">明细数据</a></li>
+      <li><a href="#" data-jump="analysis"><img src="assets/nav-analysis.svg" class="nav-icon" alt="">运营分析</a></li>
+      <li><a href="product-analysis.html?mode=indep"><img src="assets/nav-product.svg" class="nav-icon" alt="">产品分析</a></li>
     </ul>
   </nav>
 

--- a/public/index.html
+++ b/public/index.html
@@ -87,9 +87,9 @@
   <nav class="sidebar" id="sidebar">
     <div class="site-header"><span id="currentSite">自运营 A站</span><button id="addSite" class="add-site-btn">+</button></div>
     <ul class="sub-nav">
-      <li><a href="#" class="active" data-target="detail">详细数据</a></li>
-      <li><a href="operation-analysis.html?mode=self">运营分析</a></li>
-      <li><a href="product-analysis.html?mode=self">产品分析</a></li>
+      <li><a href="#" class="active" data-target="detail"><img src="assets/nav-detail.svg" class="nav-icon" alt="">详细数据</a></li>
+      <li><a href="operation-analysis.html?mode=self"><img src="assets/nav-analysis.svg" class="nav-icon" alt="">运营分析</a></li>
+      <li><a href="product-analysis.html?mode=self"><img src="assets/nav-product.svg" class="nav-icon" alt="">产品分析</a></li>
     </ul>
   </nav>
 

--- a/public/index.html
+++ b/public/index.html
@@ -85,7 +85,7 @@
 </header>
 <div class="layout container">
   <nav class="sidebar" id="sidebar">
-    <div class="site-header"><span id="currentSite">自运营 A站</span><button id="addSite" class="add-site-btn">+</button></div>
+    <div class="site-header"><div class="site-name"><img src="assets/site-icon.svg" class="site-icon" alt=""><span id="currentSite">自运营 A站</span></div><button id="addSite" class="add-site-btn">+</button></div>
     <ul class="sub-nav">
       <li><a href="#" class="active" data-target="detail"><img src="assets/nav-detail.svg" class="nav-icon" alt="">详细数据</a></li>
       <li><a href="operation-analysis.html?mode=self"><img src="assets/nav-analysis.svg" class="nav-icon" alt="">运营分析</a></li>

--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html lang="zh">
 <head>
   <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <title>跨境电商数据分析平台</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- libs -->
@@ -65,7 +66,7 @@
   </div>
 </div>
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali active"><a href="#">速卖通</a>

--- a/public/index未加新产品统计.html
+++ b/public/index未加新产品统计.html
@@ -3,6 +3,7 @@
 <html lang="zh-CN">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>速卖通全托管数据分析</title>
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">

--- a/public/login.html
+++ b/public/login.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <title>登录</title>
   <link rel="stylesheet" href="assets/login.css">
   <link rel="stylesheet" href="assets/theme.css">

--- a/public/managed.html
+++ b/public/managed.html
@@ -87,7 +87,7 @@
 </header>
 <div class="layout container">
   <nav class="sidebar" id="sidebar">
-    <div class="site-header"><span id="currentSite">全托管</span><button id="addSite" class="add-site-btn">+</button></div>
+    <div class="site-header"><div class="site-name"><img src="assets/site-icon.svg" class="site-icon" alt=""><span id="currentSite">全托管</span></div><button id="addSite" class="add-site-btn">+</button></div>
     <ul class="sub-nav">
       <li><a href="#" class="active" data-target="detail"><img src="assets/nav-detail.svg" class="nav-icon" alt="">详细数据</a></li>
       <li><a href="operation-analysis.html?mode=fm"><img src="assets/nav-analysis.svg" class="nav-icon" alt="">运营分析</a></li>

--- a/public/managed.html
+++ b/public/managed.html
@@ -89,9 +89,9 @@
   <nav class="sidebar" id="sidebar">
     <div class="site-header"><span id="currentSite">全托管</span><button id="addSite" class="add-site-btn">+</button></div>
     <ul class="sub-nav">
-      <li><a href="#" class="active" data-target="detail">详细数据</a></li>
-      <li><a href="operation-analysis.html?mode=fm">运营分析</a></li>
-      <li><a href="product-analysis.html?mode=fm">产品分析</a></li>
+      <li><a href="#" class="active" data-target="detail"><img src="assets/nav-detail.svg" class="nav-icon" alt="">详细数据</a></li>
+      <li><a href="operation-analysis.html?mode=fm"><img src="assets/nav-analysis.svg" class="nav-icon" alt="">运营分析</a></li>
+      <li><a href="product-analysis.html?mode=fm"><img src="assets/nav-product.svg" class="nav-icon" alt="">产品分析</a></li>
     </ul>
   </nav>
 

--- a/public/managed.html
+++ b/public/managed.html
@@ -3,6 +3,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>跨境电商数据分析平台</title>
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
@@ -67,7 +68,7 @@
   </div>
 </div>
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali active"><a href="#">速卖通</a>

--- a/public/operation-analysis.html
+++ b/public/operation-analysis.html
@@ -33,7 +33,7 @@
 </header>
 <div class="layout container">
   <nav class="sidebar" id="sidebar">
-    <div class="site-header"><span id="currentSite"></span><button id="addSite" class="add-site-btn">+</button></div>
+    <div class="site-header"><div class="site-name"><img src="assets/site-icon.svg" class="site-icon" alt=""><span id="currentSite"></span></div><button id="addSite" class="add-site-btn">+</button></div>
     <ul class="sub-nav">
       <li><a id="detailLink" href="managed.html"><img src="assets/nav-detail.svg" class="nav-icon" alt="">详细数据</a></li>
       <li><a class="active" href="#"><img src="assets/nav-analysis.svg" class="nav-icon" alt="">运营分析</a></li>

--- a/public/operation-analysis.html
+++ b/public/operation-analysis.html
@@ -35,9 +35,9 @@
   <nav class="sidebar" id="sidebar">
     <div class="site-header"><span id="currentSite"></span><button id="addSite" class="add-site-btn">+</button></div>
     <ul class="sub-nav">
-      <li><a id="detailLink" href="managed.html">详细数据</a></li>
-      <li><a class="active" href="#">运营分析</a></li>
-      <li><a id="productLink" href="product-analysis.html">产品分析</a></li>
+      <li><a id="detailLink" href="managed.html"><img src="assets/nav-detail.svg" class="nav-icon" alt="">详细数据</a></li>
+      <li><a class="active" href="#"><img src="assets/nav-analysis.svg" class="nav-icon" alt="">运营分析</a></li>
+      <li><a id="productLink" href="product-analysis.html"><img src="assets/nav-product.svg" class="nav-icon" alt="">产品分析</a></li>
     </ul>
   </nav>
   <main class="main">

--- a/public/operation-analysis.html
+++ b/public/operation-analysis.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>运营分析</title>
   <link rel="stylesheet" href="assets/theme.css?v=20250812-deep">
@@ -13,7 +14,7 @@
 </head>
 <body>
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali active"><a href="#">速卖通</a>

--- a/public/ozon-analysis.html
+++ b/public/ozon-analysis.html
@@ -36,9 +36,9 @@
   <nav class="sidebar" id="sidebar">
     <div class="site-header"><span>Ozon</span></div>
     <ul class="sub-nav">
-      <li><a href="ozon-detail.html">数据明细</a></li>
-      <li><a href="ozon-analysis.html" class="active">运营分析</a></li>
-      <li><a href="ozon-product-insights.html">产品分析</a></li>
+      <li><a href="ozon-detail.html"><img src="assets/nav-detail.svg" class="nav-icon" alt="">数据明细</a></li>
+      <li><a href="ozon-analysis.html" class="active"><img src="assets/nav-analysis.svg" class="nav-icon" alt="">运营分析</a></li>
+      <li><a href="ozon-product-insights.html"><img src="assets/nav-product.svg" class="nav-icon" alt="">产品分析</a></li>
     </ul>
   </nav>
   <main class="main">

--- a/public/ozon-analysis.html
+++ b/public/ozon-analysis.html
@@ -34,7 +34,7 @@
 </header>
 <div class="layout container">
   <nav class="sidebar" id="sidebar">
-    <div class="site-header"><span>Ozon</span></div>
+    <div class="site-header"><div class="site-name"><img src="assets/site-icon.svg" class="site-icon" alt=""><span>Ozon</span></div></div>
     <ul class="sub-nav">
       <li><a href="ozon-detail.html"><img src="assets/nav-detail.svg" class="nav-icon" alt="">数据明细</a></li>
       <li><a href="ozon-analysis.html" class="active"><img src="assets/nav-analysis.svg" class="nav-icon" alt="">运营分析</a></li>

--- a/public/ozon-analysis.html
+++ b/public/ozon-analysis.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Ozon 运营分析</title>
   <link rel="stylesheet" href="assets/login.css">
@@ -14,7 +15,7 @@
 </head>
 <body class="fm">
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -41,7 +41,7 @@
 </header>
 <div class="layout container">
   <nav class="sidebar" id="sidebar">
-    <div class="site-header"><span>Ozon</span></div>
+    <div class="site-header"><div class="site-name"><img src="assets/site-icon.svg" class="site-icon" alt=""><span>Ozon</span></div></div>
     <ul class="sub-nav">
       <li><a href="ozon-detail.html" class="active"><img src="assets/nav-detail.svg" class="nav-icon" alt="">数据明细</a></li>
       <li><a href="ozon-analysis.html"><img src="assets/nav-analysis.svg" class="nav-icon" alt="">运营分析</a></li>

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -43,9 +43,9 @@
   <nav class="sidebar" id="sidebar">
     <div class="site-header"><span>Ozon</span></div>
     <ul class="sub-nav">
-      <li><a href="ozon-detail.html" class="active">数据明细</a></li>
-      <li><a href="ozon-analysis.html">运营分析</a></li>
-      <li><a href="ozon-product-insights.html">产品分析</a></li>
+      <li><a href="ozon-detail.html" class="active"><img src="assets/nav-detail.svg" class="nav-icon" alt="">数据明细</a></li>
+      <li><a href="ozon-analysis.html"><img src="assets/nav-analysis.svg" class="nav-icon" alt="">运营分析</a></li>
+      <li><a href="ozon-product-insights.html"><img src="assets/nav-product.svg" class="nav-icon" alt="">产品分析</a></li>
     </ul>
   </nav>
   <main class="main">

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Ozon 数据明细</title>
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
@@ -21,7 +22,7 @@
 </head>
 <body class="fm">
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>

--- a/public/ozon-product-insights.html
+++ b/public/ozon-product-insights.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Ozon 产品分析</title>
   <link rel="stylesheet" href="assets/login.css">
@@ -13,7 +14,7 @@
 </head>
 <body class="fm">
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>

--- a/public/ozon-product-insights.html
+++ b/public/ozon-product-insights.html
@@ -33,7 +33,7 @@
 </header>
 <div class="layout container">
   <nav class="sidebar" id="sidebar">
-    <div class="site-header"><span>Ozon</span></div>
+    <div class="site-header"><div class="site-name"><img src="assets/site-icon.svg" class="site-icon" alt=""><span>Ozon</span></div></div>
     <ul class="sub-nav">
       <li><a href="ozon-detail.html"><img src="assets/nav-detail.svg" class="nav-icon" alt="">数据明细</a></li>
       <li><a href="ozon-analysis.html"><img src="assets/nav-analysis.svg" class="nav-icon" alt="">运营分析</a></li>

--- a/public/ozon-product-insights.html
+++ b/public/ozon-product-insights.html
@@ -35,9 +35,9 @@
   <nav class="sidebar" id="sidebar">
     <div class="site-header"><span>Ozon</span></div>
     <ul class="sub-nav">
-      <li><a href="ozon-detail.html">数据明细</a></li>
-      <li><a href="ozon-analysis.html">运营分析</a></li>
-      <li><a href="ozon-product-insights.html" class="active">产品分析</a></li>
+      <li><a href="ozon-detail.html"><img src="assets/nav-detail.svg" class="nav-icon" alt="">数据明细</a></li>
+      <li><a href="ozon-analysis.html"><img src="assets/nav-analysis.svg" class="nav-icon" alt="">运营分析</a></li>
+      <li><a href="ozon-product-insights.html" class="active"><img src="assets/nav-product.svg" class="nav-icon" alt="">产品分析</a></li>
     </ul>
   </nav>
   <main class="main">

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -34,7 +34,7 @@
 </header>
 <div class="layout container">
   <nav class="sidebar" id="sidebar">
-    <div class="site-header"><span id="currentSite"></span><button id="addSite" class="add-site-btn">+</button></div>
+    <div class="site-header"><div class="site-name"><img src="assets/site-icon.svg" class="site-icon" alt=""><span id="currentSite"></span></div><button id="addSite" class="add-site-btn">+</button></div>
     <ul class="sub-nav">
       <li><a id="detailLink" href="managed.html"><img src="assets/nav-detail.svg" class="nav-icon" alt="">详细数据</a></li>
       <li><a id="analysisLink" href="operation-analysis.html"><img src="assets/nav-analysis.svg" class="nav-icon" alt="">运营分析</a></li>

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>产品分析</title>
   <link rel="stylesheet" href="assets/theme.css?v=20250812-deep">
@@ -14,7 +15,7 @@
 </head>
 <body>
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -36,9 +36,9 @@
   <nav class="sidebar" id="sidebar">
     <div class="site-header"><span id="currentSite"></span><button id="addSite" class="add-site-btn">+</button></div>
     <ul class="sub-nav">
-      <li><a id="detailLink" href="managed.html">详细数据</a></li>
-      <li><a id="analysisLink" href="operation-analysis.html">运营分析</a></li>
-      <li><a class="active" href="#">产品分析</a></li>
+      <li><a id="detailLink" href="managed.html"><img src="assets/nav-detail.svg" class="nav-icon" alt="">详细数据</a></li>
+      <li><a id="analysisLink" href="operation-analysis.html"><img src="assets/nav-analysis.svg" class="nav-icon" alt="">运营分析</a></li>
+      <li><a class="active" href="#"><img src="assets/nav-product.svg" class="nav-icon" alt="">产品分析</a></li>
     </ul>
   </nav>
   <main class="main">

--- a/public/self-operatedctr计算不正确.html
+++ b/public/self-operatedctr计算不正确.html
@@ -2,6 +2,7 @@
 <html lang="zh">
 <head>
   <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <title>自运营数据分析 · 对比增强版</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- libs -->

--- a/public/temu.html
+++ b/public/temu.html
@@ -30,7 +30,7 @@
 </header>
 <div class="layout container">
   <nav class="sidebar" id="sidebar">
-    <div class="site-header"><span>站点</span></div>
+    <div class="site-header"><div class="site-name"><img src="assets/site-icon.svg" class="site-icon" alt=""><span>站点</span></div></div>
     <ul class="sub-nav">
       <li><a href="#" class="active">页面建设中</a></li>
     </ul>

--- a/public/temu.html
+++ b/public/temu.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Temu 数据分析（建设中）</title>
   <link rel="stylesheet" href="assets/login.css">
@@ -10,7 +11,7 @@
 </head>
 <body class="fm">
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>

--- a/public/tiktok.html
+++ b/public/tiktok.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TikTok Shop 数据分析（建设中）</title>
   <link rel="stylesheet" href="assets/login.css">
@@ -10,7 +11,7 @@
 </head>
 <body class="fm">
 <header class="header">
-  <div class="logo-title">跨境电商数据分析平台</div>
+  <div class="logo-title"><img src="assets/logo.svg" alt="Ecommerce Analytics" class="site-logo"> 跨境电商数据分析平台</div>
   <nav class="header-center">
     <ul class="platform-nav">
       <li class="ali"><a href="#">速卖通</a>

--- a/public/tiktok.html
+++ b/public/tiktok.html
@@ -30,7 +30,7 @@
 </header>
 <div class="layout container">
   <nav class="sidebar" id="sidebar">
-    <div class="site-header"><span>站点</span></div>
+    <div class="site-header"><div class="site-name"><img src="assets/site-icon.svg" class="site-icon" alt=""><span>站点</span></div></div>
     <ul class="sub-nav">
       <li><a href="#" class="active">页面建设中</a></li>
     </ul>


### PR DESCRIPTION
## Summary
- Add SVG logo and use it across pages as site branding and favicon.
- Replace favicon with larger SVG version for improved visibility in browser tabs.
- Style header to display logo image alongside existing title.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae84f058848325bea41c011843188b