### PR TITLE
chore: shrink KPI cards for better fit

### DIFF
--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -193,11 +193,11 @@ table.dataTable td{
 /* ------ KPI Cards (managed.html) ------ */
 .stat-card{
   background:var(--kpi-bg); border:1px solid var(--kpi-border);
-  border-radius:14px; padding:12px 14px; box-shadow:var(--shadow);
+  border-radius:14px; padding:8px 10px; box-shadow:var(--shadow);
 }
-.stat-card h4{ margin:0 0 6px; color:#334155; font-size:12px; letter-spacing:.2px }
-.stat-card p{ margin:0; color:#0f172a; font-size:28px; font-weight:900; line-height:1.1 }
-#kpi{ display:grid; grid-template-columns:repeat(auto-fit,minmax(210px,1fr)); gap:12px }
+.stat-card h4{ margin:0 0 6px; color:#334155; font-size:10px; letter-spacing:.2px }
+.stat-card p{ margin:0; color:#0f172a; font-size:22px; font-weight:900; line-height:1.1 }
+#kpi{ display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:8px }
 
 /* ------ Tables: DataTables High-Contrast Light ------ */
 #report_wrapper{ background:#fff; border-radius:12px; padding:8px; border:1px solid var(--panel-border); box-shadow:var(--shadow) }
@@ -279,7 +279,7 @@ table.dataTable thead th.sorting_desc{
 */
 .kpi{
   display:flex;
-  gap:12px;
+  gap:8px;
   padding:0 12px;
   margin:10px 0;
   overflow:auto;           /* allow horizontal scroll if viewport too narrow */
@@ -292,15 +292,15 @@ table.dataTable thead th.sorting_desc{
   background:var(--kpi-bg);
   border:1px solid var(--kpi-border);
   border-radius:14px;
-  padding:12px 14px;
-  min-width:200px;         /* keep readable width */
+  padding:8px 10px;
+  min-width:160px;         /* keep readable width */
   box-shadow: var(--shadow);
   flex:0 0 1;              /* fixed width cards for single-row layout */
 }
-.kpi .card h4{ margin:0 0 6px; color:#334155; font-size:12px; letter-spacing:.2px }
-.kpi .card p{ margin:0; color:#0f172a; font-size:22px; font-weight:900; line-height:1.1 }
-.kpi .card .sub{ margin-top:4px; font-size:12px; color:#6b7280 }
-.kpi .card .delta{ margin-left:6px; font-size:12px; font-weight:700 }
+.kpi .card h4{ margin:0 0 6px; color:#334155; font-size:10px; letter-spacing:.2px }
+.kpi .card p{ margin:0; color:#0f172a; font-size:18px; font-weight:900; line-height:1.1 }
+.kpi .card .sub{ margin-top:4px; font-size:10px; color:#6b7280 }
+.kpi .card .delta{ margin-left:6px; font-size:10px; font-weight:700 }
 .kpi .card .delta.up{ color:#10b981 }
 .kpi .card .delta.down{ color:#ef4444 }
 
@@ -351,8 +351,8 @@ table.dataTable thead th.sorting_desc{
   background:linear-gradient(135deg,#9d174d,#db2777);
 }
 
-#kpi .stat-card .sub{ margin-top:4px; font-size:12px; color:#f1f5f9; }
-#kpi .stat-card .delta{ margin-left:6px; font-size:12px; font-weight:700; }
+#kpi .stat-card .sub{ margin-top:4px; font-size:10px; color:#f1f5f9; }
+#kpi .stat-card .delta{ margin-left:6px; font-size:10px; font-weight:700; }
 #kpi .stat-card .delta.up{ color:#bbf7d0; }
 #kpi .stat-card .delta.down{ color:#fecaca; }
 

--- a/public/assets/theme深色版.css
+++ b/public/assets/theme深色版.css
@@ -45,12 +45,12 @@ table.dataTable tbody td,table.dataTable thead th{border-color:#172554!important
 .notice{font-size:12px;color:var(--muted,#9ca3af)}
 
 /* --- KPI grid & cards --- */
-.kpi{display:grid;grid-template-columns:repeat(6,minmax(160px,1fr));gap:10px;margin:10px 16px}
-.card{background:var(--panel,#0f172a);color:#fff;padding:12px;border-radius:12px;min-width:160px;box-shadow:0 0 0 1px rgba(148,163,184,.12) inset}
-.card h4{margin:0 0 6px;font-size:13px;color:#93c5fd;font-weight:600}
-.card p{margin:0;font-size:18px;font-weight:800;letter-spacing:.2px}
-.card .sub{margin-top:4px;font-size:12px;color:#9ca3af}
-.card .delta{margin-left:6px;font-size:12px;font-weight:600}
+.kpi{display:grid;grid-template-columns:repeat(6,minmax(140px,1fr));gap:8px;margin:10px 16px}
+.card{background:var(--panel,#0f172a);color:#fff;padding:10px;border-radius:12px;min-width:140px;box-shadow:0 0 0 1px rgba(148,163,184,.12) inset}
+.card h4{margin:0 0 6px;font-size:11px;color:#93c5fd;font-weight:600}
+.card p{margin:0;font-size:16px;font-weight:800;letter-spacing:.2px}
+.card .sub{margin-top:4px;font-size:10px;color:#9ca3af}
+.card .delta{margin-left:6px;font-size:10px;font-weight:600}
 .card .delta.up{color:#10b981}
 .card .delta.down{color:#ef4444}
 
@@ -67,7 +67,7 @@ table.dataTable tbody td,table.dataTable thead th{border-color:#172554!important
 input[type="file"]{display:none !important}
 
 /* --- Responsive adjustments for KPI grid --- */
-@media (max-width:1280px){.kpi{grid-template-columns:repeat(4,minmax(160px,1fr))}}
-@media (max-width:1024px){.kpi{grid-template-columns:repeat(3,minmax(160px,1fr))}}
-@media (max-width:768px){.kpi{grid-template-columns:repeat(2,minmax(160px,1fr))}}
-@media (max-width:480px){.kpi{grid-template-columns:repeat(1,minmax(160px,1fr))}}
+@media (max-width:1280px){.kpi{grid-template-columns:repeat(4,minmax(140px,1fr))}}
+@media (max-width:1024px){.kpi{grid-template-columns:repeat(3,minmax(140px,1fr))}}
+@media (max-width:768px){.kpi{grid-template-columns:repeat(2,minmax(140px,1fr))}}
+@media (max-width:480px){.kpi{grid-template-columns:repeat(1,minmax(140px,1fr))}}


### PR DESCRIPTION
## Summary
- decrease KPI card padding, fonts, and gaps for better screen fit
- apply similar size reductions in dark theme

## Testing
- `npm test` (fails: require is not defined in ES module scope in api/test-data-isolation.js, test-site-configs.js)


------
https://chatgpt.com/codex/tasks/task_e_68bd8a84b8348325bdd4a32be0852fa9