### PR TITLE
fix: ensure ozon product totals accumulate

### DIFF
--- a/api/ozon/kpi/index.js
+++ b/api/ozon/kpi/index.js
@@ -97,13 +97,6 @@ module.exports = async function handler(req,res){
       }
       const newProducts=[...newMap.values()];
 
-      const allCurResp = await supabase
-        .schema('public')
-        .from(TABLE)
-        .select('sku,model')
-        .lte('den', end)
-        .limit(100000);
-      if(allCurResp.error) throw allCurResp.error;
       const allPrevResp = await supabase
         .schema('public')
         .from(TABLE)
@@ -111,8 +104,8 @@ module.exports = async function handler(req,res){
         .lte('den', prevEnd.toISOString().slice(0,10))
         .limit(100000);
       if(allPrevResp.error) throw allPrevResp.error;
-      const allCurSet = new Set((allCurResp.data||[]).map(idOf));
       const allPrevSet = new Set((allPrevResp.data||[]).map(idOf));
+      const allCurSet = new Set([...allPrevSet, ...cur.prodSet]);
 
       return res.json({
         ok:true,
@@ -194,13 +187,6 @@ module.exports = async function handler(req,res){
     }
     const newProducts=[...newMap.values()];
 
-    const allCurResp = await supabase
-      .schema('public')
-      .from(TABLE)
-      .select('sku,model')
-      .lte('den', date)
-      .limit(100000);
-    if(allCurResp.error) throw allCurResp.error;
     let allPrevSet = new Set();
     if(prevDate){
       const allPrevResp = await supabase
@@ -212,7 +198,7 @@ module.exports = async function handler(req,res){
       if(allPrevResp.error) throw allPrevResp.error;
       allPrevSet = new Set((allPrevResp.data||[]).map(idOf));
     }
-    const allCurSet = new Set((allCurResp.data||[]).map(idOf));
+    const allCurSet = new Set([...allPrevSet, ...cur.prodSet]);
 
     res.json({
       ok:true,


### PR DESCRIPTION
## Summary
- ensure Ozon KPI endpoint counts cumulative products instead of per-query limit
- derive current total from previous total plus current period products to avoid display count exceeding total

## Testing
- `npm test` *(fails: require is not defined in ES module scope in test-data-isolation.js, test-site-configs.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c8173fa1d08325a120d02a6baa4920