### PR TITLE
Return fractional ratios from AE query API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   - `/api/independent/tiktok-ingest` - TikTok Ads数据上传
   - `/api/independent/ingest` - Google Ads数据上传
   - `/api/independent/stats?channel=<channel>` - 多渠道数据查询
+  - `/api/ae_query` - 速卖通自运营数据查询（`visitor_ratio`、`add_to_cart_ratio`、`payment_ratio` 等比率字段以0-1的小数返回）
 
 ### 📊 数据分析功能
 - **运营分析**：KPI对比、趋势分析、周期对比

--- a/api/ae_query/index.js
+++ b/api/ae_query/index.js
@@ -175,11 +175,11 @@ export default async function handler(req, res) {
       let visitor_ratio = null, add_to_cart_ratio = null, payment_ratio = null;
       if (aggregate === 'product') {
         // 访客比 = 总访客数 / 总曝光数
-        visitor_ratio = x.exposure > 0 ? (x.visitors / x.exposure) * 100 : null;
+        visitor_ratio = x.exposure > 0 ? (x.visitors / x.exposure) : null;
         // 加购比 = 总加购人数 / 总访客数
-        add_to_cart_ratio = x.visitors > 0 ? (x.add_people / x.visitors) * 100 : null;
+        add_to_cart_ratio = x.visitors > 0 ? (x.add_people / x.visitors) : null;
         // 支付比 = 总支付件数 / 总加购人数
-        payment_ratio = x.add_people > 0 ? (x.pay_items / x.add_people) * 100 : null;
+        payment_ratio = x.add_people > 0 ? (x.pay_items / x.add_people) : null;
       }
       
       return {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "test": "node --test"
+    "test": "node --test \"api/**/*.test.js\" api/test.js test-api-structure.js"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.45.4",

--- a/public/assets/global-theme.css
+++ b/public/assets/global-theme.css
@@ -72,16 +72,16 @@ body {
 /* 3. KPI卡片系统 */
 .kpi-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: var(--space-6);
-  margin: var(--space-6) 0;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--space-4);
+  margin: var(--space-4) 0;
 }
 
 .kpi-card {
   background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
   border: 1px solid var(--primary-200);
   border-radius: var(--radius-lg);
-  padding: var(--space-6);
+  padding: var(--space-4);
   box-shadow: var(--shadow-md);
   transition: all 0.3s ease;
   position: relative;
@@ -106,7 +106,7 @@ body {
 
 .kpi-card h4 {
   color: var(--primary-600);
-  font-size: 0.875rem;
+  font-size: 0.75rem;
   font-weight: 500;
   margin: 0 0 var(--space-2) 0;
   text-transform: uppercase;
@@ -115,7 +115,7 @@ body {
 
 .kpi-card p {
   color: var(--primary-900);
-  font-size: 1.875rem;
+  font-size: 1.5rem;
   font-weight: 700;
   margin: 0;
   line-height: 1;
@@ -123,7 +123,7 @@ body {
 
 .kpi-card .kpi-comparison {
   margin-top: var(--space-2);
-  font-size: 0.875rem;
+  font-size: 0.75rem;
 }
 
 .kpi-card .delta {

--- a/public/assets/page-template.js
+++ b/public/assets/page-template.js
@@ -435,8 +435,8 @@
       if (num === null || num === undefined) return '0%';
       const n = Number(num);
       if (isNaN(n)) return '0%';
-      if (n <= 1) n *= 100;
-      return n.toFixed(decimals) + '%';
+      const value = n <= 1 ? n * 100 : n;
+      return value.toFixed(decimals) + '%';
     },
 
     // 安全的JSON解析

--- a/public/assets/self-operated.js
+++ b/public/assets/self-operated.js
@@ -326,25 +326,27 @@
         });
         
         // 修复计算逻辑：使用与index.html一致的字段名
-        const vr = sum.exposure > 0 ? ((sum.visitors / sum.exposure) * 100) : 0;
-        const cr = sum.visitors > 0 ? ((sum.add_people / sum.visitors) * 100) : 0;  // 使用 add_people
-        const pr = sum.add_people > 0 ? ((sum.pay_buyers / sum.add_people) * 100) : 0;  // 使用 add_people 和 pay_buyers
+        const vr = sum.exposure > 0 ? (sum.visitors / sum.exposure) : 0;
+        const cr = sum.visitors > 0 ? (sum.add_people / sum.visitors) : 0;  // 使用 add_people
+        const pr = sum.add_people > 0 ? (sum.pay_buyers / sum.add_people) : 0;  // 使用 add_people 和 pay_buyers
         
         console.log('KPI计算调试 - 计算结果:', { vr, cr, pr, total: products.size, pe, pc, pp });
 
         return {vr, cr, pr, total: products.size, pe, pc, pp, newProducts: 0}; // 暂时返回0，后续计算
       }
       
-      function setDelta(id, diff, isPercent) {
+      const setDelta = (id, diff, isPercent) => {
         const el = document.getElementById(id);
         if (!el) return;
-        
+
         const arrow = diff >= 0 ? '↑' : '↓';
         const cls = diff >= 0 ? 'delta up' : 'delta down';
-        const val = isPercent ? Math.abs(diff).toFixed(2) + '%' : Math.abs(diff).toString();
-        
+        const val = isPercent
+          ? this.formatPercentage(Math.abs(diff))
+          : Math.abs(diff).toString();
+
         el.innerHTML = `<span class="${cls}">${arrow} ${val}</span>`;
-      }
+      };
       
       const cur = summarize(rows);
       const prev = summarize(prevRows || []);
@@ -368,9 +370,9 @@
       });
       
       // 更新KPI值
-      this.updateKPI('avgVisitor', cur.vr.toFixed(2) + '%');
-      this.updateKPI('avgCart', cur.cr.toFixed(2) + '%');
-      this.updateKPI('avgPay', cur.pr.toFixed(2) + '%');
+      this.updateKPI('avgVisitor', this.formatPercentage(cur.vr));
+      this.updateKPI('avgCart', this.formatPercentage(cur.cr));
+      this.updateKPI('avgPay', this.formatPercentage(cur.pr));
       this.updateKPI('totalProducts', cur.total);
       this.updateKPI('exposedProducts', cur.pe);
       this.updateKPI('cartedProducts', cur.pc);
@@ -391,9 +393,9 @@
       
       // 调试：输出KPI更新结果
       console.log('KPI更新结果:', {
-        avgVisitor: cur.vr.toFixed(2) + '%',
-        avgCart: cur.cr.toFixed(2) + '%',
-        avgPay: cur.pr.toFixed(2) + '%',
+        avgVisitor: this.formatPercentage(cur.vr),
+        avgCart: this.formatPercentage(cur.cr),
+        avgPay: this.formatPercentage(cur.pr),
         totalProducts: cur.total,
         exposedProducts: cur.pe,
         cartedProducts: cur.pc,
@@ -524,9 +526,9 @@
           const visitors = row.visitors || 0;
           const exposure = row.exposure || 0;
           const payItems = row.pay_items || 0;
-          const visitorRatio = exposure > 0 ? (visitors / exposure) * 100 : 0;
-          const addToCartRatio = visitors > 0 ? (addPeople / visitors) * 100 : 0;
-          const paymentRatio = addPeople > 0 ? (payItems / addPeople) * 100 : 0;
+          const visitorRatio = exposure > 0 ? (visitors / exposure) : 0;
+          const addToCartRatio = visitors > 0 ? (addPeople / visitors) : 0;
+          const paymentRatio = addPeople > 0 ? (payItems / addPeople) : 0;
 
           // 调试：输出前3行的详细数据
           if (index < 3) {

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -200,9 +200,9 @@
     
     .analysis-container h3 {
       color: #374151;
-      font-size: 24px;
+      font-size: 20px;
       font-weight: 600;
-      margin: 0 0 20px 0;
+      margin: 0 0 16px 0;
       text-align: center;
       text-shadow: none;
     }
@@ -210,21 +210,21 @@
     /* 分析KPI卡片网格 */
     .analysis-kpi-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-      gap: 16px;
-      margin-bottom: 24px;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 12px;
+      margin-bottom: 16px;
     }
 
     /* 运营分析KPI卡片特殊样式 - 两列布局 */
     #analysis .analysis-kpi-grid {
       grid-template-columns: repeat(2, 1fr);
-      gap: 16px;
+      gap: 12px;
     }
     
          .analysis-kpi-card {
        background: white;
        border-radius: 12px;
-       padding: 20px;
+       padding: 16px;
        text-align: center;
        box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
        transition: all 0.3s ease;
@@ -264,16 +264,16 @@
     
     .analysis-kpi-card h4 {
       color: #374151;
-      font-size: 14px;
+      font-size: 12px;
       font-weight: 600;
       margin: 0 0 12px 0;
       text-transform: uppercase;
       letter-spacing: 0.5px;
     }
-    
+
     .analysis-kpi-card p {
       color: #1f2937;
-      font-size: 28px;
+      font-size: 24px;
       font-weight: 700;
       margin: 0;
       text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
@@ -680,7 +680,7 @@
         </div>
            
                        <!-- 产品KPI - 单个产品的KPI指标 -->
-            <div id="productKpi" class="analysis-kpi-grid" style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 16px;">
+            <div id="productKpi" class="analysis-kpi-grid" style="grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px;">
               <div class="analysis-kpi-card">
                 <h4>平均访客比</h4>
                 <p id="productAvgVisitor">0%</p>

--- a/public/test-self-operated-simple.html
+++ b/public/test-self-operated-simple.html
@@ -37,35 +37,35 @@
         
         .kpi-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 20px;
-            margin-bottom: 30px;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 15px;
+            margin-bottom: 20px;
         }
-        
+
         .kpi-card {
             background: white;
-            padding: 20px;
+            padding: 15px;
             border-radius: 8px;
             box-shadow: 0 2px 8px rgba(0,0,0,0.1);
             text-align: center;
             border-left: 4px solid #667eea;
         }
-        
+
         .kpi-value {
-            font-size: 2em;
+            font-size: 1.5em;
             font-weight: bold;
             color: #333;
-            margin: 10px 0;
+            margin: 8px 0;
         }
-        
+
         .kpi-label {
             color: #666;
-            font-size: 0.9em;
-        }
-        
-        .kpi-comparison {
-            margin-top: 10px;
             font-size: 0.8em;
+        }
+
+        .kpi-comparison {
+            margin-top: 8px;
+            font-size: 0.75em;
         }
         
         .controls {
@@ -424,12 +424,12 @@
                 data.forEach((row, index) => {
                     // 调试前3行数据
                     if (index < 3) {
-                        this.updateDebugInfo(`行${index + 1}数据: 访客比=${row.visitor_ratio}, 加购比=${row.cart_ratio}, 支付比=${row.pay_ratio}`);
+                        this.updateDebugInfo(`行${index + 1}数据: 访客比=${row.visitor_ratio}, 加购比=${row.add_to_cart_ratio}, 支付比=${row.payment_ratio}`);
                     }
                     
                     const visitorRatio = parseFloat(row.visitor_ratio) || 0;
-                    const cartRatio = parseFloat(row.cart_ratio) || 0;
-                    const payRatio = parseFloat(row.pay_ratio) || 0;
+                    const cartRatio = parseFloat(row.add_to_cart_ratio) || 0;
+                    const payRatio = parseFloat(row.payment_ratio) || 0;
                     
                     totalVisitorRatio += visitorRatio;
                     totalCartRatio += cartRatio;
@@ -468,9 +468,9 @@
             
             displayKPIs(kpis, changes) {
                 // 更新主要KPI值
-                this.updateKPI('avgVisitor', kpis.avgVisitorRatio.toFixed(2) + '%');
-                this.updateKPI('avgCart', kpis.avgCartRatio.toFixed(2) + '%');
-                this.updateKPI('avgPay', kpis.avgPayRatio.toFixed(2) + '%');
+                this.updateKPI('avgVisitor', this.formatPercentage(kpis.avgVisitorRatio));
+                this.updateKPI('avgCart', this.formatPercentage(kpis.avgCartRatio));
+                this.updateKPI('avgPay', this.formatPercentage(kpis.avgPayRatio));
                 this.updateKPI('totalProducts', kpis.totalProducts);
                 this.updateKPI('cartedProducts', kpis.cartedProducts);
                 this.updateKPI('purchasedProducts', kpis.purchasedProducts);
@@ -527,8 +527,8 @@
                         <td>${row.product_id || '-'}</td>
                         <td>${row.bucket || '-'}</td>
                         <td>${this.formatPercentage(row.visitor_ratio)}</td>
-                        <td>${this.formatPercentage(row.cart_ratio)}</td>
-                        <td>${this.formatPercentage(row.pay_ratio)}</td>
+                        <td>${this.formatPercentage(row.add_to_cart_ratio)}</td>
+                        <td>${this.formatPercentage(row.payment_ratio)}</td>
                         <td>${this.formatNumber(row.exposure)}</td>
                         <td>${this.formatNumber(row.visitors)}</td>
                         <td>${this.formatNumber(row.cart_users)}</td>


### PR DESCRIPTION
## Summary
- return raw fractions for `visitor_ratio`, `add_to_cart_ratio`, and `payment_ratio` in the `/api/ae_query` product aggregation
- display product and KPI ratios by formatting fractions on the client
- document that `/api/ae_query` now returns fractional ratio fields
- scale down KPI cards and fonts for better small-screen layout
- run tests only on dedicated test files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd8dc870208325a8bfad01eb0e09c5