### PR TITLE
feat: pass site to new products KPI

### DIFF
--- a/public/assets/new-products-kpi.js
+++ b/public/assets/new-products-kpi.js
@@ -53,8 +53,9 @@
     return null;
   }
 
-  async function fetchNewProducts(platform, periodEndISO /* may be null */){
+  async function fetchNewProducts(platform, site, periodEndISO /* may be null */){
     const qs = new URLSearchParams({ platform });
+    if (site) qs.set('site', site);
     if (periodEndISO){ qs.set('from',periodEndISO); qs.set('to',periodEndISO); }
     const r = await fetch('/api/new-products?' + qs.toString());
     const j = await r.json();
@@ -163,9 +164,13 @@
     host.appendChild(box);
 
     let periodEndISO = currentPeriodFromGlobals(platform);
+    let site = null;
+    try{
+      site = localStorage.getItem('currentIndepSite') || (window.pageManager && window.pageManager.currentSite) || null;
+    }catch(e){}
     let data;
     try{
-      data = await fetchNewProducts(platform, periodEndISO);
+      data = await fetchNewProducts(platform, site, periodEndISO);
       count.textContent = data.new_count;
       count.title = data.range ? (data.range.from===data.range.to ? '周期：'+data.range.from : `周期：${data.range.from} ~ ${data.range.to}`) : '';
     }catch(e){


### PR DESCRIPTION
## Summary
- include optional site parameter when fetching new products
- load current independent site in bootstrap and pass to KPI fetch

## Testing
- `npm test` *(fails: ReferenceError: require is not defined in ES module scope in api/test-data-isolation.js and api/test-site-configs.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bda04299708325a596210720130080