### PR TITLE
feat: enhance managed and self-operated analysis

### DIFF
--- a/public/managed.html
+++ b/public/managed.html
@@ -157,7 +157,7 @@
       <div id="funnel" style="width:100%;height:320px;"></div>
     </div>
     <div class="panel">
-      <h3>周期对比（曝光 / 加购件数 / 支付订单数）</h3>
+      <h3>周期对比（总展示数 / 详情页访客数 / 加购次数 / 订购次数 / 有加购商品数）</h3>
       <div id="sumCompareBar" style="width:100%;height:320px;"></div>
     </div>
     <div class="panel">
@@ -619,14 +619,15 @@ function renderProductCharts(pid, rowsA) {
   const nameA = window._periodA || '当前周期', nameB = window._periodB || '上一周期';
   const toNum=v=>{ if(v===null||v===undefined) return 0; const n=Number(String(v).replace(/,/g,'')); return isNaN(n)?0:n; };
 
-  const sum = rows => rows.reduce((a,x)=>({ 
-    exp:a.exp+toNum(x.search_exposure||0),
-    uv:a.uv+toNum(x.uv||0),
-    atc_users:a.atc_users+toNum(x.add_to_cart_users||0),
-    atc_qty:a.atc_qty+toNum(x.add_to_cart_qty||0),
-    pay_buyers:a.pay_buyers+toNum(x.pay_buyers||0),
-    pay_orders:a.pay_orders+toNum(x.pay_orders||0)
-  }), {exp:0,uv:0,atc_users:0,atc_qty:0,pay_buyers:0,pay_orders:0});
+  const sum = rows => rows.reduce((a,x)=>({
+    exp: a.exp + toNum(x.search_exposure || 0),
+    uv: a.uv + toNum(x.uv || 0),
+    atc_users: a.atc_users + toNum(x.add_to_cart_users || 0),
+    atc_qty: a.atc_qty + toNum(x.add_to_cart_qty || 0),
+    atc_products: a.atc_products + (toNum(x.add_to_cart_qty || 0) > 0 ? 1 : 0),
+    pay_buyers: a.pay_buyers + toNum(x.pay_buyers || 0),
+    pay_orders: a.pay_orders + toNum(x.pay_orders || 0)
+  }), {exp:0,uv:0,atc_users:0,atc_qty:0,atc_products:0,pay_buyers:0,pay_orders:0});
 
   const A = sum(rowsA), B = sum(rowsB);
 
@@ -655,11 +656,11 @@ function renderProductCharts(pid, rowsA) {
       chart.setOption({
         tooltip:{trigger:'axis',axisPointer:{type:'shadow'}},
         legend:{ data:[nameA,nameB], textStyle:{color:'#374151'} },
-        xAxis:{ type:'category', data:['曝光量','加购数(件)','支付数(订单)'], axisLabel:{color:'#374151'} },
+        xAxis:{ type:'category', data:['总展示数','详情页访客数','加购次数','订购次数','有加购商品数'], axisLabel:{color:'#374151'} },
         yAxis:{ type:'value', axisLabel:{color:'#374151'} },
         series:[
-          { name:nameA, type:'bar', data:[A.exp, A.atc_qty, A.pay_orders], barMaxWidth:28, itemStyle:{color:COLOR_A} },
-          { name:nameB, type:'bar', data:[B.exp, B.atc_qty, B.pay_orders], barMaxWidth:28, itemStyle:{color:COLOR_B} }
+          { name:nameA, type:'bar', data:[A.exp, A.uv, A.atc_qty, A.pay_orders, A.atc_products], barMaxWidth:28, itemStyle:{color:COLOR_A}, label:{show:true, position:'top'} },
+          { name:nameB, type:'bar', data:[B.exp, B.uv, B.atc_qty, B.pay_orders, B.atc_products], barMaxWidth:28, itemStyle:{color:COLOR_B}, label:{show:true, position:'top'} }
         ],
         grid:{ left:40, right:20, top:30, bottom:40 }
       });

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -1077,7 +1077,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
       
       if (currentData.ok && currentData.rows) {  // 注意：API返回的是rows而不是data
         // 渲染访客比、加购比、支付比趋势图
-        renderAnalysisCharts(currentData.rows);
+        await renderAnalysisCharts(currentData.rows);
       } else {
         console.warn('运营分析数据格式不正确:', currentData);
         showAnalysisError('数据格式不正确，请检查API响应');
@@ -1955,24 +1955,21 @@ document.addEventListener('DOMContentLoaded', ()=>{
          if (el) el.style.display = (id === hash ? '' : 'none');
        });
        
-       // 控制主KPI卡片的显示/隐藏
-       const uploadSection = document.querySelector('.upload-section');
-       if (uploadSection) {
-         console.log('找到upload-section，当前hash:', hash);
-         if (hash === 'products') {
-           // 产品分析页面隐藏主KPI卡片
-           console.log('隐藏KPI卡片');
-           uploadSection.style.display = 'none';
-           console.log('KPI卡片隐藏后的display值:', uploadSection.style.display);
-         } else {
-           // 其他页面显示主KPI卡片
-           console.log('显示KPI卡片');
-           uploadSection.style.display = '';
-           console.log('KPI卡片显示后的display值:', uploadSection.style.display);
-         }
-       } else {
-         console.log('未找到upload-section元素');
-       }
+      // 控制主KPI卡片的显示/隐藏，仅在详情页显示
+      const uploadSection = document.querySelector('.upload-section');
+      if (uploadSection) {
+        console.log('找到upload-section，当前hash:', hash);
+        if (hash === 'detail') {
+          uploadSection.style.display = '';
+          console.log('显示KPI卡片');
+        } else {
+          uploadSection.style.display = 'none';
+          console.log('隐藏KPI卡片');
+        }
+        console.log('KPI卡片当前display值:', uploadSection.style.display);
+      } else {
+        console.log('未找到upload-section元素');
+      }
        
        // 根据路由加载相应数据
        if (hash === 'analysis') {


### PR DESCRIPTION
## Summary
- expand managed ops comparison to include more metrics with labelled bars
- hide upload section outside detail view and await chart rendering in self-operated analysis

## Testing
- `npm test` *(fails: ReferenceError: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68b91647d9248325a2ca0915435202e2