### PR TITLE
Normalize independent site names to short format

### DIFF
--- a/DEPLOYMENT_GUIDE_FIXED.md
+++ b/DEPLOYMENT_GUIDE_FIXED.md
@@ -34,7 +34,7 @@
 执行完成后，你应该看到：
 - 成功创建了 `site_configs`、`data_source_templates`、`dynamic_tables` 表
 - 插入了预定义的 Facebook Ads 和 Google Ads 模板
-- 插入了现有站点配置（A站、poolsvacuum.com、icyberite.com）
+- 插入了现有站点配置（A站、poolsvacuum、icyberite）
 - 创建了 `generate_dynamic_table` 函数
 - 生成了 `independent_icyberite_facebook_ads_daily` 表
 - 设置了 RLS 策略和索引

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -90,7 +90,7 @@ CREATE TABLE IF NOT EXISTS public.sites (
 -- 5. 初始化默认站点
 INSERT INTO public.sites (id, name, platform, display_name) VALUES
   ('ae_self_operated_a', 'A站', 'ae_self_operated', '速卖通自运营 A站'),
-  ('independent_poolsvacuum', 'poolsvacuum.com', 'independent', '独立站 poolsvacuum.com')
+  ('independent_poolsvacuum', 'poolsvacuum', 'independent', '独立站 poolsvacuum.com')
 ON CONFLICT (id) DO NOTHING;
 ```
 

--- a/api/independent/stats/index.js
+++ b/api/independent/stats/index.js
@@ -69,7 +69,7 @@ module.exports = async (req, res) => {
 
     console.log('独立站查询参数:', { site, from: fromDate, to: toDate, limit, only_new, campaign, network, device, aggregate });
 
-    if (!site) return res.status(400).json({ error: 'missing site param, e.g. ?site=poolsvacuum.com' });
+    if (!site) return res.status(400).json({ error: 'missing site param, e.g. ?site=poolsvacuum' });
 
     // table data (fetch all pages up to limit)
     const limitNum = Math.min(Number(limit) || PAGE_SIZE, 20000);

--- a/docs/CODEx_README.md
+++ b/docs/CODEx_README.md
@@ -36,7 +36,7 @@
 - CI：把 Google Ads 导出文件放在 CI 工件中，通过 `curl` 向 `/api/independent/ingest` 发送 POST。
 
 ## 5. 页面使用
-- 访问：`/independent-site.html?site=poolsvacuum.com&from=2025-05-17&to=2025-08-12`
+- 访问：`/independent-site.html?site=poolsvacuum&from=2025-05-17&to=2025-08-12`
 - “运营分析”页签：展示日趋势 & Top Landing Pages；“明细表”页签：逐行明细。
 
 ## 6. 合并上线

--- a/docs/SITE_CONFIGURATION_GUIDE.md
+++ b/docs/SITE_CONFIGURATION_GUIDE.md
@@ -13,7 +13,7 @@
 ### 2. 添加新站点
 
 #### 2.1 基本信息配置
-- **站点名称**: 输入站点标识（如：icyberite.com）
+- **站点名称**: 输入站点短名（如：icyberite）
 - **平台类型**: 选择平台（独立站、速卖通自运营等）
 - **显示名称**: 输入显示名称（如：独立站 icyberite.com）
 - **域名**: 可选，输入站点域名
@@ -193,10 +193,10 @@ CREATE TABLE data_source_templates (
 
 ## 使用示例
 
-### 添加 icyberite.com 站点
+### 添加 icyberite 站点
 
 1. **基本信息**
-   - 站点名称: icyberite.com
+   - 站点名称: icyberite
    - 平台类型: 独立站
    - 显示名称: 独立站 icyberite.com
    - 域名: icyberite.com

--- a/docs/site-configuration-framework.md
+++ b/docs/site-configuration-framework.md
@@ -12,7 +12,7 @@
 -- 站点基础信息
 CREATE TABLE public.site_configs (
   id          text primary key,
-  name        text not null,                    -- 站点名称（如：icyberite.com）
+  name        text not null,                    -- 站点短名（如：icyberite）
   platform    text not null,                    -- 平台类型
   display_name text not null,                   -- 显示名称
   domain      text,                             -- 域名
@@ -192,6 +192,6 @@ CREATE TABLE public.dynamic_tables (
 - [ ] 实现页面框架自动生成
 
 ### 阶段4：测试和优化
-- [ ] 测试icyberite.com站点
-- [ ] 测试poolsvacuum.com站点
+- [ ] 测试icyberite站点
+- [ ] 测试poolsvacuum站点
 - [ ] 性能优化和错误处理

--- a/fix_complete_framework.sql
+++ b/fix_complete_framework.sql
@@ -163,9 +163,9 @@ INSERT INTO public.data_source_templates (id, name, platform, source_type, field
 -- 5. 插入现有站点配置
 INSERT INTO public.site_configs (id, name, platform, display_name, domain, data_source, template_id) VALUES
 ('ae_self_operated_a', 'A站', 'ae_self_operated', '速卖通自运营 A站', null, 'ae_api', null),
-('independent_poolsvacuum', 'poolsvacuum.com', 'independent', '独立站 poolsvacuum.com', 'poolsvacuum.com', 'google_ads', 'google_ads_landing_pages'),
-('independent_icyberite', 'icyberite.com', 'independent', '独立站 icyberite.com', 'icyberite.com', 'facebook_ads', 'facebook_ads_v2025')
-ON CONFLICT (id) DO UPDATE SET 
+('independent_poolsvacuum', 'poolsvacuum', 'independent', '独立站 poolsvacuum.com', 'poolsvacuum.com', 'google_ads', 'google_ads_landing_pages'),
+('independent_icyberite', 'icyberite', 'independent', '独立站 icyberite.com', 'icyberite.com', 'facebook_ads', 'facebook_ads_v2025')
+ON CONFLICT (id) DO UPDATE SET
   data_source = EXCLUDED.data_source,
   template_id = EXCLUDED.template_id,
   updated_at = now();

--- a/fix_database_site_field.sql
+++ b/fix_database_site_field.sql
@@ -79,8 +79,8 @@ INSERT INTO public.sites (id, name, platform, display_name) VALUES
     ('ae_self_operated_a', 'A站', 'ae_self_operated', '速卖通自运营 A站'),
     ('ae_self_operated_poolslab', 'poolslab', 'ae_self_operated', 'Poolslab运动娱乐'),
     ('ae_managed', '全托管', 'ae_managed', '速卖通全托管'),
-    ('independent_poolsvacuum', 'poolsvacuum.com', 'independent', '独立站 poolsvacuum.com'),
-    ('independent_icyberite', 'icyberite.com', 'independent', '独立站 icyberite.com')
+    ('independent_poolsvacuum', 'poolsvacuum', 'independent', '独立站 poolsvacuum.com'),
+    ('independent_icyberite', 'icyberite', 'independent', '独立站 icyberite.com')
 ON CONFLICT (id) DO UPDATE SET
     display_name = EXCLUDED.display_name,
     updated_at = now();

--- a/fix_sites_table.sql
+++ b/fix_sites_table.sql
@@ -20,7 +20,7 @@ BEGIN
         -- 初始化默认站点
         INSERT INTO public.sites (id, name, platform, display_name) VALUES
             ('ae_self_operated_a', 'A站', 'ae_self_operated', '速卖通自运营 A站'),
-            ('independent_poolsvacuum', 'poolsvacuum.com', 'independent', '独立站 poolsvacuum.com');
+            ('independent_poolsvacuum', 'poolsvacuum', 'independent', '独立站 poolsvacuum.com');
             
         RAISE NOTICE 'Created sites table with default data';
     ELSE
@@ -57,7 +57,7 @@ BEGIN
             -- 初始化默认站点
             INSERT INTO public.sites (id, name, platform, display_name) VALUES
                 ('ae_self_operated_a', 'A站', 'ae_self_operated', '速卖通自运营 A站'),
-                ('independent_poolsvacuum', 'poolsvacuum.com', 'independent', '独立站 poolsvacuum.com');
+                ('independent_poolsvacuum', 'poolsvacuum', 'independent', '独立站 poolsvacuum.com');
                 
             RAISE NOTICE 'Initialized default sites';
         ELSE

--- a/migration_add_site_field.sql
+++ b/migration_add_site_field.sql
@@ -103,7 +103,7 @@ CREATE TABLE IF NOT EXISTS public.sites (
 -- 9. 初始化默认站点
 INSERT INTO public.sites (id, name, platform, display_name) VALUES
   ('ae_self_operated_a', 'A站', 'ae_self_operated', '速卖通自运营 A站'),
-  ('independent_poolsvacuum', 'poolsvacuum.com', 'independent', '独立站 poolsvacuum.com')
+  ('independent_poolsvacuum', 'poolsvacuum', 'independent', '独立站 poolsvacuum.com')
 ON CONFLICT (id) DO NOTHING;
 
 -- 10. 设置RLS策略

--- a/migration_safe_add_site_field.sql
+++ b/migration_safe_add_site_field.sql
@@ -89,7 +89,7 @@ CREATE TABLE IF NOT EXISTS public.sites (
 -- 9. 初始化默认站点
 INSERT INTO public.sites (id, name, platform, display_name) VALUES
   ('ae_self_operated_a', 'A站', 'ae_self_operated', '速卖通自运营 A站'),
-  ('independent_poolsvacuum', 'poolsvacuum.com', 'independent', '独立站 poolsvacuum.com')
+  ('independent_poolsvacuum', 'poolsvacuum', 'independent', '独立站 poolsvacuum.com')
 ON CONFLICT (id) DO NOTHING;
 
 -- 10. 设置RLS策略

--- a/migration_smart_add_site_field.sql
+++ b/migration_smart_add_site_field.sql
@@ -175,7 +175,7 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM public.sites LIMIT 1) THEN
         INSERT INTO public.sites (id, name, platform, display_name) VALUES
             ('ae_self_operated_a', 'A站', 'ae_self_operated', '速卖通自运营 A站'),
-            ('independent_poolsvacuum', 'poolsvacuum.com', 'independent', '独立站 poolsvacuum.com')
+            ('independent_poolsvacuum', 'poolsvacuum', 'independent', '独立站 poolsvacuum.com')
         ON CONFLICT (id) DO NOTHING;
         RAISE NOTICE 'Initialized default sites';
     ELSE

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -565,7 +565,7 @@
       <div class="panel">
         <div class="controls">
           <label>站点：</label>
-          <input type="text" id="site" value="" placeholder="如：poolsvacuum.com">
+          <input type="text" id="site" value="" placeholder="如：poolsvacuum">
           <span>日期：</span>
           <input id="dateFilter" class="date-filter" placeholder="选择日期范围">
           <label>网络：</label>

--- a/simple_fix_sites.sql
+++ b/simple_fix_sites.sql
@@ -18,7 +18,7 @@ CREATE TABLE public.sites (
 -- 3. 插入默认站点数据
 INSERT INTO public.sites (id, name, platform, display_name) VALUES
     ('ae_self_operated_a', 'A站', 'ae_self_operated', '速卖通自运营 A站'),
-    ('independent_poolsvacuum', 'poolsvacuum.com', 'independent', '独立站 poolsvacuum.com');
+    ('independent_poolsvacuum', 'poolsvacuum', 'independent', '独立站 poolsvacuum.com');
 
 -- 4. 启用RLS
 ALTER TABLE public.sites ENABLE ROW LEVEL SECURITY;

--- a/site_configuration_framework.sql
+++ b/site_configuration_framework.sql
@@ -4,7 +4,7 @@
 -- 1. 创建站点配置表
 CREATE TABLE IF NOT EXISTS public.site_configs (
   id          text primary key,
-  name        text not null,                    -- 站点名称（如：icyberite.com）
+  name        text not null,                    -- 站点短名（如：icyberite）
   platform    text not null,                    -- 平台类型
   display_name text not null,                   -- 显示名称
   domain      text,                             -- 域名
@@ -116,9 +116,9 @@ INSERT INTO public.data_source_templates (id, name, platform, source_type, field
 -- 5. 插入现有站点配置
 INSERT INTO public.site_configs (id, name, platform, display_name, domain, data_source, template_id) VALUES
 ('ae_self_operated_a', 'A站', 'ae_self_operated', '速卖通自运营 A站', null, 'ae_api', null),
-('independent_poolsvacuum', 'poolsvacuum.com', 'independent', '独立站 poolsvacuum.com', 'poolsvacuum.com', 'google_ads', 'google_ads_landing_pages'),
-('independent_icyberite', 'icyberite.com', 'independent', '独立站 icyberite.com', 'icyberite.com', 'facebook_ads', 'facebook_ads_v2025')
-ON CONFLICT (id) DO UPDATE SET 
+('independent_poolsvacuum', 'poolsvacuum', 'independent', '独立站 poolsvacuum.com', 'poolsvacuum.com', 'google_ads', 'google_ads_landing_pages'),
+('independent_icyberite', 'icyberite', 'independent', '独立站 icyberite.com', 'icyberite.com', 'facebook_ads', 'facebook_ads_v2025')
+ON CONFLICT (id) DO UPDATE SET
   data_source = EXCLUDED.data_source,
   template_id = EXCLUDED.template_id,
   updated_at = now();

--- a/supabase_schema (1).sql
+++ b/supabase_schema (1).sql
@@ -77,7 +77,7 @@ create table if not exists public.sites (
 -- 初始化默认站点
 insert into public.sites (id, name, platform, display_name) values
   ('ae_self_operated_a', 'A站', 'ae_self_operated', '速卖通自运营 A站'),
-  ('independent_poolsvacuum', 'poolsvacuum.com', 'independent', '独立站 poolsvacuum.com')
+  ('independent_poolsvacuum', 'poolsvacuum', 'independent', '独立站 poolsvacuum.com')
 on conflict (id) do nothing;
 
 -- RLS

--- a/supabase_schema_new.sql
+++ b/supabase_schema_new.sql
@@ -81,7 +81,7 @@ create table if not exists public.sites (
 -- 初始化默认站点
 insert into public.sites (id, name, platform, display_name) values
   ('ae_self_operated_a', 'A站', 'ae_self_operated', '速卖通自运营 A站'),
-  ('independent_poolsvacuum', 'poolsvacuum.com', 'independent', '独立站 poolsvacuum.com')
+  ('independent_poolsvacuum', 'poolsvacuum', 'independent', '独立站 poolsvacuum.com')
 on conflict (id) do nothing;
 
 -- RLS

--- a/test_poolsvacuum_data.sql
+++ b/test_poolsvacuum_data.sql
@@ -10,18 +10,18 @@ SELECT
   COUNT(DISTINCT day) as unique_days
 FROM independent_landing_metrics;
 
--- 检查 poolsvacuum.com 的数据
+-- 检查 poolsvacuum 的数据
 SELECT 
-  'poolsvacuum.com 数据统计' as site_info,
+  'poolsvacuum 数据统计' as site_info,
   COUNT(*) as total_records,
   COUNT(DISTINCT day) as unique_days,
   COUNT(DISTINCT landing_path) as unique_paths,
   MIN(day) as earliest_date,
   MAX(day) as latest_date
-FROM independent_landing_metrics 
-WHERE site = 'poolsvacuum.com';
+FROM independent_landing_metrics
+WHERE site = 'poolsvacuum';
 
--- 查看 poolsvacuum.com 的样本数据
+-- 查看 poolsvacuum 的样本数据
 SELECT 
   day,
   landing_path,
@@ -31,7 +31,7 @@ SELECT
   conversions,
   conv_value
 FROM independent_landing_metrics 
-WHERE site = 'poolsvacuum.com'
+WHERE site = 'poolsvacuum'
 ORDER BY day DESC
 LIMIT 10;
 
@@ -43,14 +43,14 @@ SELECT
   COUNT(DISTINCT site) as unique_sites
 FROM independent_first_seen;
 
--- 检查 poolsvacuum.com 的新产品数据
+-- 检查 poolsvacuum 的新产品数据
 SELECT 
-  'poolsvacuum.com 新产品统计' as site_info,
+  'poolsvacuum 新产品统计' as site_info,
   COUNT(*) as total_new_products,
   MIN(first_seen_date) as earliest_first_seen,
   MAX(first_seen_date) as latest_first_seen
 FROM independent_first_seen 
-WHERE site = 'poolsvacuum.com';
+WHERE site = 'poolsvacuum';
 
 -- 3. 检查 independent_landing_summary_by_day 视图
 SELECT '=== independent_landing_summary_by_day 视图数据检查 ===' as info;
@@ -60,9 +60,9 @@ SELECT
   COUNT(DISTINCT site) as unique_sites
 FROM independent_landing_summary_by_day;
 
--- 检查 poolsvacuum.com 的汇总数据
+-- 检查 poolsvacuum 的汇总数据
 SELECT 
-  'poolsvacuum.com 汇总数据统计' as site_info,
+  'poolsvacuum 汇总数据统计' as site_info,
   COUNT(*) as total_days,
   MIN(day) as earliest_date,
   MAX(day) as latest_date,
@@ -71,8 +71,8 @@ SELECT
   SUM(cost) as total_cost,
   SUM(conversions) as total_conversions,
   SUM(conv_value) as total_conv_value
-FROM independent_landing_summary_by_day 
-WHERE site = 'poolsvacuum.com';
+FROM independent_landing_summary_by_day
+WHERE site = 'poolsvacuum';
 
 -- 4. 检查所有独立站站点
 SELECT '=== 所有独立站站点检查 ===' as info;
@@ -104,7 +104,7 @@ SELECT '=== 数据检查总结 ===' as info;
 
 SELECT 
   CASE 
-    WHEN EXISTS (SELECT 1 FROM independent_landing_metrics WHERE site = 'poolsvacuum.com' LIMIT 1)
-    THEN 'poolsvacuum.com 数据存在'
-    ELSE 'poolsvacuum.com 数据不存在'
+    WHEN EXISTS (SELECT 1 FROM independent_landing_metrics WHERE site = 'poolsvacuum' LIMIT 1)
+    THEN 'poolsvacuum 数据存在'
+    ELSE 'poolsvacuum 数据不存在'
   END as poolsvacuum_data_status;

--- a/verify_database_fix.sql
+++ b/verify_database_fix.sql
@@ -143,8 +143,8 @@ WHERE site = 'ae_self_operated_a';
 SELECT 
   '独立站数据查询测试' as test_name,
   COUNT(*) as total_records
-FROM independent_landing_metrics 
-WHERE site = 'poolsvacuum.com'
+FROM independent_landing_metrics
+WHERE site = 'poolsvacuum'
 LIMIT 1;
 
 -- 12. 总结


### PR DESCRIPTION
## Summary
- Use short site names (e.g. `icyberite`, `poolsvacuum`) in site configuration and migration scripts
- Update documentation and guides to reference short site names and adjust examples
- Clarify API error messages and UI placeholders to expect short site names

## Testing
- ❌ `npm test` (2 failing tests)


------
https://chatgpt.com/codex/tasks/task_e_68ba9fa73c5483259baf942a14627f79