### PR TITLE
feat: add Ozon display product KPI and chart navigation

### DIFF
--- a/api/ozon/kpi/index.js
+++ b/api/ozon/kpi/index.js
@@ -67,15 +67,16 @@ module.exports = async function handler(req,res){
         const prodSet=new Set();
         const cartProds=new Set();
         const payProds=new Set();
+        const displayProds=new Set();
         for(const r of rows){
           const id=idOf(r);
           prodSet.add(id);
-          const e=Number(r.voronka_prodazh_pokazy_vsego)||0; sums.exposure+=e;
+          const e=Number(r.voronka_prodazh_pokazy_vsego)||0; sums.exposure+=e; if(e>0) displayProds.add(id);
           const u=Number(r.uv)||0; sums.uv+=u;
           const c=Number(r.voronka_prodazh_dobavleniya_v_korzinu_vsego)||0; sums.cart+=c; if(c>0) cartProds.add(id);
           const p=Number(r.voronka_prodazh_zakazano_tovarov)||0; sums.pay+=p; if(p>0) payProds.add(id);
         }
-        return {sums, prodSet, cartProds, payProds, rows};
+        return {sums, prodSet, cartProds, payProds, displayProds, rows};
       }
       const cur=agg(curResp.data||[]);
       const prev=agg(prevResp.data||[]);
@@ -113,6 +114,7 @@ module.exports = async function handler(req,res){
           visitor_rate:{current:visitorRate, previous:visitorRatePrev},
           cart_rate:{current:cartRate, previous:cartRatePrev},
           pay_rate:{current:payRate, previous:payRatePrev},
+          display_product_total:{current:cur.displayProds.size, previous:prev.displayProds.size},
           product_total:{current:allCurSet.size, previous:allPrevSet.size},
           cart_product_total:{current:cur.cartProds.size, previous:prev.cartProds.size},
           pay_product_total:{current:cur.payProds.size, previous:prev.payProds.size},
@@ -154,15 +156,16 @@ module.exports = async function handler(req,res){
       const prodSet=new Set();
       const cartProds=new Set();
       const payProds=new Set();
+      const displayProds=new Set();
       for(const r of rows){
         const id=idOf(r);
         prodSet.add(id);
-        const e=Number(r.voronka_prodazh_pokazy_vsego)||0; sums.exposure+=e;
+        const e=Number(r.voronka_prodazh_pokazy_vsego)||0; sums.exposure+=e; if(e>0) displayProds.add(id);
         const u=Number(r.uv)||0; sums.uv+=u;
         const c=Number(r.voronka_prodazh_dobavleniya_v_korzinu_vsego)||0; sums.cart+=c; if(c>0) cartProds.add(id);
         const p=Number(r.voronka_prodazh_zakazano_tovarov)||0; sums.pay+=p; if(p>0) payProds.add(id);
       }
-      return {sums, prodSet, cartProds, payProds, rows};
+      return {sums, prodSet, cartProds, payProds, displayProds, rows};
     }
     const cur=agg(curResp.data||[]);
     const prev=agg(prevResp.data||[]);
@@ -203,6 +206,7 @@ module.exports = async function handler(req,res){
         visitor_rate:{current:visitorRate, previous:visitorRatePrev},
         cart_rate:{current:cartRate, previous:cartRatePrev},
         pay_rate:{current:payRate, previous:payRatePrev},
+        display_product_total:{current:cur.displayProds.size, previous:prev.displayProds.size},
         product_total:{current:allCurSet.size, previous:allPrevSet.size},
         cart_product_total:{current:cur.cartProds.size, previous:prev.cartProds.size},
         pay_product_total:{current:cur.payProds.size, previous:prev.payProds.size},

--- a/public/managed.html
+++ b/public/managed.html
@@ -469,10 +469,12 @@
     ids.forEach(id=> $sel.append(`<option value="${id}" data-pid="${id}">${id}</option>`));
     populateProductNames($sel[0]);
     $sel.on('change', ()=> { const pid = $sel.val(); updateProductMeta(pid); renderProductCharts(pid); });
-    const firstId = ids[0];
+    const storedPid = localStorage.getItem('selectedProductId');
+    const firstId = storedPid && ids.includes(storedPid) ? storedPid : ids[0];
     $sel.val(firstId);
     updateProductMeta(firstId);
     renderProductCharts(firstId);
+    if(storedPid) localStorage.removeItem('selectedProductId');
   }
 
   function updateProductMeta(pid){
@@ -758,7 +760,16 @@
       series:[{type:'bar',data:vals,barMaxWidth:24,itemStyle:{color:COLOR_A}}],
       grid:{left:40,right:20,top:30,bottom:60}
     };
-    initResponsiveChart(el, option);
+    const chart = initResponsiveChart(el, option);
+    if(chart){
+      chart.on('dblclick', params => {
+        const pid = params.name;
+        if(pid){
+          localStorage.setItem('selectedProductId', pid);
+          window.location.href = 'managed.html#products';
+        }
+      });
+    }
   }
   topByRate(rowsA,'search_exposure','uv','vrBar',50);
   topByRate(rowsA,'add_to_cart_users','pay_buyers','payBar',5);

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -233,6 +233,7 @@
       `<div class="kpi-card info"><h4>总访客比<span class="help" onclick="alert('访客比 = 浏览过商品详情页的独立访客 / 总展示次数')">?</span></h4><p>${(k.visitor_rate.current*100).toFixed(2)}%</p><div class="kpi-comparison">${delta(k.visitor_rate.current,k.visitor_rate.previous,true)}</div></div>`,
       `<div class="kpi-card success"><h4>加购比<span class="help" onclick="alert('加购比 = 总加入购物车次数 / 浏览过商品详情页的独立访客')">?</span></h4><p>${(k.cart_rate.current*100).toFixed(2)}%</p><div class="kpi-comparison">${delta(k.cart_rate.current,k.cart_rate.previous,true)}</div></div>`,
       `<div class="kpi-card danger"><h4>支付比</h4><p>${(k.pay_rate.current*100).toFixed(2)}%</p><div class="kpi-comparison">${delta(k.pay_rate.current,k.pay_rate.previous,true)}</div></div>`,
+      `<div class="kpi-card info"><h4>展示商品总数</h4><p>${k.display_product_total.current}</p><div class="kpi-comparison">${delta(k.display_product_total.current,k.display_product_total.previous,false)}</div></div>`,
       `<div class="kpi-card success"><h4>商品总数</h4><p>${k.product_total.current}</p><div class="kpi-comparison">${delta(k.product_total.current,k.product_total.previous,false)}</div></div>`,
       `<div class="kpi-card warning"><h4>有加购商品总数</h4><p>${k.cart_product_total.current}</p><div class="kpi-comparison">${delta(k.cart_product_total.current,k.cart_product_total.previous,false)}</div></div>`,
       `<div class="kpi-card danger"><h4>有支付商品总数</h4><p>${k.pay_product_total.current}</p><div class="kpi-comparison">${delta(k.pay_product_total.current,k.pay_product_total.previous,false)}</div></div>`,

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -1532,7 +1532,16 @@ document.addEventListener('DOMContentLoaded', ()=>{
         series:[{ type:'bar', data:vals, barMaxWidth:24, itemStyle:{ color:'#3B82F6' } }],
         grid:{ left:40, right:20, top:30, bottom:60 }
       };
-      initResponsiveChart(elId, option);
+      const chart = initResponsiveChart(elId, option);
+      if(chart){
+        chart.on('dblclick', params => {
+          const pid = params.name;
+          if(pid){
+            localStorage.setItem('selectedProductId', pid);
+            window.location.href = 'self-operated.html#products';
+          }
+        });
+      }
     }
 
     topByRate(list, 'exposure', 'visitors', 'analysisVrBar', 50);


### PR DESCRIPTION
## Summary
- track products with exposure and return `display_product_total` in Ozon KPI API
- show “展示商品总数” card on Ozon data detail page
- allow double-clicking Top10 charts to jump to product analysis on self-operated and managed pages

## Testing
- `npm test` *(fails: require is not defined in ES module scope for api/test-data-isolation.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b98e14321c832586b15df4a7dd9c1f