### PR TITLE
Add Meta advertising schema and migration wiring

### DIFF
--- a/api/lib/date.js
+++ b/api/lib/date.js
@@ -1,0 +1,28 @@
+const XLSX = require('xlsx');
+
+function parseDay(dayRaw) {
+  if (dayRaw === null || dayRaw === undefined || dayRaw === '') return null;
+
+  if (typeof dayRaw === 'number') {
+    const s = String(dayRaw);
+    if (/^\d{8}$/.test(s)) {
+      return new Date(Date.UTC(+s.slice(0,4), +s.slice(4,6)-1, +s.slice(6,8)));
+    }
+    const parsed = XLSX.SSF && XLSX.SSF.parse_date_code(dayRaw);
+    if (parsed && parsed.y && parsed.m && parsed.d) {
+      return new Date(Date.UTC(parsed.y, parsed.m-1, parsed.d));
+    }
+    return null;
+  }
+
+  const s = String(dayRaw).trim();
+  const m = s.match(/^(\d{4})[\/\-](\d{1,2})[\/\-](\d{1,2})$/);
+  if (m) return new Date(Date.UTC(+m[1], +m[2]-1, +m[3]));
+  if (/^\d{8}$/.test(s)) {
+    return new Date(Date.UTC(+s.slice(0,4), +s.slice(4,6)-1, +s.slice(6,8)));
+  }
+  const d = new Date(s);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+module.exports = { parseDay };

--- a/api/lib/date.test.js
+++ b/api/lib/date.test.js
@@ -1,20 +1,19 @@
-const { _parseDay } = require('./index.js');
+const { parseDay } = require('./date.js');
 const test = require('node:test');
 const assert = require('assert');
 
 test('parses slash-separated date', () => {
-  const d = _parseDay('2025/8/18');
+  const d = parseDay('2025/8/18');
   assert.ok(d);
   assert.strictEqual(d.toISOString().slice(0,10), '2025-08-18');
 });
 
 test('parses numeric yyyymmdd', () => {
-  const d = _parseDay(20250818);
+  const d = parseDay(20250818);
   assert.ok(d);
   assert.strictEqual(d.toISOString().slice(0,10), '2025-08-18');
 });
 
 test('invalid date returns null', () => {
-  assert.strictEqual(_parseDay('not-a-date'), null);
+  assert.strictEqual(parseDay('not-a-date'), null);
 });
-

--- a/api/meta/ingest/index.js
+++ b/api/meta/ingest/index.js
@@ -1,0 +1,215 @@
+// /api/meta/ingest/index.js
+// Ingest Facebook (Meta) Ads export into staging (fb_raw) and aggregated fact table.
+// Env: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY or SUPABASE_ANON_KEY
+
+const { createClient } = require('@supabase/supabase-js');
+const formidable = require('formidable').default;
+const XLSX = require('xlsx');
+const { randomUUID } = require('crypto');
+const { parseDay } = require('../../lib/date');
+
+function getClient() {
+  const url = process.env.SUPABASE_URL;
+  const key =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.SUPABASE_SERVICE_ROLE ||
+    process.env.SUPABASE_ANON_KEY;
+  if (!url || !key) throw new Error('Supabase env not configured');
+  return createClient(url, key);
+}
+
+function toNumber(v) {
+  if (v === null || v === undefined || v === '' || v === '--') return 0;
+  let s = String(v).trim();
+  if (s.includes(',') && !s.includes('.')) s = s.replace(',', '.');
+  s = s.replace(/[^0-9.-]/g, '');
+  const n = Number(s);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function canon(s) {
+  return String(s || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ ok: false, error: 'Use POST with multipart/form-data' });
+    return;
+  }
+
+  const form = formidable({ multiples: false, keepExtensions: true });
+
+  try {
+    const { fields, files } = await new Promise((resolve, reject) => {
+      form.parse(req, (err, fields, files) => {
+        if (err) reject(err); else resolve({ fields, files });
+      });
+    });
+    const uploaded = Array.isArray(files.file) ? files.file[0] : files.file;
+    if (!uploaded) throw new Error('No file uploaded. Use field name "file".');
+    const filePath = uploaded.filepath || uploaded.path;
+    if (!filePath) throw new Error('Upload failed: file path missing.');
+
+    const site = String(fields.site || '').trim();
+    if (!site) throw new Error('Missing form field "site"');
+    const batchId = randomUUID();
+
+    const wb = XLSX.readFile(filePath, { raw: false });
+    const ws = wb.Sheets[wb.SheetNames[0]];
+    const rows = XLSX.utils.sheet_to_json(ws, { header: 1 });
+    const header = rows[0] || [];
+    const dataRows = rows.slice(1);
+    const headerCanon = header.map(canon);
+    const col = (...names) => {
+      for (const n of names) {
+        const idx = headerCanon.indexOf(canon(n));
+        if (idx !== -1) return idx;
+      }
+      return -1;
+    };
+
+    const cDate = col('date', 'day', 'reportingstarts');
+    const cCampaignId = col('campaignid');
+    const cCampaignName = col('campaignname');
+    const cAdsetId = col('adsetid', 'adsetid_');
+    const cAdsetName = col('adsetname', 'adsetname_');
+    const cAdId = col('adid');
+    const cAdName = col('adname');
+    const cImpressions = col('impressions');
+    const cClicks = col('linkclicks', 'clicks');
+    const cSpend = col('amountspent', 'spend');
+    const cCurrency = col('currency');
+    const cAtc = col('addtocart', 'addtocarttotal', 'addtocartactions');
+    const cIc = col('initiatecheckout');
+    const cPurchase = col('purchases');
+
+    const rawRows = [];
+    const aggMap = new Map();
+    const campaigns = new Map();
+    const adsets = new Map();
+    const ads = new Map();
+
+    for (const r of dataRows) {
+      const day = parseDay(r[cDate]);
+      if (!day) continue;
+      const dayStr = day.toISOString().slice(0, 10);
+      const campaignId = String(r[cCampaignId] || '').trim();
+      const adsetId = String(r[cAdsetId] || '').trim();
+      const adId = String(r[cAdId] || '').trim();
+      const payload = {
+        batch_id: batchId,
+        date: dayStr,
+        campaign_id: campaignId || null,
+        campaign_name: String(r[cCampaignName] || '').trim() || null,
+        adset_id: adsetId || null,
+        adset_name: String(r[cAdsetName] || '').trim() || null,
+        ad_id: adId || null,
+        ad_name: String(r[cAdName] || '').trim() || null,
+        currency: cCurrency >= 0 ? String(r[cCurrency] || '').trim() : null,
+        impressions: cImpressions >= 0 ? toNumber(r[cImpressions]) : 0,
+        clicks: cClicks >= 0 ? toNumber(r[cClicks]) : 0,
+        spend: cSpend >= 0 ? toNumber(r[cSpend]) : 0,
+        add_to_cart: cAtc >= 0 ? toNumber(r[cAtc]) : 0,
+        initiate_checkout: cIc >= 0 ? toNumber(r[cIc]) : 0,
+        purchases: cPurchase >= 0 ? toNumber(r[cPurchase]) : 0,
+      };
+      payload.cpc = payload.clicks ? payload.spend / payload.clicks : null;
+      payload.cpm = payload.impressions ? (payload.spend / payload.impressions) * 1000 : null;
+      payload.ctr = payload.impressions ? (payload.clicks / payload.impressions) : null;
+
+      rawRows.push({ site_id: site, channel_id: 'meta_ads', payload });
+
+      if (campaignId) campaigns.set(campaignId, {
+        campaign_id: campaignId,
+        site_id: site,
+        campaign_name: payload.campaign_name || null,
+      });
+      if (adsetId) adsets.set(adsetId, {
+        adset_id: adsetId,
+        site_id: site,
+        campaign_id: campaignId || null,
+        adset_name: payload.adset_name || null,
+      });
+      if (adId) ads.set(adId, {
+        ad_id: adId,
+        site_id: site,
+        adset_id: adsetId || null,
+        ad_name: payload.ad_name || null,
+      });
+
+      const key = [dayStr, campaignId, adsetId, adId].join('|');
+      if (!aggMap.has(key)) {
+        aggMap.set(key, {
+          site_id: site,
+          date: dayStr,
+          level: 'ad',
+          campaign_id: campaignId || null,
+          adset_id: adsetId || null,
+          ad_id: adId || null,
+          impressions: 0,
+          all_clicks: 0,
+          link_clicks: 0,
+          spend_usd: 0,
+          atc_total: 0,
+          ic_total: 0,
+          purchase_meta: 0,
+          batch_id: batchId,
+        });
+      }
+      const ag = aggMap.get(key);
+      ag.impressions += payload.impressions;
+      ag.all_clicks += payload.clicks;
+      ag.link_clicks += payload.clicks;
+      ag.spend_usd += payload.spend;
+      ag.atc_total += payload.add_to_cart;
+      ag.ic_total += payload.initiate_checkout;
+      ag.purchase_meta += payload.purchases;
+    }
+
+    const dailyRows = Array.from(aggMap.values()).map(r => {
+      return {
+        ...r,
+        ctr_all: r.impressions ? r.all_clicks / r.impressions : null,
+        ctr_link: r.impressions ? r.link_clicks / r.impressions : null,
+        cpm: r.impressions ? (r.spend_usd / r.impressions) * 1000 : null,
+        cpc_all: r.all_clicks ? r.spend_usd / r.all_clicks : null,
+        cpc_link: r.link_clicks ? r.spend_usd / r.link_clicks : null,
+      };
+    });
+
+    const supabase = getClient();
+
+    if (rawRows.length) {
+      await supabase.from('fb_raw').insert(rawRows);
+    }
+    if (campaigns.size) {
+      await supabase.from('meta_campaign').upsert(Array.from(campaigns.values()), { onConflict: 'campaign_id' });
+    }
+    if (adsets.size) {
+      await supabase.from('meta_adset').upsert(Array.from(adsets.values()), { onConflict: 'adset_id' });
+    }
+    if (ads.size) {
+      await supabase.from('meta_ad').upsert(Array.from(ads.values()), { onConflict: 'ad_id' });
+    }
+    if (dailyRows.length) {
+      await supabase.from('fact_meta_daily').upsert(dailyRows, { onConflict: 'site_id,date,level,campaign_id,adset_id,ad_id,product_id' });
+    }
+    await supabase.from('core_ingestion_batch').insert({
+      batch_id: batchId,
+      site_id: site,
+      channel_id: 'meta_ads',
+      file_name: uploaded.originalFilename || uploaded.newFilename || uploaded.name,
+      row_count: rawRows.length,
+    });
+
+    res.status(200).json({ ok: true, rows: rawRows.length, batch_id: batchId });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: e.message });
+  }
+}
+
+handler.config = {
+  api: { bodyParser: false },
+};
+
+module.exports = handler;

--- a/meta.sql
+++ b/meta.sql
@@ -1,0 +1,185 @@
+-- Meta advertising schema and related helpers
+
+-- Core site table
+create table if not exists core_site (
+  site_id       text primary key,
+  domain        text not null,
+  brand_name    text,
+  created_at    timestamptz default now()
+);
+
+-- Channel registry
+create table if not exists core_channel (
+  channel_id    text primary key,
+  display_name  text not null
+);
+
+-- Datasource definitions (template mapping, currency, timezone)
+create table if not exists core_datasource (
+  datasource_id uuid primary key default gen_random_uuid(),
+  site_id       text references core_site(site_id) on delete cascade,
+  channel_id    text references core_channel(channel_id),
+  name          text,
+  currency      text default 'USD',
+  timezone      text default 'UTC',
+  mapping_json  jsonb not null,
+  created_at    timestamptz default now()
+);
+
+-- Raw staging uploads
+create table if not exists fb_raw (
+  raw_id     bigserial primary key,
+  site_id    text references core_site(site_id),
+  channel_id text references core_channel(channel_id) default 'meta_ads',
+  payload    jsonb not null,
+  created_at timestamptz default now()
+);
+
+-- Ingestion batch log
+create table if not exists core_ingestion_batch (
+  batch_id      uuid primary key default gen_random_uuid(),
+  site_id       text references core_site(site_id),
+  channel_id    text references core_channel(channel_id),
+  datasource_id uuid references core_datasource(datasource_id),
+  file_name     text,
+  file_hash     text,
+  report_start  date,
+  report_end    date,
+  row_count     int,
+  created_at    timestamptz default now(),
+  unique(file_hash)
+);
+
+-- Campaign dimension
+create table if not exists meta_campaign (
+  campaign_id   text primary key,
+  site_id       text references core_site(site_id),
+  campaign_name text,
+  objective     text,
+  status        text,
+  created_at    timestamptz default now()
+);
+
+-- Adset dimension
+create table if not exists meta_adset (
+  adset_id    text primary key,
+  site_id     text references core_site(site_id),
+  campaign_id text references meta_campaign(campaign_id) on delete cascade,
+  adset_name  text,
+  status      text,
+  created_at  timestamptz default now()
+);
+
+-- Ad dimension
+create table if not exists meta_ad (
+  ad_id        text primary key,
+  site_id      text references core_site(site_id),
+  adset_id     text references meta_adset(adset_id) on delete cascade,
+  ad_name      text,
+  creative_name text,
+  landing_url  text,
+  status       text,
+  created_at   timestamptz default now()
+);
+
+-- Daily fact table
+create table if not exists fact_meta_daily (
+  site_id       text references core_site(site_id),
+  date          date not null,
+  level         text,
+  campaign_id   text,
+  adset_id      text,
+  ad_id         text,
+  product_id    text,
+
+  reach         bigint default 0,
+  impressions   bigint default 0,
+  frequency     numeric(10,4),
+  all_clicks    bigint default 0,
+  link_clicks   bigint default 0,
+  ctr_all       numeric(10,6),
+  ctr_link      numeric(10,6),
+  spend_usd     numeric(18,6) default 0,
+  cpm           numeric(18,6),
+  cpc_all       numeric(18,6),
+  cpc_link      numeric(18,6),
+
+  atc_total     int default 0,
+  atc_web       int default 0,
+  atc_meta      int default 0,
+  ic_total      int default 0,
+  ic_web        int default 0,
+  ic_meta       int default 0,
+  purchase_web  int default 0,
+  purchase_meta int default 0,
+
+  batch_id      uuid references core_ingestion_batch(batch_id),
+  primary key (site_id, date, level, campaign_id, adset_id, ad_id, product_id)
+);
+
+create index if not exists idx_fact_meta_daily_site_date on fact_meta_daily(site_id, date);
+create index if not exists idx_fact_meta_daily_rollup on fact_meta_daily(site_id, level, campaign_id, adset_id);
+
+-- Product identifier mapping
+create table if not exists product_map (
+  map_id         uuid primary key default gen_random_uuid(),
+  site_id        text references core_site(site_id),
+  raw_identifier text not null,
+  product_id     text,
+  confidence     int default 100,
+  unique(site_id, raw_identifier)
+);
+
+-- Weekly materialized view
+create materialized view if not exists mv_meta_weekly as
+select
+  site_id,
+  date_trunc('week', date)::date as week_start,
+  max(date) as week_end,
+  level, campaign_id, adset_id, ad_id, product_id,
+  sum(reach) as reach,
+  sum(impressions) as impressions,
+  sum(spend_usd) as spend_usd,
+  sum(all_clicks) as all_clicks,
+  sum(link_clicks) as link_clicks,
+  sum(atc_web) as atc_web,
+  sum(ic_web) as ic_web,
+  sum(purchase_web) as purchase_web,
+  (case when sum(impressions)>0 then sum(spend_usd)/sum(impressions)*1000 end) as cpm,
+  (case when sum(link_clicks)>0 then sum(spend_usd)/sum(link_clicks) end) as cpc_link
+from fact_meta_daily
+group by 1,2,4,5,6,7,8;
+
+create index if not exists idx_mv_meta_weekly on mv_meta_weekly(site_id, week_start);
+
+-- Product level materialized view
+create materialized view if not exists mv_meta_product as
+select
+  site_id,
+  product_id,
+  sum(reach) as reach,
+  sum(impressions) as impressions,
+  sum(spend_usd) as spend_usd,
+  sum(link_clicks) as link_clicks,
+  sum(atc_web) as atc_web,
+  sum(ic_web) as ic_web,
+  sum(purchase_web) as purchase_web,
+  (case when sum(impressions)>0 then sum(spend_usd)/sum(impressions)*1000 end) as cpm,
+  (case when sum(link_clicks)>0 then sum(spend_usd)/sum(link_clicks) end) as cpc_link
+from fact_meta_daily
+group by site_id, product_id;
+
+create index if not exists idx_mv_meta_product on mv_meta_product(site_id, product_id);
+
+-- Schema cache refresh helper
+create or replace function public.refresh_meta_schema_cache()
+returns void
+language plpgsql
+security definer
+as $$
+begin
+  perform pg_notify('pgrst', 'reload schema');
+end;
+$$;
+
+select public.refresh_meta_schema_cache();

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "migrate": "bash scripts/migrate.sh"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.45.4",

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${SUPABASE_DB_URL:?SUPABASE_DB_URL environment variable is required}"
+
+for f in independent.sql ozon.sql meta.sql; do
+  if [ -f "$f" ]; then
+    psql "$SUPABASE_DB_URL" -f "$f"
+  fi
+done


### PR DESCRIPTION
## Summary
- add SQL schema for Meta advertising tables, materialized views, and schema cache refresh
- provide migration script hooking meta.sql into deploy process

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aef2f6b8e48325a23c849f258c51ff