### PR TITLE
Return fractional ratios from AE query API

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@
 - **Ozon**：俄罗斯市场分析
 - **独立站**：多渠道广告数据统一管理
 
+### 📈 自运营查询 API 更新
+- `/api/ae_query` 现在返回 `visitor_ratio`、`add_to_cart_ratio` 和 `payment_ratio` 等比率字段的原始小数（例如 `0.15` 表示 15%），前端应使用 `formatPercentage` 等工具进行百分比格式化。
+
 ---
 
 ## Facebook Ads 优化记录 (2025-01-07)

--- a/api/ae_query/index.js
+++ b/api/ae_query/index.js
@@ -175,11 +175,11 @@ export default async function handler(req, res) {
       let visitor_ratio = null, add_to_cart_ratio = null, payment_ratio = null;
       if (aggregate === 'product') {
         // 访客比 = 总访客数 / 总曝光数
-        visitor_ratio = x.exposure > 0 ? (x.visitors / x.exposure) * 100 : null;
+        visitor_ratio = x.exposure > 0 ? (x.visitors / x.exposure) : null;
         // 加购比 = 总加购人数 / 总访客数
-        add_to_cart_ratio = x.visitors > 0 ? (x.add_people / x.visitors) * 100 : null;
+        add_to_cart_ratio = x.visitors > 0 ? (x.add_people / x.visitors) : null;
         // 支付比 = 总支付件数 / 总加购人数
-        payment_ratio = x.add_people > 0 ? (x.pay_items / x.add_people) * 100 : null;
+        payment_ratio = x.add_people > 0 ? (x.pay_items / x.add_people) : null;
       }
       
       return {

--- a/public/assets/self-operated.js
+++ b/public/assets/self-operated.js
@@ -326,9 +326,9 @@
         });
         
         // 修复计算逻辑：使用与index.html一致的字段名
-        const vr = sum.exposure > 0 ? ((sum.visitors / sum.exposure) * 100) : 0;
-        const cr = sum.visitors > 0 ? ((sum.add_people / sum.visitors) * 100) : 0;  // 使用 add_people
-        const pr = sum.add_people > 0 ? ((sum.pay_buyers / sum.add_people) * 100) : 0;  // 使用 add_people 和 pay_buyers
+        const vr = sum.exposure > 0 ? (sum.visitors / sum.exposure) : 0;
+        const cr = sum.visitors > 0 ? (sum.add_people / sum.visitors) : 0;  // 使用 add_people
+        const pr = sum.add_people > 0 ? (sum.pay_buyers / sum.add_people) : 0;  // 使用 add_people 和 pay_buyers
         
         console.log('KPI计算调试 - 计算结果:', { vr, cr, pr, total: products.size, pe, pc, pp });
 
@@ -341,7 +341,7 @@
         
         const arrow = diff >= 0 ? '↑' : '↓';
         const cls = diff >= 0 ? 'delta up' : 'delta down';
-        const val = isPercent ? Math.abs(diff).toFixed(2) + '%' : Math.abs(diff).toString();
+        const val = isPercent ? (Math.abs(diff) * 100).toFixed(2) + '%' : Math.abs(diff).toString();
         
         el.innerHTML = `<span class="${cls}">${arrow} ${val}</span>`;
       }
@@ -368,9 +368,9 @@
       });
       
       // 更新KPI值
-      this.updateKPI('avgVisitor', cur.vr.toFixed(2) + '%');
-      this.updateKPI('avgCart', cur.cr.toFixed(2) + '%');
-      this.updateKPI('avgPay', cur.pr.toFixed(2) + '%');
+      this.updateKPI('avgVisitor', this.formatPercentage(cur.vr));
+      this.updateKPI('avgCart', this.formatPercentage(cur.cr));
+      this.updateKPI('avgPay', this.formatPercentage(cur.pr));
       this.updateKPI('totalProducts', cur.total);
       this.updateKPI('exposedProducts', cur.pe);
       this.updateKPI('cartedProducts', cur.pc);
@@ -391,9 +391,9 @@
       
       // 调试：输出KPI更新结果
       console.log('KPI更新结果:', {
-        avgVisitor: cur.vr.toFixed(2) + '%',
-        avgCart: cur.cr.toFixed(2) + '%',
-        avgPay: cur.pr.toFixed(2) + '%',
+        avgVisitor: this.formatPercentage(cur.vr),
+        avgCart: this.formatPercentage(cur.cr),
+        avgPay: this.formatPercentage(cur.pr),
         totalProducts: cur.total,
         exposedProducts: cur.pe,
         cartedProducts: cur.pc,
@@ -524,9 +524,9 @@
           const visitors = row.visitors || 0;
           const exposure = row.exposure || 0;
           const payItems = row.pay_items || 0;
-          const visitorRatio = exposure > 0 ? (visitors / exposure) * 100 : 0;
-          const addToCartRatio = visitors > 0 ? (addPeople / visitors) * 100 : 0;
-          const paymentRatio = addPeople > 0 ? (payItems / addPeople) * 100 : 0;
+          const visitorRatio = exposure > 0 ? (visitors / exposure) : 0;
+          const addToCartRatio = visitors > 0 ? (addPeople / visitors) : 0;
+          const paymentRatio = addPeople > 0 ? (payItems / addPeople) : 0;
 
           // 调试：输出前3行的详细数据
           if (index < 3) {

--- a/public/history.html
+++ b/public/history.html
@@ -64,7 +64,7 @@ const dt = $('#tb').DataTable({
     { data:'visitors' },
     { data:'add_people' },
     { data:'pay_orders' },
-    { data:'visitor_ratio' },
+    { data:'visitor_ratio', render: v => v != null ? (Number(v)*100).toFixed(2)+'%' : '' },
     { data:'updated_at' },
   ]
 });

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -1421,17 +1421,17 @@ document.addEventListener('DOMContentLoaded', ()=>{
       const vr = sorted.map(r => {
         const exposure = r.exposure || 0;
         const visitors = r.visitors || 0;
-        return exposure > 0 ? (visitors / exposure * 100) : 0;
+        return exposure > 0 ? (visitors / exposure) : 0;
       });
       const cr = sorted.map(r => {
         const visitors = r.visitors || 0;
         const add = r.add_people || 0;
-        return visitors > 0 ? (add / visitors * 100) : 0;
+        return visitors > 0 ? (add / visitors) : 0;
       });
       const pr = sorted.map(r => {
         const add = r.add_people || 0;
         const pay = r.pay_buyers || 0;
-        return add > 0 ? (pay / add * 100) : 0;
+        return add > 0 ? (pay / add) : 0;
       });
       return { dates, vr, cr, pr };
     }
@@ -1467,11 +1467,11 @@ document.addEventListener('DOMContentLoaded', ()=>{
   // 渲染折线图
   function renderRateChart(id, dates, currentSeries, prevSeries) {
     const option = {
-      tooltip: { trigger: 'axis', valueFormatter: v => `${v.toFixed(2)}%` },
+      tooltip: { trigger: 'axis', valueFormatter: v => PageUtils.formatPercentage(v) },
       legend: { data: ['当前周期', '上一周期'], textStyle: { color: '#374151' } },
       grid: { left: '3%', right: '4%', bottom: '3%', containLabel: true },
       xAxis: { type: 'category', data: dates, axisLabel: { color: '#374151' } },
-      yAxis: { type: 'value', axisLabel: { formatter: v => v.toFixed(2) + '%', color: '#374151' } },
+      yAxis: { type: 'value', max: 1, axisLabel: { formatter: v => PageUtils.formatPercentage(v), color: '#374151' } },
       series: [
         { name: '当前周期', type: 'line', data: currentSeries },
         { name: '上一周期', type: 'line', data: prevSeries }
@@ -1546,11 +1546,11 @@ document.addEventListener('DOMContentLoaded', ()=>{
         return { id:String(x.product_id), rate: den>0? num/den:0, den };
       }).filter(o => o.den >= (minDen||1)).sort((a,b)=>b.rate-a.rate).slice(0,10);
       const names = arr.map(o => o.id);
-      const vals = arr.map(o => Number((o.rate*100).toFixed(2)));
+      const vals = arr.map(o => Number(o.rate.toFixed(4)));
       const option = {
-        tooltip:{ trigger:'axis', axisPointer:{ type:'shadow' }, formatter:p=> p[0].name+': '+p[0].value+'%' },
+        tooltip:{ trigger:'axis', axisPointer:{ type:'shadow' }, formatter:p=> p[0].name+': '+PageUtils.formatPercentage(p[0].value) },
         xAxis:{ type:'category', data:names, axisLabel:{ color:'#374151', rotate:45 } },
-        yAxis:{ type:'value', axisLabel:{ color:'#374151', formatter:'{value}%' } },
+        yAxis:{ type:'value', max:1, axisLabel:{ color:'#374151', formatter: v => PageUtils.formatPercentage(v) } },
         series:[{ type:'bar', data:vals, barMaxWidth:24, itemStyle:{ color:'#3B82F6' } }],
         grid:{ left:40, right:20, top:30, bottom:60 }
       };
@@ -1673,9 +1673,9 @@ document.addEventListener('DOMContentLoaded', ()=>{
       const currentTotalPayItems = data.reduce((sum, item) => sum + (item.pay_items || 0), 0);
       
              // 计算当前周期比率
-       const currentAvgVisitorRate = currentTotalExposure > 0 ? (currentTotalVisitors / currentTotalExposure * 100).toFixed(2) : 0;
-       const currentAvgCartRate = currentTotalVisitors > 0 ? (currentTotalAddPeople / currentTotalVisitors * 100).toFixed(2) : 0; // 使用add_people计算加购比
-       const currentAvgPayRate = currentTotalAddPeople > 0 ? (currentTotalPayItems / currentTotalAddPeople * 100).toFixed(2) : 0; // 使用add_people计算支付比
+       const currentAvgVisitorRate = currentTotalExposure > 0 ? (currentTotalVisitors / currentTotalExposure) : 0;
+       const currentAvgCartRate = currentTotalVisitors > 0 ? (currentTotalAddPeople / currentTotalVisitors) : 0; // 使用add_people计算加购比
+       const currentAvgPayRate = currentTotalAddPeople > 0 ? (currentTotalPayItems / currentTotalAddPeople) : 0; // 使用add_people计算支付比
 
       let comparisonData = {};
       if (previousData && previousData.length > 0) {
@@ -1685,25 +1685,25 @@ document.addEventListener('DOMContentLoaded', ()=>{
          const previousTotalPayItems = previousData.reduce((sum, item) => sum + (item.pay_items || 0), 0);
          const previousTotalPayBuyers = previousData.reduce((sum, item) => sum + (item.pay_buyers || 0), 0);
          
-         const previousAvgVisitorRate = previousTotalExposure > 0 ? (previousTotalVisitors / previousTotalExposure * 100).toFixed(2) : 0;
-         const previousAvgCartRate = previousTotalVisitors > 0 ? (previousTotalAddPeople / previousTotalVisitors * 100).toFixed(2) : 0; // 使用add_people计算加购比
-         const previousAvgPayRate = previousTotalAddPeople > 0 ? (previousTotalPayItems / previousTotalAddPeople * 100).toFixed(2) : 0; // 使用add_people计算支付比
+         const previousAvgVisitorRate = previousTotalExposure > 0 ? (previousTotalVisitors / previousTotalExposure) : 0;
+         const previousAvgCartRate = previousTotalVisitors > 0 ? (previousTotalAddPeople / previousTotalVisitors) : 0; // 使用add_people计算加购比
+         const previousAvgPayRate = previousTotalAddPeople > 0 ? (previousTotalPayItems / previousTotalAddPeople) : 0; // 使用add_people计算支付比
         
         comparisonData = {
           avgVisitorRate: {
-            current: parseFloat(currentAvgVisitorRate),
-            previous: parseFloat(previousAvgVisitorRate),
-            change: parseFloat(currentAvgVisitorRate) - parseFloat(previousAvgVisitorRate)
+            current: currentAvgVisitorRate,
+            previous: previousAvgVisitorRate,
+            change: currentAvgVisitorRate - previousAvgVisitorRate
           },
           avgCartRate: {
-            current: parseFloat(currentAvgCartRate),
-            previous: parseFloat(previousAvgCartRate),
-            change: parseFloat(currentAvgCartRate) - parseFloat(previousAvgCartRate)
+            current: currentAvgCartRate,
+            previous: previousAvgCartRate,
+            change: currentAvgCartRate - previousAvgCartRate
           },
           avgPayRate: {
-            current: parseFloat(currentAvgPayRate),
-            previous: parseFloat(previousAvgPayRate),
-            change: parseFloat(currentAvgPayRate) - parseFloat(previousAvgPayRate)
+            current: currentAvgPayRate,
+            previous: previousAvgPayRate,
+            change: currentAvgPayRate - previousAvgPayRate
           },
           totalExposure: {
             current: currentTotalExposure,
@@ -1740,9 +1740,9 @@ document.addEventListener('DOMContentLoaded', ()=>{
       });
       
       // 更新KPI显示
-      document.getElementById('productAvgVisitor').textContent = currentAvgVisitorRate + '%';
-      document.getElementById('productAvgCart').textContent = currentAvgCartRate + '%';
-      document.getElementById('productAvgPay').textContent = currentAvgPayRate + '%';
+      document.getElementById('productAvgVisitor').textContent = PageUtils.formatPercentage(currentAvgVisitorRate);
+      document.getElementById('productAvgCart').textContent = PageUtils.formatPercentage(currentAvgCartRate);
+      document.getElementById('productAvgPay').textContent = PageUtils.formatPercentage(currentAvgPayRate);
       document.getElementById('productTotalExposure').textContent = currentTotalExposure.toLocaleString();
       document.getElementById('productTotalVisitors').textContent = currentTotalVisitors.toLocaleString();
       document.getElementById('productTotalAddPeople').textContent = currentTotalAddPeople.toLocaleString();
@@ -1770,22 +1770,22 @@ document.addEventListener('DOMContentLoaded', ()=>{
       const visitorChange = comparisonData.avgVisitorRate.change;
       const visitorSymbol = visitorChange > 0 ? '↑' : visitorChange < 0 ? '↓' : '';
       const visitorColor = visitorChange > 0 ? 'text-green-600' : visitorChange < 0 ? 'text-red-600' : 'text-gray-500';
-      document.getElementById('productAvgVisitorComparison').innerHTML = 
-        `<span class="${visitorColor}">${visitorSymbol} ${Math.abs(visitorChange).toFixed(2)}%</span>`;
+      document.getElementById('productAvgVisitorComparison').innerHTML =
+        `<span class="${visitorColor}">${visitorSymbol} ${PageUtils.formatPercentage(Math.abs(visitorChange))}</span>`;
       
       // 更新平均加购比对比
       const cartChange = comparisonData.avgCartRate.change;
       const cartSymbol = cartChange > 0 ? '↑' : cartChange < 0 ? '↓' : '';
       const cartColor = cartChange > 0 ? 'text-green-600' : cartChange < 0 ? 'text-red-600' : 'text-gray-500';
-      document.getElementById('productAvgCartComparison').innerHTML = 
-        `<span class="${cartColor}">${cartSymbol} ${Math.abs(cartChange).toFixed(2)}%</span>`;
+      document.getElementById('productAvgCartComparison').innerHTML =
+        `<span class="${cartColor}">${cartSymbol} ${PageUtils.formatPercentage(Math.abs(cartChange))}</span>`;
       
       // 更新平均支付比对比
       const payChange = comparisonData.avgPayRate.change;
       const paySymbol = payChange > 0 ? '↑' : payChange < 0 ? '↓' : '';
       const payColor = payChange > 0 ? 'text-green-600' : payChange < 0 ? 'text-red-600' : 'text-gray-500';
-      document.getElementById('productAvgPayComparison').innerHTML = 
-        `<span class="${payColor}">${cartSymbol} ${Math.abs(payChange).toFixed(2)}%</span>`;
+      document.getElementById('productAvgPayComparison').innerHTML =
+        `<span class="${payColor}">${paySymbol} ${PageUtils.formatPercentage(Math.abs(payChange))}</span>`;
       
       // 更新总曝光量对比
       const exposureChange = comparisonData.totalExposure.change;
@@ -1911,7 +1911,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
 
     // 访客比趋势图
     const productVisitorRateOption = {
-      tooltip: { trigger: 'axis' },
+      tooltip: { trigger: 'axis', valueFormatter: v => PageUtils.formatPercentage(v) },
       legend: { data: [curLabel, prevLabel], textStyle: { color: '#374151' } },
       xAxis: {
         type: 'category',
@@ -1920,7 +1920,8 @@ document.addEventListener('DOMContentLoaded', ()=>{
       },
       yAxis: {
         type: 'value',
-        axisLabel: { color: '#374151', fontSize: 12, formatter: '{value}%' }
+        max: 1,
+        axisLabel: { color: '#374151', fontSize: 12, formatter: v => PageUtils.formatPercentage(v) }
       },
       series: [
         {
@@ -1928,7 +1929,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
           data: data.map(item => {
             const exposure = item.exposure || 0;
             const visitors = item.visitors || 0;
-            return exposure > 0 ? ((visitors / exposure) * 100).toFixed(2) : 0;
+            return exposure > 0 ? (visitors / exposure) : 0;
           }),
           type: 'line',
           smooth: true,
@@ -1940,7 +1941,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
             const item = previousData[i] || {};
             const exposure = item.exposure || 0;
             const visitors = item.visitors || 0;
-            return exposure > 0 ? ((visitors / exposure) * 100).toFixed(2) : 0;
+            return exposure > 0 ? (visitors / exposure) : 0;
           }),
           type: 'line',
           smooth: true,
@@ -1952,7 +1953,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
 
     // 加购比趋势图
     const productAddRateOption = {
-       tooltip: { trigger: 'axis' },
+       tooltip: { trigger: 'axis', valueFormatter: v => PageUtils.formatPercentage(v) },
        legend: { data: [curLabel, prevLabel], textStyle: { color: '#374151' } },
        xAxis: {
          type: 'category',
@@ -1961,7 +1962,8 @@ document.addEventListener('DOMContentLoaded', ()=>{
        },
        yAxis: {
          type: 'value',
-         axisLabel: { color: '#374151', fontSize: 12, formatter: '{value}%' }
+         max: 1,
+         axisLabel: { color: '#374151', fontSize: 12, formatter: v => PageUtils.formatPercentage(v) }
        },
        series: [
          {
@@ -1969,7 +1971,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
            data: data.map(item => {
              const visitors = item.visitors || 0;
              const addPeople = item.add_people || 0;
-             return visitors > 0 ? ((addPeople / visitors) * 100).toFixed(2) : 0;
+             return visitors > 0 ? (addPeople / visitors) : 0;
            }),
            type: 'line',
            smooth: true,
@@ -1981,7 +1983,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
              const item = previousData[i] || {};
              const visitors = item.visitors || 0;
              const addPeople = item.add_people || 0;
-             return visitors > 0 ? ((addPeople / visitors) * 100).toFixed(2) : 0;
+             return visitors > 0 ? (addPeople / visitors) : 0;
            }),
            type: 'line',
            smooth: true,
@@ -1993,7 +1995,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
 
     // 支付比趋势图
     const productPayRateOption = {
-       tooltip: { trigger: 'axis' },
+       tooltip: { trigger: 'axis', valueFormatter: v => PageUtils.formatPercentage(v) },
        legend: { data: [curLabel, prevLabel], textStyle: { color: '#374151' } },
        xAxis: {
          type: 'category',
@@ -2002,7 +2004,8 @@ document.addEventListener('DOMContentLoaded', ()=>{
        },
        yAxis: {
          type: 'value',
-         axisLabel: { color: '#374151', fontSize: 12, formatter: '{value}%' }
+         max: 1,
+         axisLabel: { color: '#374151', fontSize: 12, formatter: v => PageUtils.formatPercentage(v) }
        },
        series: [
          {
@@ -2010,7 +2013,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
            data: data.map(item => {
              const addPeople = item.add_people || 0;
              const payItems = item.pay_items || 0;
-             return addPeople > 0 ? ((payItems / addPeople) * 100).toFixed(2) : 0;
+             return addPeople > 0 ? (payItems / addPeople) : 0;
            }),
            type: 'line',
            smooth: true,
@@ -2022,7 +2025,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
              const item = previousData[i] || {};
              const addPeople = item.add_people || 0;
              const payItems = item.pay_items || 0;
-             return addPeople > 0 ? ((payItems / addPeople) * 100).toFixed(2) : 0;
+             return addPeople > 0 ? (payItems / addPeople) : 0;
            }),
            type: 'line',
            smooth: true,

--- a/public/test-self-operated-simple.html
+++ b/public/test-self-operated-simple.html
@@ -468,9 +468,9 @@
             
             displayKPIs(kpis, changes) {
                 // 更新主要KPI值
-                this.updateKPI('avgVisitor', kpis.avgVisitorRatio.toFixed(2) + '%');
-                this.updateKPI('avgCart', kpis.avgCartRatio.toFixed(2) + '%');
-                this.updateKPI('avgPay', kpis.avgPayRatio.toFixed(2) + '%');
+                this.updateKPI('avgVisitor', this.formatPercentage(kpis.avgVisitorRatio));
+                this.updateKPI('avgCart', this.formatPercentage(kpis.avgCartRatio));
+                this.updateKPI('avgPay', this.formatPercentage(kpis.avgPayRatio));
                 this.updateKPI('totalProducts', kpis.totalProducts);
                 this.updateKPI('cartedProducts', kpis.cartedProducts);
                 this.updateKPI('purchasedProducts', kpis.purchasedProducts);


### PR DESCRIPTION
## Summary
- Stop multiplying visitor, add-to-cart, and payment ratios by 100 in `/api/ae_query`
- Convert frontend KPI calculations and tables to treat ratios as fractions and format via `formatPercentage`
- Document that AE query ratios are now returned as raw fractions

## Testing
- `npm test` *(fails: ReferenceError: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8dc870208325a8bfad01eb0e09c5