### PR TITLE
Return fractional ratios from AE query API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   - `/api/independent/tiktok-ingest` - TikTok Ads数据上传
   - `/api/independent/ingest` - Google Ads数据上传
   - `/api/independent/stats?channel=<channel>` - 多渠道数据查询
+  - `/api/ae_query` - 速卖通自运营数据查询（`visitor_ratio`、`add_to_cart_ratio`、`payment_ratio` 等比率字段以0-1的小数返回）
 
 ### 📊 数据分析功能
 - **运营分析**：KPI对比、趋势分析、周期对比

--- a/api/ae_query/index.js
+++ b/api/ae_query/index.js
@@ -175,11 +175,11 @@ export default async function handler(req, res) {
       let visitor_ratio = null, add_to_cart_ratio = null, payment_ratio = null;
       if (aggregate === 'product') {
         // 访客比 = 总访客数 / 总曝光数
-        visitor_ratio = x.exposure > 0 ? (x.visitors / x.exposure) * 100 : null;
+        visitor_ratio = x.exposure > 0 ? (x.visitors / x.exposure) : null;
         // 加购比 = 总加购人数 / 总访客数
-        add_to_cart_ratio = x.visitors > 0 ? (x.add_people / x.visitors) * 100 : null;
+        add_to_cart_ratio = x.visitors > 0 ? (x.add_people / x.visitors) : null;
         // 支付比 = 总支付件数 / 总加购人数
-        payment_ratio = x.add_people > 0 ? (x.pay_items / x.add_people) * 100 : null;
+        payment_ratio = x.add_people > 0 ? (x.pay_items / x.add_people) : null;
       }
       
       return {

--- a/api/test-data-isolation.js
+++ b/api/test-data-isolation.js
@@ -9,7 +9,7 @@ function getClient() {
   return createClient(url, key);
 }
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
@@ -114,3 +114,5 @@ export default async function handler(req, res) {
     });
   }
 }
+
+module.exports = handler;

--- a/api/test-site-configs.js
+++ b/api/test-site-configs.js
@@ -9,7 +9,7 @@ function getClient() {
   return createClient(url, key);
 }
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   // 设置CORS头
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
@@ -111,3 +111,5 @@ export default async function handler(req, res) {
     });
   }
 }
+
+module.exports = handler;

--- a/public/assets/global-theme.css
+++ b/public/assets/global-theme.css
@@ -389,13 +389,31 @@ body {
   .grid-2, .grid-3, .grid-4 {
     grid-template-columns: 1fr;
   }
-  
+
   .kpi-card {
     padding: var(--space-4);
   }
-  
+
+  .kpi-card h4 {
+    font-size: 0.75rem;
+  }
+
+  .kpi-card p {
+    font-size: 1.5rem;
+  }
+
   .chart-container {
     padding: var(--space-4);
+  }
+}
+
+@media (max-width: 480px) {
+  .kpi-card {
+    padding: var(--space-3);
+  }
+
+  .kpi-card p {
+    font-size: 1.25rem;
   }
 }
 

--- a/public/assets/page-template.js
+++ b/public/assets/page-template.js
@@ -435,8 +435,8 @@
       if (num === null || num === undefined) return '0%';
       const n = Number(num);
       if (isNaN(n)) return '0%';
-      if (n <= 1) n *= 100;
-      return n.toFixed(decimals) + '%';
+      const value = n <= 1 ? n * 100 : n;
+      return value.toFixed(decimals) + '%';
     },
 
     // 安全的JSON解析

--- a/public/assets/self-operated.js
+++ b/public/assets/self-operated.js
@@ -326,25 +326,27 @@
         });
         
         // 修复计算逻辑：使用与index.html一致的字段名
-        const vr = sum.exposure > 0 ? ((sum.visitors / sum.exposure) * 100) : 0;
-        const cr = sum.visitors > 0 ? ((sum.add_people / sum.visitors) * 100) : 0;  // 使用 add_people
-        const pr = sum.add_people > 0 ? ((sum.pay_buyers / sum.add_people) * 100) : 0;  // 使用 add_people 和 pay_buyers
+        const vr = sum.exposure > 0 ? (sum.visitors / sum.exposure) : 0;
+        const cr = sum.visitors > 0 ? (sum.add_people / sum.visitors) : 0;  // 使用 add_people
+        const pr = sum.add_people > 0 ? (sum.pay_buyers / sum.add_people) : 0;  // 使用 add_people 和 pay_buyers
         
         console.log('KPI计算调试 - 计算结果:', { vr, cr, pr, total: products.size, pe, pc, pp });
 
         return {vr, cr, pr, total: products.size, pe, pc, pp, newProducts: 0}; // 暂时返回0，后续计算
       }
       
-      function setDelta(id, diff, isPercent) {
+      const setDelta = (id, diff, isPercent) => {
         const el = document.getElementById(id);
         if (!el) return;
-        
+
         const arrow = diff >= 0 ? '↑' : '↓';
         const cls = diff >= 0 ? 'delta up' : 'delta down';
-        const val = isPercent ? Math.abs(diff).toFixed(2) + '%' : Math.abs(diff).toString();
-        
+        const val = isPercent
+          ? this.formatPercentage(Math.abs(diff))
+          : Math.abs(diff).toString();
+
         el.innerHTML = `<span class="${cls}">${arrow} ${val}</span>`;
-      }
+      };
       
       const cur = summarize(rows);
       const prev = summarize(prevRows || []);
@@ -368,9 +370,9 @@
       });
       
       // 更新KPI值
-      this.updateKPI('avgVisitor', cur.vr.toFixed(2) + '%');
-      this.updateKPI('avgCart', cur.cr.toFixed(2) + '%');
-      this.updateKPI('avgPay', cur.pr.toFixed(2) + '%');
+      this.updateKPI('avgVisitor', this.formatPercentage(cur.vr));
+      this.updateKPI('avgCart', this.formatPercentage(cur.cr));
+      this.updateKPI('avgPay', this.formatPercentage(cur.pr));
       this.updateKPI('totalProducts', cur.total);
       this.updateKPI('exposedProducts', cur.pe);
       this.updateKPI('cartedProducts', cur.pc);
@@ -391,9 +393,9 @@
       
       // 调试：输出KPI更新结果
       console.log('KPI更新结果:', {
-        avgVisitor: cur.vr.toFixed(2) + '%',
-        avgCart: cur.cr.toFixed(2) + '%',
-        avgPay: cur.pr.toFixed(2) + '%',
+        avgVisitor: this.formatPercentage(cur.vr),
+        avgCart: this.formatPercentage(cur.cr),
+        avgPay: this.formatPercentage(cur.pr),
         totalProducts: cur.total,
         exposedProducts: cur.pe,
         cartedProducts: cur.pc,
@@ -524,9 +526,9 @@
           const visitors = row.visitors || 0;
           const exposure = row.exposure || 0;
           const payItems = row.pay_items || 0;
-          const visitorRatio = exposure > 0 ? (visitors / exposure) * 100 : 0;
-          const addToCartRatio = visitors > 0 ? (addPeople / visitors) * 100 : 0;
-          const paymentRatio = addPeople > 0 ? (payItems / addPeople) * 100 : 0;
+          const visitorRatio = exposure > 0 ? (visitors / exposure) : 0;
+          const addToCartRatio = visitors > 0 ? (addPeople / visitors) : 0;
+          const paymentRatio = addPeople > 0 ? (payItems / addPeople) : 0;
 
           // 调试：输出前3行的详细数据
           if (index < 3) {

--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -358,6 +358,13 @@ table.dataTable thead th.sorting_desc{
 
 /* Override self-operated KPI sub/delta colors for contrast */
 .kpi .card .sub{ color:#f1f5f9; }
+
+@media (max-width:768px){
+  .stat-card,
+  .kpi .card{ padding:12px; }
+  .stat-card p,
+  .kpi .card p{ font-size:22px; }
+}
 .kpi .card .delta.up{ color:#bbf7d0; }
 .kpi .card .delta.down{ color:#fecaca; }
 .kpi .card a{ color:#fff; text-decoration:underline; }

--- a/public/test-self-operated-simple.html
+++ b/public/test-self-operated-simple.html
@@ -44,28 +44,37 @@
         
         .kpi-card {
             background: white;
-            padding: 20px;
+            padding: 12px;
             border-radius: 8px;
             box-shadow: 0 2px 8px rgba(0,0,0,0.1);
             text-align: center;
             border-left: 4px solid #667eea;
         }
-        
+
         .kpi-value {
-            font-size: 2em;
+            font-size: 1.5em;
             font-weight: bold;
             color: #333;
-            margin: 10px 0;
+            margin: 8px 0;
         }
-        
+
         .kpi-label {
             color: #666;
-            font-size: 0.9em;
-        }
-        
-        .kpi-comparison {
-            margin-top: 10px;
             font-size: 0.8em;
+        }
+
+        .kpi-comparison {
+            margin-top: 8px;
+            font-size: 0.7em;
+        }
+
+        @media (max-width: 600px) {
+            .kpi-card {
+                padding: 10px;
+            }
+            .kpi-value {
+                font-size: 1.25em;
+            }
         }
         
         .controls {
@@ -424,12 +433,12 @@
                 data.forEach((row, index) => {
                     // 调试前3行数据
                     if (index < 3) {
-                        this.updateDebugInfo(`行${index + 1}数据: 访客比=${row.visitor_ratio}, 加购比=${row.cart_ratio}, 支付比=${row.pay_ratio}`);
+                        this.updateDebugInfo(`行${index + 1}数据: 访客比=${row.visitor_ratio}, 加购比=${row.add_to_cart_ratio}, 支付比=${row.payment_ratio}`);
                     }
                     
                     const visitorRatio = parseFloat(row.visitor_ratio) || 0;
-                    const cartRatio = parseFloat(row.cart_ratio) || 0;
-                    const payRatio = parseFloat(row.pay_ratio) || 0;
+                    const cartRatio = parseFloat(row.add_to_cart_ratio) || 0;
+                    const payRatio = parseFloat(row.payment_ratio) || 0;
                     
                     totalVisitorRatio += visitorRatio;
                     totalCartRatio += cartRatio;
@@ -468,9 +477,9 @@
             
             displayKPIs(kpis, changes) {
                 // 更新主要KPI值
-                this.updateKPI('avgVisitor', kpis.avgVisitorRatio.toFixed(2) + '%');
-                this.updateKPI('avgCart', kpis.avgCartRatio.toFixed(2) + '%');
-                this.updateKPI('avgPay', kpis.avgPayRatio.toFixed(2) + '%');
+                this.updateKPI('avgVisitor', this.formatPercentage(kpis.avgVisitorRatio));
+                this.updateKPI('avgCart', this.formatPercentage(kpis.avgCartRatio));
+                this.updateKPI('avgPay', this.formatPercentage(kpis.avgPayRatio));
                 this.updateKPI('totalProducts', kpis.totalProducts);
                 this.updateKPI('cartedProducts', kpis.cartedProducts);
                 this.updateKPI('purchasedProducts', kpis.purchasedProducts);
@@ -527,8 +536,8 @@
                         <td>${row.product_id || '-'}</td>
                         <td>${row.bucket || '-'}</td>
                         <td>${this.formatPercentage(row.visitor_ratio)}</td>
-                        <td>${this.formatPercentage(row.cart_ratio)}</td>
-                        <td>${this.formatPercentage(row.pay_ratio)}</td>
+                        <td>${this.formatPercentage(row.add_to_cart_ratio)}</td>
+                        <td>${this.formatPercentage(row.payment_ratio)}</td>
                         <td>${this.formatNumber(row.exposure)}</td>
                         <td>${this.formatNumber(row.visitors)}</td>
                         <td>${this.formatNumber(row.cart_users)}</td>


### PR DESCRIPTION
## Summary
- return raw fractions for `visitor_ratio`, `add_to_cart_ratio`, and `payment_ratio` in the `/api/ae_query` product aggregation
- display product and KPI ratios by formatting fractions on the client
- document that `/api/ae_query` now returns fractional ratio fields
- adjust KPI card padding and fonts for better fit on small screens
- convert test API handlers to CommonJS so node tests run cleanly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd8dc870208325a8bfad01eb0e09c5