### PR TITLE
fix: adjust dynamic table creation RPC

### DIFF
--- a/api/independent/facebook-ingest/index.js
+++ b/api/independent/facebook-ingest/index.js
@@ -434,16 +434,49 @@ export default async function handler(req, res) {
         .from(tableName)
         .select('day')
         .limit(1);
-      
+
       if (tableCheckError) {
         console.log('表不存在，尝试创建:', tableName);
-        // 调用动态表创建函数
+        // 调用动态表创建函数（使用新的参数名）
+        const tableSchema = {
+          columns: {
+            site: 'text not null',
+            day: 'date not null',
+            campaign_name: 'text',
+            adset_name: 'text',
+            landing_url: 'text',
+            impressions: 'integer',
+            clicks: 'integer',
+            spend_usd: 'numeric(10,2)',
+            cpm: 'numeric(10,2)',
+            cpc_all: 'numeric(10,2)',
+            all_ctr: 'numeric(10,4)',
+            reach: 'integer',
+            frequency: 'numeric(10,2)',
+            all_clicks: 'integer',
+            link_clicks: 'integer',
+            ic_web: 'integer',
+            ic_meta: 'integer',
+            ic_total: 'integer',
+            atc_web: 'integer',
+            atc_meta: 'integer',
+            atc_total: 'integer',
+            purchase_web: 'integer',
+            purchase_meta: 'integer',
+            cpa_purchase_web: 'numeric(10,2)',
+            link_ctr: 'numeric(10,4)',
+            conversion_value: 'numeric(10,2)',
+            row_start_date: 'date',
+            row_end_date: 'date'
+          }
+        };
+
         const { error: createError } = await supabase.rpc('generate_dynamic_table', {
           p_site_id: currentIndepSiteId,
-          p_table_name: tableName,
-          p_data_source: 'facebook_ads'
+          p_source_type: 'facebook_ads',
+          p_table_schema: tableSchema
         });
-        
+
         if (createError) {
           console.error('创建表失败:', createError);
           return res.status(500).json({ error: `Failed to create table: ${createError.message}` });

--- a/api/site-sync/index.js
+++ b/api/site-sync/index.js
@@ -98,10 +98,10 @@ export default async function handler(req, res) {
     if (action === 'create' && siteConfig.platform === 'independent') {
       console.log('为新建的独立站创建数据表');
       
-      // 调用动态表生成函数
+      // 调用动态表生成函数（使用更新的参数名）
       const { error: tableError } = await supabase.rpc('generate_dynamic_table', {
         p_site_id: siteId,
-        p_table_name: `independent_${siteConfig.name}_daily`,
+        p_source_type: siteConfig.data_source || 'facebook_ads',
         p_table_schema: siteConfig.config_json || {}
       });
       


### PR DESCRIPTION
## Summary
- ensure facebook ingest uses new generate_dynamic_table RPC signature and schema
- update site-sync to call generate_dynamic_table with p_source_type

## Testing
- `npm test` *(fails: ReferenceError: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68baa44a2b788325924e76c72d164f28