### PR TITLE
fix: scope independent new-products KPI by site

### DIFF
--- a/public/assets/new-products-kpi.js
+++ b/public/assets/new-products-kpi.js
@@ -56,6 +56,16 @@
   async function fetchNewProducts(platform, periodEndISO /* may be null */){
     const qs = new URLSearchParams({ platform });
     if (periodEndISO){ qs.set('from',periodEndISO); qs.set('to',periodEndISO); }
+    if (platform === 'indep'){
+      try{
+        const urlParams = new URLSearchParams(window.location.search);
+        let site = urlParams.get('site') || '';
+        if (site && typeof normalizeSite === 'function'){
+          site = normalizeSite(site);
+        }
+        if (site) qs.set('site', site);
+      }catch(e){/* ignore */}
+    }
     const r = await fetch('/api/new-products?' + qs.toString());
     const j = await r.json();
     if (!j.ok) throw new Error(j.msg||'fetch error');


### PR DESCRIPTION
## Summary
- ensure new products KPI fetch passes site param for independent pages

## Testing
- `npm test` *(fails: ReferenceError: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68bda1734ad88325898202e05a45c91a