### PR TITLE
Add consent privacy notice and footer link

### DIFF
--- a/public/assets/site-nav.js
+++ b/public/assets/site-nav.js
@@ -60,7 +60,7 @@
     footer.style.textAlign='center';
     footer.style.fontSize='12px';
     footer.style.margin='2rem 0';
-    footer.innerHTML='<a href="consent-privacy-notice.html" target="_blank">Consent & Privacy Notice</a>';
+    footer.innerHTML='<a href="consent-privacy-notice.html" target="_blank">Consent & Privacy Notice / 同意与隐私声明</a>';
     document.body.appendChild(footer);
   }
 

--- a/public/assets/site-nav.js
+++ b/public/assets/site-nav.js
@@ -55,6 +55,16 @@
     applyNavIcons();
   }
 
+  function renderFooter(){
+    const footer=document.createElement('footer');
+    footer.style.textAlign='center';
+    footer.style.fontSize='12px';
+    footer.style.margin='2rem 0';
+    footer.innerHTML='<a href="consent-privacy-notice.html" target="_blank">Consent & Privacy Notice</a>';
+    document.body.appendChild(footer);
+  }
+
   window.renderSiteMenus=render;
   document.addEventListener('DOMContentLoaded',render);
+  document.addEventListener('DOMContentLoaded',renderFooter);
 })();

--- a/public/consent-privacy-notice.html
+++ b/public/consent-privacy-notice.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+  <meta charset="UTF-8">
+  <title>Consent & Privacy Notice</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg" sizes="64x64">
+  <link rel="stylesheet" href="assets/theme.css">
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif;line-height:1.6;padding:2rem;max-width:800px;margin:0 auto;}
+    h1{font-size:1.5rem;margin-bottom:1rem;}
+    p{margin:1rem 0;}
+  </style>
+</head>
+<body>
+  <h1>Consent & Privacy Notice</h1>
+  <p>我们非常重视您的隐私。本页面说明我们如何收集、使用和保护您的信息。使用本站即表示您同意本声明。</p>
+  <p>我们仅在提供服务所必需的范围内收集数据，例如登录信息或站点分析结果。除非法律要求，我们不会与第三方分享您的数据。</p>
+  <p>如需撤回授权或删除您的信息，请通过站点提供的联系方式与我们取得联系。</p>
+  <p>我们可能不时更新本声明，更新后内容会发布在本页。</p>
+</body>
+</html>

--- a/public/consent-privacy-notice.html
+++ b/public/consent-privacy-notice.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <title>Consent & Privacy Notice</title>
@@ -10,13 +10,35 @@
     body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif;line-height:1.6;padding:2rem;max-width:800px;margin:0 auto;}
     h1{font-size:1.5rem;margin-bottom:1rem;}
     p{margin:1rem 0;}
+    ul{margin:1rem 0;padding-left:1.5rem;}
+    li{margin:0.5rem 0;}
   </style>
 </head>
 <body>
-  <h1>Consent & Privacy Notice</h1>
-  <p>我们非常重视您的隐私。本页面说明我们如何收集、使用和保护您的信息。使用本站即表示您同意本声明。</p>
-  <p>我们仅在提供服务所必需的范围内收集数据，例如登录信息或站点分析结果。除非法律要求，我们不会与第三方分享您的数据。</p>
-  <p>如需撤回授权或删除您的信息，请通过站点提供的联系方式与我们取得联系。</p>
-  <p>我们可能不时更新本声明，更新后内容会发布在本页。</p>
+  <h1>Consent & Privacy Notice / 同意与隐私声明</h1>
+  <section>
+    <h2>English</h2>
+    <p>This notice explains how we collect, use, and protect seller data accessed through Amazon and related services. It is provided for Amazon's compliance review and for the awareness of all users.</p>
+    <ul>
+      <li><strong>Data Collection:</strong> We collect Amazon order metrics, product information, and account identifiers solely to provide analytics features.</li>
+      <li><strong>Use of Data:</strong> Collected data is used to generate reports and operational insights. We do not use this information for advertising or unrelated purposes.</li>
+      <li><strong>Data Sharing:</strong> We do not share seller data with third parties. Data may be disclosed to Amazon if required to demonstrate policy compliance.</li>
+      <li><strong>Retention & Deletion:</strong> Data is retained only as long as necessary to deliver the service. You may request deletion or revoke access at any time by contacting us.</li>
+      <li><strong>Security:</strong> Encryption, access controls, and regular audits are employed to safeguard all stored data.</li>
+      <li><strong>Updates & Contact:</strong> This notice may be updated. For questions or requests, email <a href="mailto:privacy@icyberite.com">privacy@icyberite.com</a>.</li>
+    </ul>
+  </section>
+  <section>
+    <h2>中文</h2>
+    <p>本声明说明我们如何收集、使用并保护通过亚马逊及相关服务获取的卖家数据。该说明主要供亚马逊合规审查，同时也让所有用户了解我们的数据处理方式。</p>
+    <ul>
+      <li><strong>数据收集：</strong>我们仅收集亚马逊订单指标、产品信息和账号标识等数据，用于提供分析功能。</li>
+      <li><strong>数据使用：</strong>收集的数据仅用于生成报告和运营洞察，不会用于广告或其他无关目的。</li>
+      <li><strong>数据共享：</strong>我们不会向第三方分享卖家数据。如需向亚马逊提供以证明遵守政策，我们会在合法情况下配合。</li>
+      <li><strong>数据保留与删除：</strong>数据仅在提供服务所需期间保留。您可以随时通过联系我们来请求删除或撤销访问权限。</li>
+      <li><strong>安全措施：</strong>我们采用加密、访问控制和定期审计等方式来保障所有存储数据的安全。</li>
+      <li><strong>更新与联系：</strong>本声明可能会更新。如有疑问或请求，请发送邮件至 <a href="mailto:privacy@icyberite.com">privacy@icyberite.com</a>。</li>
+    </ul>
+  </section>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add site-wide footer with link to Consent & Privacy Notice
- create dedicated Consent & Privacy Notice page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b15c1a1ed88325ab1e24a3e5f0f702