### PR TITLE
feat: add icyberite independent site pages

### DIFF
--- a/public/assets/site-nav.js
+++ b/public/assets/site-nav.js
@@ -34,7 +34,7 @@
       try{
         const resp=await fetch('/api/independent/sites');
         const j=await resp.json();
-        const sites=Array.from(new Set((j.sites||[]).filter(Boolean)));
+        const sites=Array.from(new Set([...(j.sites||[]), 'icyberite.com'].filter(Boolean)));
         sites.forEach(name=>{
           const li=document.createElement('li');
           const a=document.createElement('a');

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -85,8 +85,8 @@
       </div>
     </div>
     <ul class="sub-nav">
-      <li><a href="#" data-jump="detail" class="active">明细数据</a></li>
-      <li><a href="#" data-jump="analysis">运营分析</a></li>
+      <li><a href="independent-site.html#detail" data-jump="detail" class="active">明细表（Facebook）</a></li>
+      <li><a href="independent-site.html#analysis" data-jump="analysis">运营分析</a></li>
       <li><a href="product-analysis.html?mode=indep">产品分析</a></li>
     </ul>
   </nav>

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -555,7 +555,7 @@
   try{
     const resp=await fetch("/api/independent/sites");
     const j=await resp.json();
-    const sites=Array.from(new Set((j.sites||[]).filter(Boolean)));
+    const sites=Array.from(new Set([...(j.sites||[]), 'icyberite.com'].filter(Boolean)));
     siteSelect.innerHTML=sites.map(s=>`<option value="${s}">${s}</option>`).join("");
     let cur=localStorage.getItem("currentIndepSite");
     if(!cur||!sites.includes(cur)) cur=sites[0]||"";

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -117,7 +117,10 @@ document.addEventListener('DOMContentLoaded',()=>{
     if(detailLink)detailLink.href='index.html';
     if(analysisLink)analysisLink.href='operation-analysis.html?mode=self';
   }else if(mode==='indep'){
-    if(detailLink)detailLink.href='independent-site.html';
+    if(detailLink){
+      detailLink.href='independent-site.html#detail';
+      detailLink.innerHTML = detailLink.innerHTML.replace('详细数据','明细表（Facebook）');
+    }
     if(analysisLink)analysisLink.href='independent-site.html#analysis';
   }else if(mode==='ozon'){
     if(detailLink)detailLink.href='ozon-detail.html';

--- a/public/product-analysis.html
+++ b/public/product-analysis.html
@@ -135,7 +135,7 @@ document.addEventListener('DOMContentLoaded',()=>{
     if(addBtn) addBtn.style.display='none';
     renderSiteMenus();
     fetch('/api/independent/sites').then(r=>r.json()).then(j=>{
-      const sites=j.sites||[];
+      const sites=Array.from(new Set([...(j.sites||[]), 'icyberite.com'].filter(Boolean)));
       const paramSite=params.get('site');
       const stored=localStorage.getItem('currentIndepSite');
       let site=sites[0]||'';


### PR DESCRIPTION
## Summary
- rename independent site detail tab to "明细表（Facebook）" and link to analysis/product pages
- adjust product analysis navigation for independent sites to point back to the new detail and analysis views

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aed2fcbe608325acba577ce820e73d