### PR TITLE
feat: enlarge digits in detail tables

### DIFF
--- a/public/assets/big-number.js
+++ b/public/assets/big-number.js
@@ -1,0 +1,22 @@
+(function(){
+  function markNumericCells(table){
+    if(!table) return;
+    table.querySelectorAll('tbody td').forEach(function(td){
+      var text = td.textContent.trim().replace(/,/g,'');
+      if(/^[-+]?\d+(?:\.\d+)?%?$/.test(text)){
+        td.classList.add('num-cell');
+      }
+    });
+  }
+  window.addEventListener('DOMContentLoaded', function(){
+    var table = document.querySelector('#report');
+    if(table){
+      markNumericCells(table);
+      if(window.jQuery){
+        jQuery(table).on('draw.dt', function(){
+          markNumericCells(table);
+        });
+      }
+    }
+  });
+})();

--- a/public/assets/global-theme.css
+++ b/public/assets/global-theme.css
@@ -208,6 +208,11 @@ body {
   font-size: 0.875rem;
 }
 
+/* Larger font for numeric cells in detail tables */
+.data-table tbody td.num-cell {
+  font-size: 0.95rem;
+}
+
 .data-table tbody tr:hover {
   background-color: var(--primary-50);
 }

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -494,6 +494,7 @@
   <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
   <script src="assets/site-nav.js"></script>
   <script src="assets/loading.js"></script>
+  <script src="assets/big-number.js"></script>
 </head>
 <body class="fm">
 <div id="loginOverlay" class="login-overlay" style="display:none">

--- a/public/managed.html
+++ b/public/managed.html
@@ -1123,6 +1123,7 @@
   })();</script>
   <script src="assets/login.js"></script>
   <script src="assets/site-nav.js"></script>
+  <script src="assets/big-number.js"></script>
   <script>
   document.addEventListener('DOMContentLoaded', ()=>{
   const siteListKey='managedSites';

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -107,6 +107,7 @@
 </main>
 </div>
 <script src="assets/site-nav.js"></script>
+<script src="assets/big-number.js"></script>
 <script>
 (function(){
   const storeId = 'demo';

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -25,6 +25,7 @@
   <script src="assets/site-nav.js"></script>
   <script src="assets/page-template.js"></script>
   <script src="assets/self-operated.js"></script>
+  <script src="assets/big-number.js"></script>
   <style>
     /* 移除旧的KPI样式，使用全局UI系统 */
     /* 旧的样式已被全局主题系统替代 */


### PR DESCRIPTION
## Summary
- enlarge numeric cell font size in detail tables via shared CSS class
- add big-number script to auto-tag digits and wire it on detail pages

## Testing
- `npm test` (fails: 2 tests failing)

------
https://chatgpt.com/codex/tasks/task_e_68b97ba340a48325a900ff3bb5f1aea9