### PR TITLE
feat: enhance analytics visualization

### DIFF
--- a/public/assets/self-operated.js
+++ b/public/assets/self-operated.js
@@ -71,6 +71,15 @@
       }
     }
 
+    // 切换内部页面时控制上传控件显示
+    switchInternalSection(target) {
+      super.switchInternalSection(target);
+      const controls = document.getElementById('uploadControls');
+      if (controls) {
+        controls.style.display = (target === 'detail') ? '' : 'none';
+      }
+    }
+
     // 更新页面标题显示当前站点名称
     updatePageTitle() {
       const siteSubtitleEl = document.getElementById('siteSubtitle');
@@ -142,12 +151,20 @@
         
         // 渲染数据表格
         await this.renderDataTable(rowsAggA, 'day');
-        
-                 // 更新状态为成功
-         this.updateStatus('数据加载完成', 'success');
-         
-         // 数据加载完成后，绑定新品筛选事件
-         this.bindNewProductsFilter();
+
+        // 同步刷新运营分析和产品分析图表
+        if (typeof window.loadAnalysisData === 'function') {
+          await window.loadAnalysisData();
+        }
+        if (typeof window.loadProductAnalysisData === 'function') {
+          await window.loadProductAnalysisData();
+        }
+
+        // 更新状态为成功
+        this.updateStatus('数据加载完成', 'success');
+
+        // 数据加载完成后，绑定新品筛选事件
+        this.bindNewProductsFilter();
          
        } catch (error) {
          console.error('数据加载失败:', error);

--- a/public/managed.html
+++ b/public/managed.html
@@ -651,15 +651,17 @@ function renderProductCharts(pid, rowsA) {
   // Grouped sum comparison
   try{
     const el = document.getElementById('sumCompareBar'); if (el){
+      const atcProdA = new Set(rowsA.filter(r=>toNum(r.add_to_cart_qty||0)>0).map(r=>r.product_id)).size;
+      const atcProdB = new Set(rowsB.filter(r=>toNum(r.add_to_cart_qty||0)>0).map(r=>r.product_id)).size;
       const chart = echarts.init(el, null, {backgroundColor:'transparent'});
       chart.setOption({
         tooltip:{trigger:'axis',axisPointer:{type:'shadow'}},
         legend:{ data:[nameA,nameB], textStyle:{color:'#374151'} },
-        xAxis:{ type:'category', data:['曝光量','加购数(件)','支付数(订单)'], axisLabel:{color:'#374151'} },
+        xAxis:{ type:'category', data:['总展示数','详情页访客数','加购次数','订购次数','有加购商品数'], axisLabel:{color:'#374151'} },
         yAxis:{ type:'value', axisLabel:{color:'#374151'} },
         series:[
-          { name:nameA, type:'bar', data:[A.exp, A.atc_qty, A.pay_orders], barMaxWidth:28, itemStyle:{color:COLOR_A} },
-          { name:nameB, type:'bar', data:[B.exp, B.atc_qty, B.pay_orders], barMaxWidth:28, itemStyle:{color:COLOR_B} }
+          { name:nameA, type:'bar', data:[A.exp, A.uv, A.atc_qty, A.pay_orders, atcProdA], barMaxWidth:28, itemStyle:{color:COLOR_A}, label:{show:true,position:'top'} },
+          { name:nameB, type:'bar', data:[B.exp, B.uv, B.atc_qty, B.pay_orders, atcProdB], barMaxWidth:28, itemStyle:{color:COLOR_B}, label:{show:true,position:'top'} }
         ],
         grid:{ left:40, right:20, top:30, bottom:40 }
       });

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -547,6 +547,11 @@
           <span>日期：</span>
           <input id="dateFilter" class="date-filter" placeholder="选择日期范围">
           <div id="statusDisplay" class="status-display">数据加载完成</div>
+          <div id="uploadControls" style="display:flex;align-items:center;gap:8px;">
+            <button id="uploadBtn" class="btn">上传数据</button>
+            <input type="file" id="fileInput" accept=".xlsx,.csv" style="display:none;">
+            <span id="progress" class="small"></span>
+          </div>
         </div>
       </div>
       <div class="divider"></div>
@@ -737,6 +742,7 @@ const GRID_LINE  = 'rgba(148,163,184,0.18)';
 //  - 下单商品件数（→ order_items）
 //  - 平均停留时长（秒）（→ avg_stay_seconds）
 //  - 搜索点击率（% 数值）（→ search_ctr）
+$('#uploadBtn').on('click', function(){ $('#fileInput').click(); });
 $('#fileInput').on('change', function(e) {
   const file = e.target.files[0]; if (!file) return;
   const reader = new FileReader();


### PR DESCRIPTION
## Summary
- expand managed analysis bar chart with visitors and add-to-cart product counts, showing values atop bars
- auto-refresh self-operated analytics charts after period changes
- restore file upload controls on self-operated detail view while hiding them in analysis

## Testing
- `npm test` *(fails: ReferenceError: require is not defined in ES module scope in api/test-data-isolation.js, api/test-site-configs.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b918630544832582bdab7ef05bc5cc