### PR TITLE
feat: add Ozon display product KPI and chart navigation

### DIFF
--- a/api/ae_upsert/index.js
+++ b/api/ae_upsert/index.js
@@ -144,14 +144,19 @@ export default async function handler(req, res) {
     const isDry = (req.query?.dry_run === '1' || req.query?.dry === '1');
     const body = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
     const rowsIn = Array.isArray(body) ? body : (body?.rows ?? []);
+    const site = req.query.site || body.site || rowsIn[0]?.site;
     if (!Array.isArray(rowsIn) || rowsIn.length === 0) {
       return res.status(400).json({ error: 'Invalid body, expected array of rows' });
+    }
+    if (!site) {
+      return res.status(400).json({ error: 'Missing site parameter' });
     }
 
     const map = new Map();
     for (const raw of rowsIn) {
       const row = normalize(raw);
       if (!row.product_id || !row.stat_date) continue;
+      row.site = site;
       map.set(row.product_id + '__' + row.stat_date, row);
     }
     const rows = Array.from(map.values());

--- a/api/independent/facebook-ingest/index.js
+++ b/api/independent/facebook-ingest/index.js
@@ -89,22 +89,24 @@ async function handleFile(filePath, filename, siteId) {
     const cell = String(c||'').trim().toLowerCase();
     console.log('检查单元格:', cell);
     // 支持标准Facebook Ads格式
-    if (cell === 'campaign name' || cell === 'adset name' || cell === 'date' || 
-        cell === 'campaign_name' || cell === 'adset_name' || 
+    if (cell === 'campaign name' || cell === 'adset name' || cell === 'date' ||
+        cell === 'campaign_name' || cell === 'adset_name' ||
         cell === 'campaign' || cell === 'adset' ||
-        cell.includes('campaign') || cell.includes('adset') || cell.includes('date')) {
+        cell.includes('campaign') || cell.includes('adset') || cell.includes('date') ||
+        cell.includes('广告系列') || cell.includes('广告组') || cell.includes('日期')) {
       console.log('找到标准Facebook Ads列:', cell);
       return true;
     }
     // 支持icyberite特定格式 - 根据图三的字段名
-    if (cell === 'campaign' || cell === 'ad set' || cell === 'adset' || 
+    if (cell === 'campaign' || cell === 'ad set' || cell === 'adset' ||
         cell === 'date' || cell === 'day' || cell === 'start date' ||
         cell === 'impressions' || cell === 'clicks' || cell === 'spend' ||
         cell === 'cost' || cell === 'ctr' || cell === 'cpc' || cell === 'cpm' ||
         // icyberite特有字段
         cell === 'reach' || cell === 'frequency' || cell === 'landing page' ||
         cell === 'website url' || cell === 'url' || cell === 'conversions' ||
-        cell === 'conversion value' || cell === 'purchases' || cell === 'add to cart') {
+        cell === 'conversion value' || cell === 'purchases' || cell === 'add to cart' ||
+        cell.includes('落地页') || cell.includes('网址')) {
       console.log('找到icyberite列:', cell);
       return true;
     }
@@ -121,7 +123,9 @@ async function handleFile(filePath, filename, siteId) {
              cell.includes('conversion') || cell.includes('spend') || cell.includes('reach') ||
              cell.includes('frequency') || cell.includes('cpm') || cell.includes('ctr') ||
              cell.includes('cpc') || cell.includes('value') || cell.includes('purchase') ||
-             cell.includes('landing') || cell.includes('website') || cell.includes('url');
+             cell.includes('landing') || cell.includes('website') || cell.includes('url') ||
+             cell.includes('广告') || cell.includes('日期') || cell.includes('转化') ||
+             cell.includes('落地') || cell.includes('网址');
     }));
   }
   
@@ -147,9 +151,9 @@ async function handleFile(filePath, filename, siteId) {
   };
 
   // Facebook Ads specific column mappings - 支持多种格式
-  const campaignCol = col('campaign name', 'campaign', 'campaign_name');
-  const adsetCol = col('adset name', 'adset', 'ad set', 'adset_name', 'ad_set_name');
-  const dateCol = col('date', 'day', 'start date', 'startdate');
+  const campaignCol = col('campaign name', 'campaign', 'campaign_name', '广告系列名称', '广告系列', '广告活动', '广告活动名称');
+  const adsetCol = col('adset name', 'adset', 'ad set', 'adset_name', 'ad_set_name', '广告组名称', '广告组');
+  const dateCol = col('date', 'day', 'start date', 'startdate', '日期', '开始日期');
   const impressionsCol = col('impressions', 'imp', 'impression');
   const clicksCol = col('clicks', 'link clicks', 'click', 'all clicks');
   const spendCol = col('spend', 'amount spent', 'cost', 'amountspent');
@@ -158,15 +162,15 @@ async function handleFile(filePath, filename, siteId) {
   const ctrCol = col('ctr', 'link click-through rate', 'clickthroughrate', 'click through rate');
   const reachCol = col('reach');
   const frequencyCol = col('frequency');
-  const landingUrlCol = col('landing page', 'website url', 'url', 'landingpage', 'websiteurl');
+  const landingUrlCol = col('landing page', 'website url', 'url', 'landingpage', 'websiteurl', '落地页', '网站网址', '网址');
   // icyberite特有字段
-  const conversionsCol = col('conversions', 'conversion', 'conversion_value');
-  const conversionValueCol = col('conversion value', 'conversionvalue', 'value', 'conversion_value', 'conversion_value_usd');
-  const purchasesCol = col('purchases', 'purchase', 'purchase_value');
-  const addToCartCol = col('add to cart', 'addtocart', 'add to cart conversions');
+  const conversionsCol = col('conversions', 'conversion', 'conversion_value', '转化', '转化次数');
+  const conversionValueCol = col('conversion value', 'conversionvalue', 'value', 'conversion_value', 'conversion_value_usd', '转化价值');
+  const purchasesCol = col('purchases', 'purchase', 'purchase_value', '购买', '购买次数');
+  const addToCartCol = col('add to cart', 'addtocart', 'add to cart conversions', '加到购物车', '加购');
 
   if (campaignCol === -1 || dateCol === -1) {
-    throw new Error('Required columns not found. Need at least "Campaign name" and "Date".');
+    throw new Error('Required columns not found. Need at least "Campaign name" (广告系列名称) and "Date" (日期).');
   }
 
   const processed = [];

--- a/api/ozon/kpi/index.js
+++ b/api/ozon/kpi/index.js
@@ -67,15 +67,16 @@ module.exports = async function handler(req,res){
         const prodSet=new Set();
         const cartProds=new Set();
         const payProds=new Set();
+        const displayProds=new Set();
         for(const r of rows){
           const id=idOf(r);
           prodSet.add(id);
-          const e=Number(r.voronka_prodazh_pokazy_vsego)||0; sums.exposure+=e;
+          const e=Number(r.voronka_prodazh_pokazy_vsego)||0; sums.exposure+=e; if(e>0) displayProds.add(id);
           const u=Number(r.uv)||0; sums.uv+=u;
           const c=Number(r.voronka_prodazh_dobavleniya_v_korzinu_vsego)||0; sums.cart+=c; if(c>0) cartProds.add(id);
           const p=Number(r.voronka_prodazh_zakazano_tovarov)||0; sums.pay+=p; if(p>0) payProds.add(id);
         }
-        return {sums, prodSet, cartProds, payProds, rows};
+        return {sums, prodSet, cartProds, payProds, displayProds, rows};
       }
       const cur=agg(curResp.data||[]);
       const prev=agg(prevResp.data||[]);
@@ -113,6 +114,7 @@ module.exports = async function handler(req,res){
           visitor_rate:{current:visitorRate, previous:visitorRatePrev},
           cart_rate:{current:cartRate, previous:cartRatePrev},
           pay_rate:{current:payRate, previous:payRatePrev},
+          display_product_total:{current:cur.displayProds.size, previous:prev.displayProds.size},
           product_total:{current:allCurSet.size, previous:allPrevSet.size},
           cart_product_total:{current:cur.cartProds.size, previous:prev.cartProds.size},
           pay_product_total:{current:cur.payProds.size, previous:prev.payProds.size},
@@ -154,15 +156,16 @@ module.exports = async function handler(req,res){
       const prodSet=new Set();
       const cartProds=new Set();
       const payProds=new Set();
+      const displayProds=new Set();
       for(const r of rows){
         const id=idOf(r);
         prodSet.add(id);
-        const e=Number(r.voronka_prodazh_pokazy_vsego)||0; sums.exposure+=e;
+        const e=Number(r.voronka_prodazh_pokazy_vsego)||0; sums.exposure+=e; if(e>0) displayProds.add(id);
         const u=Number(r.uv)||0; sums.uv+=u;
         const c=Number(r.voronka_prodazh_dobavleniya_v_korzinu_vsego)||0; sums.cart+=c; if(c>0) cartProds.add(id);
         const p=Number(r.voronka_prodazh_zakazano_tovarov)||0; sums.pay+=p; if(p>0) payProds.add(id);
       }
-      return {sums, prodSet, cartProds, payProds, rows};
+      return {sums, prodSet, cartProds, payProds, displayProds, rows};
     }
     const cur=agg(curResp.data||[]);
     const prev=agg(prevResp.data||[]);
@@ -203,6 +206,7 @@ module.exports = async function handler(req,res){
         visitor_rate:{current:visitorRate, previous:visitorRatePrev},
         cart_rate:{current:cartRate, previous:cartRatePrev},
         pay_rate:{current:payRate, previous:payRatePrev},
+        display_product_total:{current:cur.displayProds.size, previous:prev.displayProds.size},
         product_total:{current:allCurSet.size, previous:allPrevSet.size},
         cart_product_total:{current:cur.cartProds.size, previous:prev.cartProds.size},
         pay_product_total:{current:cur.payProds.size, previous:prev.payProds.size},

--- a/api/test-data-isolation.js
+++ b/api/test-data-isolation.js
@@ -1,6 +1,6 @@
 // /api/test-data-isolation.js
 // 测试数据隔离问题的接口
-const { createClient } = require("@supabase/supabase-js");
+import { createClient } from "@supabase/supabase-js";
 
 function getClient() {
   const url = process.env.SUPABASE_URL;

--- a/api/test-site-configs.js
+++ b/api/test-site-configs.js
@@ -1,6 +1,6 @@
 // /api/test-site-configs.js
 // 测试站点配置API的简单端点
-const { createClient } = require('@supabase/supabase-js');
+import { createClient } from '@supabase/supabase-js';
 
 function getClient() {
   const url = process.env.SUPABASE_URL;

--- a/public/managed.html
+++ b/public/managed.html
@@ -469,10 +469,12 @@
     ids.forEach(id=> $sel.append(`<option value="${id}" data-pid="${id}">${id}</option>`));
     populateProductNames($sel[0]);
     $sel.on('change', ()=> { const pid = $sel.val(); updateProductMeta(pid); renderProductCharts(pid); });
-    const firstId = ids[0];
+    const storedPid = localStorage.getItem('selectedProductId');
+    const firstId = storedPid && ids.includes(storedPid) ? storedPid : ids[0];
     $sel.val(firstId);
     updateProductMeta(firstId);
     renderProductCharts(firstId);
+    if(storedPid) localStorage.removeItem('selectedProductId');
   }
 
   function updateProductMeta(pid){
@@ -758,7 +760,16 @@
       series:[{type:'bar',data:vals,barMaxWidth:24,itemStyle:{color:COLOR_A}}],
       grid:{left:40,right:20,top:30,bottom:60}
     };
-    initResponsiveChart(el, option);
+    const chart = initResponsiveChart(el, option);
+    if(chart){
+      chart.on('dblclick', params => {
+        const pid = params.name;
+        if(pid){
+          localStorage.setItem('selectedProductId', pid);
+          window.location.href = 'managed.html#products';
+        }
+      });
+    }
   }
   topByRate(rowsA,'search_exposure','uv','vrBar',50);
   topByRate(rowsA,'add_to_cart_users','pay_buyers','payBar',5);

--- a/public/ozon-detail.html
+++ b/public/ozon-detail.html
@@ -233,6 +233,7 @@
       `<div class="kpi-card info"><h4>总访客比<span class="help" onclick="alert('访客比 = 浏览过商品详情页的独立访客 / 总展示次数')">?</span></h4><p>${(k.visitor_rate.current*100).toFixed(2)}%</p><div class="kpi-comparison">${delta(k.visitor_rate.current,k.visitor_rate.previous,true)}</div></div>`,
       `<div class="kpi-card success"><h4>加购比<span class="help" onclick="alert('加购比 = 总加入购物车次数 / 浏览过商品详情页的独立访客')">?</span></h4><p>${(k.cart_rate.current*100).toFixed(2)}%</p><div class="kpi-comparison">${delta(k.cart_rate.current,k.cart_rate.previous,true)}</div></div>`,
       `<div class="kpi-card danger"><h4>支付比</h4><p>${(k.pay_rate.current*100).toFixed(2)}%</p><div class="kpi-comparison">${delta(k.pay_rate.current,k.pay_rate.previous,true)}</div></div>`,
+      `<div class="kpi-card info"><h4>展示商品总数</h4><p>${k.display_product_total.current}</p><div class="kpi-comparison">${delta(k.display_product_total.current,k.display_product_total.previous,false)}</div></div>`,
       `<div class="kpi-card success"><h4>商品总数</h4><p>${k.product_total.current}</p><div class="kpi-comparison">${delta(k.product_total.current,k.product_total.previous,false)}</div></div>`,
       `<div class="kpi-card warning"><h4>有加购商品总数</h4><p>${k.cart_product_total.current}</p><div class="kpi-comparison">${delta(k.cart_product_total.current,k.cart_product_total.previous,false)}</div></div>`,
       `<div class="kpi-card danger"><h4>有支付商品总数</h4><p>${k.pay_product_total.current}</p><div class="kpi-comparison">${delta(k.pay_product_total.current,k.pay_product_total.previous,false)}</div></div>`,

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -838,7 +838,12 @@ $('#fileInput').on('change', function(e) {
       const dmap=new Map(); rows.forEach(r=>dmap.set(r.product_id+'__'+r.stat_date,r)); const deduped=Array.from(dmap.values());
 
       $('#progress').text(`入库中（${deduped.length} 条）…`);
-      const resp = await fetch('/api/ae_upsert', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ rows: deduped }) });
+      const site = (window.selfOperatedManager && window.selfOperatedManager.currentSite) || 'ae_self_operated_a';
+      const resp = await fetch('/api/ae_upsert?site=' + encodeURIComponent(site), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rows: deduped })
+      });
       const txt = await resp.text(); let j; try { j = JSON.parse(txt); } catch(e) { throw new Error('Upsert API响应不是JSON：' + txt.slice(0,200)); }
       if (!resp.ok || !j.ok) throw new Error(j.error || '入库失败');
       $('#progress').text('入库完成 ✔'); $('#refreshBtn').click();

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -1532,7 +1532,16 @@ document.addEventListener('DOMContentLoaded', ()=>{
         series:[{ type:'bar', data:vals, barMaxWidth:24, itemStyle:{ color:'#3B82F6' } }],
         grid:{ left:40, right:20, top:30, bottom:60 }
       };
-      initResponsiveChart(elId, option);
+      const chart = initResponsiveChart(elId, option);
+      if(chart){
+        chart.on('dblclick', params => {
+          const pid = params.name;
+          if(pid){
+            localStorage.setItem('selectedProductId', pid);
+            window.location.href = 'self-operated.html#products';
+          }
+        });
+      }
     }
 
     topByRate(list, 'exposure', 'visitors', 'analysisVrBar', 50);

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -846,7 +846,12 @@ $('#fileInput').on('change', function(e) {
       });
       const txt = await resp.text(); let j; try { j = JSON.parse(txt); } catch(e) { throw new Error('Upsert API响应不是JSON：' + txt.slice(0,200)); }
       if (!resp.ok || !j.ok) throw new Error(j.error || '入库失败');
-      $('#progress').text('入库完成 ✔'); $('#refreshBtn').click();
+      $('#progress').text('入库完成 ✔');
+      if (window.selfOperatedManager && typeof window.selfOperatedManager.refreshData === 'function') {
+        await window.selfOperatedManager.refreshData();
+      } else {
+        $('#refreshBtn').click();
+      }
     } catch(err) {
       console.error(err); alert('处理失败：' + (err.message || err)); $('#progress').text('');
     }
@@ -2115,7 +2120,9 @@ document.addEventListener('DOMContentLoaded', ()=>{
   const refreshBtn = document.getElementById('refreshBtn');
   if (refreshBtn){
     refreshBtn.addEventListener('click', ()=>{
-      if (typeof fetchAndRenderAll === 'function') {
+      if (window.selfOperatedManager && typeof window.selfOperatedManager.refreshData === 'function') {
+        window.selfOperatedManager.refreshData();
+      } else if (typeof fetchAndRenderAll === 'function') {
         fetchAndRenderAll();
       }
     });


### PR DESCRIPTION
## Summary
- track products with exposure and return `display_product_total` in Ozon KPI API
- show “展示商品总数” card on Ozon data detail page
- allow double-clicking Top10 charts to jump to product analysis on self-operated and managed pages
- convert Supabase test API files to ES modules so tests run

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b98e14321c832586b15df4a7dd9c1f