### PR TITLE
feat: add independent landing path search

### DIFF
--- a/api/independent/search/index.js
+++ b/api/independent/search/index.js
@@ -1,0 +1,63 @@
+const { createClient } = require('@supabase/supabase-js');
+
+function getClient(){
+  const url = process.env.SUPABASE_URL;
+  const key =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.SUPABASE_SERVICE_ROLE ||
+    process.env.SUPABASE_ANON_KEY;
+  if(!url || !key) throw new Error('Supabase env not configured');
+  return createClient(url,key);
+}
+
+function safeNum(v){
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function aggregate(rows){
+  const map = {};
+  (rows||[]).forEach(r=>{
+    const key = r.landing_path;
+    if(!map[key]){
+      map[key] = {
+        landing_path: key,
+        landing_url: r.landing_url,
+        clicks:0, impr:0, cost:0, conversions:0, conv_value:0
+      };
+    }
+    const m = map[key];
+    m.clicks += safeNum(r.clicks);
+    m.impr += safeNum(r.impr);
+    m.cost += safeNum(r.cost);
+    m.conversions += safeNum(r.conversions);
+    m.conv_value += safeNum(r.conv_value);
+  });
+  return Object.values(map).map(m=>({
+    ...m,
+    ctr: m.impr>0 ? m.clicks/m.impr : 0,
+    conv_rate: m.clicks>0 ? m.conversions/m.clicks : 0
+  }));
+}
+
+module.exports = async (req,res) => {
+  try{
+    const { site, q, limit = '20' } = req.query;
+    if(!site || !q) return res.status(400).json({ error: 'missing site or q param' });
+    const supabase = getClient();
+    const limitNum = Math.min(Number(limit) || 20, 100);
+    const { data, error } = await supabase
+      .from('independent_landing_metrics')
+      .select('landing_path, landing_url, clicks, impr, cost, conversions, conv_value')
+      .eq('site', site)
+      .ilike('landing_path', `%${q}%`)
+      .limit(1000);
+    if(error) throw error;
+    const items = aggregate(data).sort((a,b)=>b.clicks - a.clicks).slice(0, limitNum);
+    res.status(200).json({ ok:true, items });
+  }catch(e){
+    res.status(500).json({ error: e.message });
+  }
+};
+
+module.exports._aggregate = aggregate;

--- a/api/independent/search/index.js
+++ b/api/independent/search/index.js
@@ -15,6 +15,16 @@ function safeNum(v){
   return Number.isFinite(n) ? n : 0;
 }
 
+function buildPattern(q){
+  if(!q) return '%';
+  const tokens = q
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(t=>t.replace(/[%_]/g,''));
+  return `%${tokens.join('%')}%`;
+}
+
 function aggregate(rows){
   const map = {};
   (rows||[]).forEach(r=>{
@@ -50,7 +60,7 @@ module.exports = async (req,res) => {
       .from('independent_landing_metrics')
       .select('landing_path, landing_url, clicks, impr, cost, conversions, conv_value')
       .eq('site', site)
-      .ilike('landing_path', `%${q}%`)
+      .ilike('landing_path', buildPattern(q))
       .limit(1000);
     if(error) throw error;
     const items = aggregate(data).sort((a,b)=>b.clicks - a.clicks).slice(0, limitNum);
@@ -61,3 +71,4 @@ module.exports = async (req,res) => {
 };
 
 module.exports._aggregate = aggregate;
+module.exports._buildPattern = buildPattern;

--- a/api/independent/search/index.test.js
+++ b/api/independent/search/index.test.js
@@ -1,4 +1,4 @@
-const { _aggregate } = require('./index.js');
+const { _aggregate, _buildPattern } = require('./index.js');
 const test = require('node:test');
 const assert = require('assert');
 
@@ -13,4 +13,8 @@ test('aggregate sums metrics and computes rates', () => {
     { landing_path:'/a', landing_url:'/a', clicks:15, impr:30, cost:8, conversions:3, conv_value:45, ctr:0.5, conv_rate:0.2 },
     { landing_path:'/b', landing_url:'/b', clicks:2, impr:4, cost:1, conversions:0, conv_value:0, ctr:0.5, conv_rate:0 }
   ]);
+});
+
+test('buildPattern joins tokens with wildcards', () => {
+  assert.strictEqual(_buildPattern('bestway inflatable pool'), '%bestway%inflatable%pool%');
 });

--- a/api/independent/search/index.test.js
+++ b/api/independent/search/index.test.js
@@ -1,0 +1,16 @@
+const { _aggregate } = require('./index.js');
+const test = require('node:test');
+const assert = require('assert');
+
+test('aggregate sums metrics and computes rates', () => {
+  const rows = [
+    { landing_path:'/a', landing_url:'/a', clicks:10, impr:20, cost:5, conversions:2, conv_value:30 },
+    { landing_path:'/a', landing_url:'/a', clicks:5, impr:10, cost:3, conversions:1, conv_value:15 },
+    { landing_path:'/b', landing_url:'/b', clicks:2, impr:4, cost:1, conversions:0, conv_value:0 },
+  ];
+  const res = _aggregate(rows).sort((x,y)=>x.landing_path.localeCompare(y.landing_path));
+  assert.deepStrictEqual(res, [
+    { landing_path:'/a', landing_url:'/a', clicks:15, impr:30, cost:8, conversions:3, conv_value:45, ctr:0.5, conv_rate:0.2 },
+    { landing_path:'/b', landing_url:'/b', clicks:2, impr:4, cost:1, conversions:0, conv_value:0, ctr:0.5, conv_rate:0 }
+  ]);
+});

--- a/docs/CODEx_README.md
+++ b/docs/CODEx_README.md
@@ -2,9 +2,10 @@
 
 目标：
 - 在当前分支新增独立站“Landing Pages 明细”页面（`independent-site.html`）。
-- 新建 Supabase 表 `independent_landing_metrics` 并提供两个 API：
+- 新建 Supabase 表 `independent_landing_metrics` 并提供三个 API：
   - `POST /api/independent/ingest`：上传 Google Ads 导出的 xlsx/csv，自动 upsert。
   - `GET  /api/independent/stats`：按站点、日期区间返回表格数据与图表数据。
+  - `GET  /api/independent/search`：按站点和 `landing_path` 关键字模糊搜索相关商品。
 
 ## 1. 代码变更（提交到当前分支）
 新增文件：

--- a/docs/CODEx_README.md
+++ b/docs/CODEx_README.md
@@ -5,7 +5,7 @@
 - 新建 Supabase 表 `independent_landing_metrics` 并提供三个 API：
   - `POST /api/independent/ingest`：上传 Google Ads 导出的 xlsx/csv，自动 upsert。
   - `GET  /api/independent/stats`：按站点、日期区间返回表格数据与图表数据。
-  - `GET  /api/independent/search`：按站点和 `landing_path` 关键字模糊搜索相关商品。
+  - `GET  /api/independent/search`：按站点和 `landing_path` 关键字模糊搜索相关商品，`q` 参数可用空格分隔多个关键词。
 
 ## 1. 代码变更（提交到当前分支）
 新增文件：


### PR DESCRIPTION
## Summary
- add `/api/independent/search` endpoint to look up products by landing path
- document new search API in Codex README
- test aggregation logic for landing path results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af0f850a2083258680c0bcac93e66e