### PR TITLE
feat: implement Amazon report download endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ### 🏪 平台支持
 - **速卖通**：全托管、自运营
-- **亚马逊**：数据导入与分析
+- **亚马逊**：接入 SP-API（report-create、report-poll、report-download、upsert、query、cron-daily），详见 [README_AMAZON.md](README_AMAZON.md)
 - **TikTok Shop**：广告数据分析
 - **Temu**：平台数据整合
 - **Ozon**：俄罗斯市场分析

--- a/README_AMAZON.md
+++ b/README_AMAZON.md
@@ -14,7 +14,7 @@
 - **2025-01-XX**: 确认SP-API权限范围（USA marketplace，基础seller数据权限）
 - **2025-01-XX**: 确认数据拉取频率（每日拉取前一天数据）
 - **2025-01-XX**: 确认UI风格要求（与整个站点保持一致）
-- **2025-01-XX**: ✅ 完成SP-API核心功能实现（report-create, report-poll, report-download）
+- **2025-09-13**: ✅ 完成SP-API核心功能实现（report-create, report-poll, report-download）
 - **2025-01-XX**: ✅ 完成定时任务配置（vercel.json cron配置）
 - **2025-01-XX**: ✅ 完成前端页面完善（amazon-overview.html）
 - **2025-01-XX**: ✅ 完成API集成测试

--- a/api/amazon/report-download/index.js
+++ b/api/amazon/report-download/index.js
@@ -1,0 +1,129 @@
+import crypto from 'crypto';
+import zlib from 'zlib';
+
+// Amazon SP-API helper
+class AmazonSPAPI {
+  constructor() {
+    this.clientId = process.env.AMZ_LWA_CLIENT_ID;
+    this.clientSecret = process.env.AMZ_LWA_CLIENT_SECRET;
+    this.refreshToken = process.env.AMZ_SP_REFRESH_TOKEN;
+    this.roleArn = process.env.AMZ_ROLE_ARN;
+    this.appRegion = process.env.AMZ_APP_REGION || 'us-east-1';
+    this.marketplaceIds = (process.env.AMZ_MARKETPLACE_IDS || '').split(',').filter(Boolean);
+    this.accessToken = null;
+    this.accessTokenExpiry = null;
+  }
+
+  async getAccessToken() {
+    if (this.accessToken && this.accessTokenExpiry && Date.now() < this.accessTokenExpiry) {
+      return this.accessToken;
+    }
+
+    const resp = await fetch('https://api.amazon.com/auth/o2/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: this.refreshToken,
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+      }),
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(`Failed to get access token: ${resp.status} ${text}`);
+    }
+    const data = await resp.json();
+    this.accessToken = data.access_token;
+    this.accessTokenExpiry = Date.now() + (data.expires_in - 60) * 1000;
+    return this.accessToken;
+  }
+
+  async getDocument(documentId) {
+    const token = await this.getAccessToken();
+    const resp = await fetch(`https://sellingpartnerapi-${this.appRegion}.amazon.com/reports/2021-06-30/documents/${documentId}`, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'x-amz-access-token': token,
+      },
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(`Failed to get document: ${resp.status} ${text}`);
+    }
+    return await resp.json();
+  }
+}
+
+function parseTsv(tsv) {
+  const lines = tsv.trim().split(/\r?\n/);
+  if (lines.length === 0) return [];
+  const headers = lines.shift().split('\t');
+  const rows = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const cols = line.split('\t');
+    const obj = {};
+    headers.forEach((h, i) => { obj[h.trim()] = cols[i] ? cols[i].trim() : ''; });
+    rows.push({
+      marketplace_id: obj.marketplaceId || obj.marketplace_id || obj.marketplace || '',
+      asin: obj.asin || '',
+      stat_date: obj.date || obj.stat_date || obj.day || '',
+      sessions: Number(obj.sessions || 0),
+      page_views: Number(obj.pageViews || obj.page_views || 0),
+      units_ordered: Number(obj.unitsOrdered || obj.orders || obj.units_ordered || 0),
+      ordered_product_sales: Number(obj.orderedProductSales || obj.ordered_product_sales || 0),
+      buy_box_pct: Number(obj.buyBoxPercentage || obj.buy_box_pct || 0),
+    });
+  }
+  return rows;
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+  try {
+    const { documentId } = req.query;
+    if (!documentId) {
+      return res.status(400).json({ error: 'Missing documentId parameter' });
+    }
+
+    const requiredEnv = [
+      'AMZ_LWA_CLIENT_ID',
+      'AMZ_LWA_CLIENT_SECRET',
+      'AMZ_SP_REFRESH_TOKEN',
+      'AMZ_ROLE_ARN',
+      'AMZ_MARKETPLACE_IDS',
+    ];
+    for (const k of requiredEnv) {
+      if (!process.env[k]) {
+        return res.status(500).json({ error: `Missing environment variable: ${k}` });
+      }
+    }
+
+    const spApi = new AmazonSPAPI();
+    const docInfo = await spApi.getDocument(documentId);
+    if (!docInfo.url || !docInfo.encryptionDetails) {
+      throw new Error('Invalid document info returned');
+    }
+
+    const encBuf = Buffer.from(await (await fetch(docInfo.url)).arrayBuffer());
+    const key = Buffer.from(docInfo.encryptionDetails.key, 'base64');
+    const iv = Buffer.from(docInfo.encryptionDetails.initializationVector, 'base64');
+    const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
+    const decrypted = Buffer.concat([decipher.update(encBuf), decipher.final()]);
+    const unzipped = docInfo.compressionAlgorithm === 'GZIP'
+      ? zlib.gunzipSync(decrypted)
+      : decrypted;
+    const text = unzipped.toString('utf-8');
+    const rows = parseTsv(text);
+
+    return res.status(200).json({ ok: true, totalRows: rows.length, rows });
+  } catch (err) {
+    console.error('Amazon report download error:', err);
+    return res.status(500).json({ error: 'Failed to download Amazon report', details: err.message });
+  }
+}


### PR DESCRIPTION
## Summary
- add Amazon SP-API report-download handler to decrypt and parse sales reports
- document Amazon SP-API integration and link from main README

## Testing
- `npm test` *(fails: ReferenceError: require is not defined in ES module scope in api/test-data-isolation.js and api/test-site-configs.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fd2d0cb48325913b67876ad1f2bd