### PR TITLE
fix: enforce light color scheme

### DIFF
--- a/public/assets/global-theme.css
+++ b/public/assets/global-theme.css
@@ -2,6 +2,7 @@
 
 /* 1. CSS变量定义 */
 :root {
+  color-scheme: light;
   /* 主色调 - 专业稳重 */
   --primary-900: #0f172a;
   --primary-800: #1e293b;
@@ -398,30 +399,3 @@ body {
   }
 }
 
-/* 13. 暗色主题支持 */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --primary-50: #0f172a;
-    --primary-100: #1e293b;
-    --primary-200: #334155;
-    --primary-300: #475569;
-    --primary-400: #64748b;
-    --primary-500: #94a3b8;
-    --primary-600: #cbd5e1;
-    --primary-700: #e2e8f0;
-    --primary-800: #f1f5f9;
-    --primary-900: #f8fafc;
-  }
-  
-  body {
-    background-color: var(--primary-50);
-    color: var(--primary-800);
-  }
-  
-  .kpi-card,
-  .chart-container,
-  .data-table {
-    background: var(--primary-100);
-    border-color: var(--primary-200);
-  }
-}


### PR DESCRIPTION
## Summary
- ensure UI uses light color scheme regardless of system theme
- remove prefers-color-scheme media query so tables keep consistent contrast

## Testing
- `npm test` *(fails: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd54c8c4c8325a806294aefef0a68