### PR TITLE
Return fractional ratios from AE query API and split cycle comparison charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   - `/api/independent/tiktok-ingest` - TikTok Ads数据上传
   - `/api/independent/ingest` - Google Ads数据上传
   - `/api/independent/stats?channel=<channel>` - 多渠道数据查询
+  - `/api/ae_query` - 速卖通自运营数据查询（`visitor_ratio`、`add_to_cart_ratio`、`payment_ratio` 等比率字段以0-1的小数返回）
 
 ### 📊 数据分析功能
 - **运营分析**：KPI对比、趋势分析、周期对比

--- a/api/ae_query/index.js
+++ b/api/ae_query/index.js
@@ -175,11 +175,11 @@ export default async function handler(req, res) {
       let visitor_ratio = null, add_to_cart_ratio = null, payment_ratio = null;
       if (aggregate === 'product') {
         // 访客比 = 总访客数 / 总曝光数
-        visitor_ratio = x.exposure > 0 ? (x.visitors / x.exposure) * 100 : null;
+        visitor_ratio = x.exposure > 0 ? (x.visitors / x.exposure) : null;
         // 加购比 = 总加购人数 / 总访客数
-        add_to_cart_ratio = x.visitors > 0 ? (x.add_people / x.visitors) * 100 : null;
+        add_to_cart_ratio = x.visitors > 0 ? (x.add_people / x.visitors) : null;
         // 支付比 = 总支付件数 / 总加购人数
-        payment_ratio = x.add_people > 0 ? (x.pay_items / x.add_people) * 100 : null;
+        payment_ratio = x.add_people > 0 ? (x.pay_items / x.add_people) : null;
       }
       
       return {

--- a/public/assets/global-theme.css
+++ b/public/assets/global-theme.css
@@ -72,16 +72,16 @@ body {
 /* 3. KPI卡片系统 */
 .kpi-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: var(--space-6);
-  margin: var(--space-6) 0;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--space-4);
+  margin: var(--space-4) 0;
 }
 
 .kpi-card {
   background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
   border: 1px solid var(--primary-200);
   border-radius: var(--radius-lg);
-  padding: var(--space-6);
+  padding: var(--space-4);
   box-shadow: var(--shadow-md);
   transition: all 0.3s ease;
   position: relative;
@@ -106,7 +106,7 @@ body {
 
 .kpi-card h4 {
   color: var(--primary-600);
-  font-size: 0.875rem;
+  font-size: 0.75rem;
   font-weight: 500;
   margin: 0 0 var(--space-2) 0;
   text-transform: uppercase;
@@ -115,7 +115,7 @@ body {
 
 .kpi-card p {
   color: var(--primary-900);
-  font-size: 1.875rem;
+  font-size: 1.5rem;
   font-weight: 700;
   margin: 0;
   line-height: 1;
@@ -123,7 +123,7 @@ body {
 
 .kpi-card .kpi-comparison {
   margin-top: var(--space-2);
-  font-size: 0.875rem;
+  font-size: 0.75rem;
 }
 
 .kpi-card .delta {

--- a/public/assets/page-template.js
+++ b/public/assets/page-template.js
@@ -435,8 +435,8 @@
       if (num === null || num === undefined) return '0%';
       const n = Number(num);
       if (isNaN(n)) return '0%';
-      if (n <= 1) n *= 100;
-      return n.toFixed(decimals) + '%';
+      const value = n <= 1 ? n * 100 : n;
+      return value.toFixed(decimals) + '%';
     },
 
     // 安全的JSON解析

--- a/public/assets/self-operated.js
+++ b/public/assets/self-operated.js
@@ -326,25 +326,27 @@
         });
         
         // 修复计算逻辑：使用与index.html一致的字段名
-        const vr = sum.exposure > 0 ? ((sum.visitors / sum.exposure) * 100) : 0;
-        const cr = sum.visitors > 0 ? ((sum.add_people / sum.visitors) * 100) : 0;  // 使用 add_people
-        const pr = sum.add_people > 0 ? ((sum.pay_buyers / sum.add_people) * 100) : 0;  // 使用 add_people 和 pay_buyers
+        const vr = sum.exposure > 0 ? (sum.visitors / sum.exposure) : 0;
+        const cr = sum.visitors > 0 ? (sum.add_people / sum.visitors) : 0;  // 使用 add_people
+        const pr = sum.add_people > 0 ? (sum.pay_buyers / sum.add_people) : 0;  // 使用 add_people 和 pay_buyers
         
         console.log('KPI计算调试 - 计算结果:', { vr, cr, pr, total: products.size, pe, pc, pp });
 
         return {vr, cr, pr, total: products.size, pe, pc, pp, newProducts: 0}; // 暂时返回0，后续计算
       }
       
-      function setDelta(id, diff, isPercent) {
+      const setDelta = (id, diff, isPercent) => {
         const el = document.getElementById(id);
         if (!el) return;
-        
+
         const arrow = diff >= 0 ? '↑' : '↓';
         const cls = diff >= 0 ? 'delta up' : 'delta down';
-        const val = isPercent ? Math.abs(diff).toFixed(2) + '%' : Math.abs(diff).toString();
-        
+        const val = isPercent
+          ? this.formatPercentage(Math.abs(diff))
+          : Math.abs(diff).toString();
+
         el.innerHTML = `<span class="${cls}">${arrow} ${val}</span>`;
-      }
+      };
       
       const cur = summarize(rows);
       const prev = summarize(prevRows || []);
@@ -368,9 +370,9 @@
       });
       
       // 更新KPI值
-      this.updateKPI('avgVisitor', cur.vr.toFixed(2) + '%');
-      this.updateKPI('avgCart', cur.cr.toFixed(2) + '%');
-      this.updateKPI('avgPay', cur.pr.toFixed(2) + '%');
+      this.updateKPI('avgVisitor', this.formatPercentage(cur.vr));
+      this.updateKPI('avgCart', this.formatPercentage(cur.cr));
+      this.updateKPI('avgPay', this.formatPercentage(cur.pr));
       this.updateKPI('totalProducts', cur.total);
       this.updateKPI('exposedProducts', cur.pe);
       this.updateKPI('cartedProducts', cur.pc);
@@ -391,9 +393,9 @@
       
       // 调试：输出KPI更新结果
       console.log('KPI更新结果:', {
-        avgVisitor: cur.vr.toFixed(2) + '%',
-        avgCart: cur.cr.toFixed(2) + '%',
-        avgPay: cur.pr.toFixed(2) + '%',
+        avgVisitor: this.formatPercentage(cur.vr),
+        avgCart: this.formatPercentage(cur.cr),
+        avgPay: this.formatPercentage(cur.pr),
         totalProducts: cur.total,
         exposedProducts: cur.pe,
         cartedProducts: cur.pc,
@@ -524,9 +526,9 @@
           const visitors = row.visitors || 0;
           const exposure = row.exposure || 0;
           const payItems = row.pay_items || 0;
-          const visitorRatio = exposure > 0 ? (visitors / exposure) * 100 : 0;
-          const addToCartRatio = visitors > 0 ? (addPeople / visitors) * 100 : 0;
-          const paymentRatio = addPeople > 0 ? (payItems / addPeople) * 100 : 0;
+          const visitorRatio = exposure > 0 ? (visitors / exposure) : 0;
+          const addToCartRatio = visitors > 0 ? (addPeople / visitors) : 0;
+          const paymentRatio = addPeople > 0 ? (payItems / addPeople) : 0;
 
           // 调试：输出前3行的详细数据
           if (index < 3) {

--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -193,11 +193,11 @@ table.dataTable td{
 /* ------ KPI Cards (managed.html) ------ */
 .stat-card{
   background:var(--kpi-bg); border:1px solid var(--kpi-border);
-  border-radius:14px; padding:12px 14px; box-shadow:var(--shadow);
+  border-radius:14px; padding:8px 10px; box-shadow:var(--shadow);
 }
-.stat-card h4{ margin:0 0 6px; color:#334155; font-size:12px; letter-spacing:.2px }
-.stat-card p{ margin:0; color:#0f172a; font-size:28px; font-weight:900; line-height:1.1 }
-#kpi{ display:grid; grid-template-columns:repeat(auto-fit,minmax(210px,1fr)); gap:12px }
+.stat-card h4{ margin:0 0 6px; color:#334155; font-size:11px; letter-spacing:.2px }
+.stat-card p{ margin:0; color:#0f172a; font-size:24px; font-weight:900; line-height:1.1 }
+#kpi{ display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:8px }
 
 /* ------ Tables: DataTables High-Contrast Light ------ */
 #report_wrapper{ background:#fff; border-radius:12px; padding:8px; border:1px solid var(--panel-border); box-shadow:var(--shadow) }

--- a/public/managed.html
+++ b/public/managed.html
@@ -166,8 +166,16 @@
       <div id="funnel" style="width:100%;height:320px;"></div>
     </div>
     <div class="panel">
-      <h3>周期对比（曝光 / 加购件数 / 支付订单数）</h3>
-      <div id="sumCompareBar" style="width:100%;height:320px;"></div>
+      <h3>曝光周期对比</h3>
+      <div id="expCompareBar" style="width:100%;height:320px;"></div>
+    </div>
+    <div class="panel">
+      <h3>加购件数对比</h3>
+      <div id="addCompareBar" style="width:100%;height:320px;"></div>
+    </div>
+    <div class="panel">
+      <h3>支付订单数对比</h3>
+      <div id="payCompareBar" style="width:100%;height:320px;"></div>
     </div>
     <div class="panel">
       <h3>Top10 访客比（UV/曝光）</h3>
@@ -725,24 +733,30 @@
     }
   }catch(e){ console.warn(e); }
 
-  // Grouped sum comparison
-  try{
-    const el = document.getElementById('sumCompareBar');
-    if (el){
-      const option = {
-        tooltip:{trigger:'axis',axisPointer:{type:'shadow'}},
-        legend:{ data:[nameA,nameB], textStyle:{color:'#374151'} },
-        xAxis:{ type:'category', data:['总展示数','详情页访客数','加购次数','订购次数','有加购商品数'], axisLabel:{color:'#374151'} },
-        yAxis:{ type:'value', axisLabel:{color:'#374151'} },
-        series:[
-          { name:nameA, type:'bar', data:[A.exp, A.uv, A.atc_qty, A.pay_orders, A.atc_products], barMaxWidth:28, label:{show:true, position:'top'}, itemStyle:{color:COLOR_A} },
-          { name:nameB, type:'bar', data:[B.exp, B.uv, B.atc_qty, B.pay_orders, B.atc_products], barMaxWidth:28, label:{show:true, position:'top'}, itemStyle:{color:COLOR_B} }
-        ],
-        grid:{ left:40, right:20, top:30, bottom:40 }
-      };
-      initResponsiveChart(el, option);
-    }
-  }catch(e){ console.warn(e); }
+  // Period comparison charts
+  const renderCompare = (elId, label, curVal, prevVal) => {
+    try{
+      const el = document.getElementById(elId);
+      if (el){
+        const option = {
+          tooltip:{trigger:'axis',axisPointer:{type:'shadow'}},
+          legend:{ data:[nameA,nameB], textStyle:{color:'#374151'} },
+          xAxis:{ type:'category', data:[label], axisLabel:{color:'#374151'} },
+          yAxis:{ type:'value', axisLabel:{color:'#374151'} },
+          series:[
+            { name:nameA, type:'bar', data:[curVal], barMaxWidth:28, label:{show:true, position:'top'}, itemStyle:{color:COLOR_A} },
+            { name:nameB, type:'bar', data:[prevVal], barMaxWidth:28, label:{show:true, position:'top'}, itemStyle:{color:COLOR_B} }
+          ],
+          grid:{ left:40, right:20, top:30, bottom:40 }
+        };
+        initResponsiveChart(el, option);
+      }
+    }catch(e){ console.warn(e); }
+  };
+
+  renderCompare('expCompareBar','曝光',A.exp,B.exp);
+  renderCompare('addCompareBar','加购件数',A.atc_qty,B.atc_qty);
+  renderCompare('payCompareBar','支付订单数',A.pay_orders,B.pay_orders);
 
   // Top charts for A
   function topByRate(rows, denKey, numKey, elId, minDen){

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -631,8 +631,16 @@
             <div id="analysisFunnel" style="width:100%;height:320px;"></div>
           </div>
           <div class="panel">
-            <h3>周期对比（曝光 / 加购件数 / 支付订单数）</h3>
-            <div id="analysisCompareBar" style="width:100%;height:320px;"></div>
+            <h3>曝光周期对比</h3>
+            <div id="analysisExposureCompare" style="width:100%;height:320px;"></div>
+          </div>
+          <div class="panel">
+            <h3>加购件数对比</h3>
+            <div id="analysisCartCompare" style="width:100%;height:320px;"></div>
+          </div>
+          <div class="panel">
+            <h3>支付订单数对比</h3>
+            <div id="analysisPayCompare" style="width:100%;height:320px;"></div>
           </div>
           <div class="panel">
             <h3>Top10 访客比（UV/曝光）</h3>
@@ -1128,7 +1136,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
 
       if (currentData.ok && currentData.rows && prevData.ok && prevData.rows) {
         renderAnalysisCharts(currentData.rows, prevData.rows);
-        renderSummaryBarChart(currentData.rows, prevData.rows);
+        renderPeriodComparisonCharts(currentData.rows, prevData.rows);
         renderFunnelChart(currentData.rows, prevData.rows);
         renderTopCharts(currentData.rows);
       } else {
@@ -1480,7 +1488,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
     initResponsiveChart(id, option);
   }
 
-  function renderSummaryBarChart(currentRows, previousRows) {
+  function renderPeriodComparisonCharts(currentRows, previousRows) {
     const sum = rows => ({
       exp: rows.reduce((t, r) => t + (r.exposure || 0), 0),
       add: rows.reduce((t, r) => t + (r.add_people || 0), 0),
@@ -1488,18 +1496,24 @@ document.addEventListener('DOMContentLoaded', ()=>{
     });
     const cur = sum(currentRows);
     const prev = sum(previousRows);
-    const cats = ['曝光','加购件数','支付订单数'];
-    const option = {
-      tooltip:{ trigger:'axis', axisPointer:{ type:'shadow' } },
-      legend:{ data:['本期','上期'], textStyle:{ color:'#374151' } },
-      xAxis:{ type:'category', data: cats, axisLabel:{ color:'#374151' } },
-      yAxis:{ type:'value', axisLabel:{ color:'#374151' } },
-      series:[
-        { name:'本期', type:'bar', data:[cur.exp, cur.add, cur.pay], label:{show:true, position:'top'} },
-        { name:'上期', type:'bar', data:[prev.exp, prev.add, prev.pay], label:{show:true, position:'top'} }
-      ]
+
+    const render = (id, label, curVal, prevVal) => {
+      const option = {
+        tooltip:{ trigger:'axis', axisPointer:{ type:'shadow' } },
+        legend:{ data:['本期','上期'], textStyle:{ color:'#374151' } },
+        xAxis:{ type:'category', data:[label], axisLabel:{ color:'#374151' } },
+        yAxis:{ type:'value', axisLabel:{ color:'#374151' } },
+        series:[
+          { name:'本期', type:'bar', data:[curVal], label:{show:true, position:'top'} },
+          { name:'上期', type:'bar', data:[prevVal], label:{show:true, position:'top'} }
+        ]
+      };
+      initResponsiveChart(id, option);
     };
-    initResponsiveChart('analysisCompareBar', option);
+
+    render('analysisExposureCompare', '曝光', cur.exp, prev.exp);
+    render('analysisCartCompare', '加购件数', cur.add, prev.add);
+    render('analysisPayCompare', '支付订单数', cur.pay, prev.pay);
   }
 
   function renderFunnelChart(currentRows, previousRows) {

--- a/public/test-self-operated-simple.html
+++ b/public/test-self-operated-simple.html
@@ -424,12 +424,12 @@
                 data.forEach((row, index) => {
                     // 调试前3行数据
                     if (index < 3) {
-                        this.updateDebugInfo(`行${index + 1}数据: 访客比=${row.visitor_ratio}, 加购比=${row.cart_ratio}, 支付比=${row.pay_ratio}`);
+                        this.updateDebugInfo(`行${index + 1}数据: 访客比=${row.visitor_ratio}, 加购比=${row.add_to_cart_ratio}, 支付比=${row.payment_ratio}`);
                     }
                     
                     const visitorRatio = parseFloat(row.visitor_ratio) || 0;
-                    const cartRatio = parseFloat(row.cart_ratio) || 0;
-                    const payRatio = parseFloat(row.pay_ratio) || 0;
+                    const cartRatio = parseFloat(row.add_to_cart_ratio) || 0;
+                    const payRatio = parseFloat(row.payment_ratio) || 0;
                     
                     totalVisitorRatio += visitorRatio;
                     totalCartRatio += cartRatio;
@@ -468,9 +468,9 @@
             
             displayKPIs(kpis, changes) {
                 // 更新主要KPI值
-                this.updateKPI('avgVisitor', kpis.avgVisitorRatio.toFixed(2) + '%');
-                this.updateKPI('avgCart', kpis.avgCartRatio.toFixed(2) + '%');
-                this.updateKPI('avgPay', kpis.avgPayRatio.toFixed(2) + '%');
+                this.updateKPI('avgVisitor', this.formatPercentage(kpis.avgVisitorRatio));
+                this.updateKPI('avgCart', this.formatPercentage(kpis.avgCartRatio));
+                this.updateKPI('avgPay', this.formatPercentage(kpis.avgPayRatio));
                 this.updateKPI('totalProducts', kpis.totalProducts);
                 this.updateKPI('cartedProducts', kpis.cartedProducts);
                 this.updateKPI('purchasedProducts', kpis.purchasedProducts);
@@ -527,8 +527,8 @@
                         <td>${row.product_id || '-'}</td>
                         <td>${row.bucket || '-'}</td>
                         <td>${this.formatPercentage(row.visitor_ratio)}</td>
-                        <td>${this.formatPercentage(row.cart_ratio)}</td>
-                        <td>${this.formatPercentage(row.pay_ratio)}</td>
+                        <td>${this.formatPercentage(row.add_to_cart_ratio)}</td>
+                        <td>${this.formatPercentage(row.payment_ratio)}</td>
                         <td>${this.formatNumber(row.exposure)}</td>
                         <td>${this.formatNumber(row.visitors)}</td>
                         <td>${this.formatNumber(row.cart_users)}</td>


### PR DESCRIPTION
## Summary
- return raw fractions for `visitor_ratio`, `add_to_cart_ratio`, and `payment_ratio` in the `/api/ae_query` product aggregation
- display product and KPI ratios by formatting fractions on the client
- document that `/api/ae_query` now returns fractional ratio fields
- shrink KPI cards and fonts for better fit on smaller screens
- split cycle comparison into separate exposure, cart, and payment order bar charts on self-operated and managed pages

## Testing
- `npm test` *(fails: ReferenceError: require is not defined in ES module scope for api/test-data-isolation.js, api/test-site-configs.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8dc870208325a8bfad01eb0e09c5