### PR TITLE
Fix new product KPI mismatch for independent sites

### DIFF
--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -917,12 +917,13 @@ async function loadIndependentAnalysisData() {
       return;
     }
 
-    const dateRange = getDateRange('analysisDate');
-    const params = new URLSearchParams({
-      site: site,
-      from: dateRange.start,
-      to: dateRange.end
-    });
+  const dateRange = getDateRange('analysisDate');
+  const params = new URLSearchParams({
+    site: site,
+    from: dateRange.start,
+    to: dateRange.end,
+    aggregate: 'product'
+  });
 
     // 获取当前周期数据
     const response = await fetch(`/api/independent/stats?${params.toString()}`);


### PR DESCRIPTION
## Summary
- ensure independent analysis KPI requests aggregate by product so new product counts match detail table
- handle managed daily totals when `add_people` column is missing by falling back to `add_to_cart_users`

## Testing
- `npm test` *(fails: ReferenceError: require is not defined in ES module scope for api/test-data-isolation.js, api/test-site-configs.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bda1734ad88325898202e05a45c91a