### PR TITLE
fix ozon product total calculation

### DIFF
--- a/api/ozon/kpi/index.js
+++ b/api/ozon/kpi/index.js
@@ -51,6 +51,24 @@ module.exports = async function handler(req,res){
 
     const idOf = r => `${r.sku}@@${r.model||''}`;
 
+    async function fetchAllProductSet(until){
+      const PAGE = 1000;
+      const set = new Set();
+      for(let from=0;;from+=PAGE){
+        const { data, error } = await supabase
+          .schema('public')
+          .from(TABLE)
+          .select('sku,model')
+          .lte('den', until)
+          .order('den', { ascending: true })
+          .range(from, from+PAGE-1);
+        if(error) throw error;
+        for(const r of data||[]) set.add(idOf(r));
+        if(!data || data.length < PAGE) break;
+      }
+      return set;
+    }
+
     const select = `sku,model,tovary,voronka_prodazh_pokazy_vsego,uv:${uvCol},voronka_prodazh_dobavleniya_v_korzinu_vsego,voronka_prodazh_zakazano_tovarov`;
 
     if(start && end){
@@ -97,22 +115,8 @@ module.exports = async function handler(req,res){
       }
       const newProducts=[...newMap.values()];
 
-      const allCurResp = await supabase
-        .schema('public')
-        .from(TABLE)
-        .select('sku,model')
-        .lte('den', end)
-        .limit(100000);
-      if(allCurResp.error) throw allCurResp.error;
-      const allPrevResp = await supabase
-        .schema('public')
-        .from(TABLE)
-        .select('sku,model')
-        .lte('den', prevEnd.toISOString().slice(0,10))
-        .limit(100000);
-      if(allPrevResp.error) throw allPrevResp.error;
-      const allCurSet = new Set((allCurResp.data||[]).map(idOf));
-      const allPrevSet = new Set((allPrevResp.data||[]).map(idOf));
+      const allCurSet = await fetchAllProductSet(end);
+      const allPrevSet = await fetchAllProductSet(prevEnd.toISOString().slice(0,10));
 
       return res.json({
         ok:true,
@@ -194,25 +198,11 @@ module.exports = async function handler(req,res){
     }
     const newProducts=[...newMap.values()];
 
-    const allCurResp = await supabase
-      .schema('public')
-      .from(TABLE)
-      .select('sku,model')
-      .lte('den', date)
-      .limit(100000);
-    if(allCurResp.error) throw allCurResp.error;
+    const allCurSet = await fetchAllProductSet(date);
     let allPrevSet = new Set();
     if(prevDate){
-      const allPrevResp = await supabase
-        .schema('public')
-        .from(TABLE)
-        .select('sku,model')
-        .lte('den', prevDate)
-        .limit(100000);
-      if(allPrevResp.error) throw allPrevResp.error;
-      allPrevSet = new Set((allPrevResp.data||[]).map(idOf));
+      allPrevSet = await fetchAllProductSet(prevDate);
     }
-    const allCurSet = new Set((allCurResp.data||[]).map(idOf));
 
     res.json({
       ok:true,

--- a/public/independent-site.html
+++ b/public/independent-site.html
@@ -934,7 +934,7 @@ async function loadIndependentAnalysisData() {
       // 更新KPI卡片
       updateIndependentAnalysisKPI(table, kpis);
       // 渲染图表
-      await renderIndependentAnalysisCharts(table, kpis);
+      await renderIndependentAnalysisCharts(site);
     }
   } catch (error) {
     console.error('加载独立站运营分析数据失败:', error);
@@ -1029,102 +1029,81 @@ function updateIndependentAnalysisKPI(data, kpis = {}) {
 }
 
 // 渲染独立站运营分析对比图表
-async function renderIndependentAnalysisCharts(data, kpis = {}) {
-  // 获取上一周期数据进行对比
-  const previousData = await getIndependentPreviousPeriodData('analysisDate');
-
-  // 计算当前周期数据
-  const currentData = {
-    impressions: data.reduce((sum, item) => sum + Number(item.impressions || item.impr || 0), 0),
-    clicks: data.reduce((sum, item) => sum + Number(item.clicks || 0), 0),
-    conversions: data.reduce((sum, item) => sum + Number(item.conversions || 0), 0),
-    ctr: 0,
-    clickedProducts: kpis.click_product_count != null
-      ? Number(kpis.click_product_count)
-      : new Set(data.filter(item => Number(item.clicks || 0) > 0).map(item => item.product)).size
-  };
-  currentData.ctr = currentData.impressions > 0 ? currentData.clicks / currentData.impressions * 100 : 0;
-
-  // 计算上一周期数据
-  const previousDataCalculated = previousData ? {
-    impressions: previousData.table.reduce((sum, item) => sum + Number(item.impressions || item.impr || 0), 0),
-    clicks: previousData.table.reduce((sum, item) => sum + Number(item.clicks || 0), 0),
-    conversions: previousData.table.reduce((sum, item) => sum + Number(item.conversions || 0), 0),
-    ctr: 0,
-    clickedProducts: previousData.kpis?.click_product_count != null
-      ? Number(previousData.kpis.click_product_count)
-      : new Set(previousData.table.filter(item => Number(item.clicks || 0) > 0).map(item => item.product)).size
-  } : null;
-  if (previousDataCalculated) {
-    previousDataCalculated.ctr = previousDataCalculated.impressions > 0
-      ? previousDataCalculated.clicks / previousDataCalculated.impressions * 100
-      : 0;
-  }
-
-  // 渲染产品展示总数对比图
-  renderIndependentComparisonChart('impressionsComparisonChart',
-    currentData.impressions, previousDataCalculated?.impressions || 0, '产品展示总数');
-
-  // 渲染 CTR 对比图
-  renderIndependentComparisonChart('ctrComparisonChart',
-    currentData.ctr, previousDataCalculated?.ctr || 0, 'CTR (%)');
-
-  // 渲染转化次数对比图
-  renderIndependentComparisonChart('conversionsComparisonChart',
-    currentData.conversions, previousDataCalculated?.conversions || 0, '转化次数');
-
-  // 渲染有点击商品数对比图
-  renderIndependentComparisonChart('clickedProductsComparisonChart',
-    currentData.clickedProducts, previousDataCalculated?.clickedProducts || 0, '有点击商品数');
+async function renderIndependentAnalysisCharts(site) {
+  const weeklyStats = await fetchIndependentWeeklyStats(site);
+  renderIndependentWeeklyCharts(weeklyStats);
 }
 
-// 渲染独立站对比柱状图
-function renderIndependentComparisonChart(chartId, currentValue, previousValue, label) {
-  const chart = echarts.init(document.getElementById(chartId));
-  const curr = Number(currentValue) || 0;
-  const prev = Number(previousValue) || 0;
-  const formatVal = v => label.includes('CTR') ? v.toFixed(2) + '%' : Number(v).toLocaleString();
-  const option = {
-    tooltip: {
-      trigger: 'axis',
-      formatter: function(params) {
-        const data = params[0];
-        return `${data.seriesName}: ${formatVal(data.value)}`;
+async function fetchIndependentWeeklyStats(site) {
+  const today = new Date();
+  const lastSunday = new Date(today);
+  lastSunday.setUTCDate(lastSunday.getUTCDate() - lastSunday.getUTCDay());
+  const weeks = [];
+  for (let i = 0; i < 12; i++) {
+    const end = new Date(lastSunday);
+    end.setUTCDate(lastSunday.getUTCDate() - i * 7);
+    const start = new Date(end);
+    start.setUTCDate(end.getUTCDate() - 6);
+    weeks.push({ start: start.toISOString().slice(0, 10), end: end.toISOString().slice(0, 10) });
+  }
+  const results = await Promise.all(weeks.map(({ start, end }) => {
+    const params = new URLSearchParams({ site, from: start, to: end, limit: '20000' });
+    return fetch(`/api/independent/stats?${params.toString()}`)
+      .then(r => r.json().then(j => ({ end, table: j.table || [], kpis: j.kpis || {} })));
+  }));
+  const map = new Map();
+  results.forEach(({ end, table, kpis }) => {
+    let impressions = 0, clicks = 0, conversions = 0;
+    const clickSet = new Set();
+    table.forEach(item => {
+      const impr = Number(item.impressions || item.impr || 0);
+      const clk = Number(item.clicks || 0);
+      impressions += impr;
+      clicks += clk;
+      conversions += Number(item.conversions || 0);
+      if (clk > 0) {
+        const prod = item.product || item.product_id || item.landing_path || item.campaign || '';
+        clickSet.add(prod);
       }
-    },
-    legend: {
-      data: ['当前周期', '上一周期'],
-      textStyle: { color: '#374151' }
-    },
-    xAxis: {
-      type: 'category',
-      data: ['当前周期', '上一周期'],
-      axisLabel: { color: '#374151', fontSize: 12 }
-    },
-    yAxis: {
-      type: 'value',
-      axisLabel: { color: '#374151', fontSize: 12 }
-    },
-    series: [
-      {
-        name: '当前周期',
-        data: [curr, null],
+    });
+    const clickedProducts = kpis.click_product_count != null ? Number(kpis.click_product_count) : clickSet.size;
+    map.set(end, {
+      impressions,
+      ctr: impressions > 0 ? clicks / impressions * 100 : 0,
+      conversions,
+      clickedProducts
+    });
+  });
+  return map;
+}
+
+function renderIndependentWeeklyCharts(map) {
+  const weeks = Array.from(map.keys()).sort();
+  const impressions = weeks.map(w => map.get(w).impressions);
+  const ctr = weeks.map(w => map.get(w).ctr);
+  const conversions = weeks.map(w => map.get(w).conversions);
+  const clickedProducts = weeks.map(w => map.get(w).clickedProducts);
+  const render = (id, data, formatter = v => Number(v).toLocaleString()) => {
+    const chart = echarts.init(document.getElementById(id));
+    const option = {
+      tooltip: { trigger: 'axis', formatter: params => formatter(params[0].value) },
+      xAxis: { type: 'category', data: weeks, axisLabel: { color: '#374151' } },
+      yAxis: { type: 'value', axisLabel: { color: '#374151' } },
+      series: [{
         type: 'bar',
+        data,
+        barMaxWidth: 24,
         itemStyle: { color: '#3B82F6' },
-        barWidth: '40%',
-        label: { show: true, position: 'top', formatter: p => formatVal(p.value) }
-      },
-      {
-        name: '上一周期',
-        data: [null, prev],
-        type: 'bar',
-        itemStyle: { color: '#10B981' },
-        barWidth: '40%',
-        label: { show: true, position: 'top', formatter: p => formatVal(p.value) }
-      }
-    ]
+        label: { show: true, position: 'top', color: '#374151', formatter: p => formatter(p.value) }
+      }],
+      grid: { left: 40, right: 20, top: 30, bottom: 30 }
+    };
+    chart.setOption(option);
   };
-  chart.setOption(option);
+  render('impressionsComparisonChart', impressions);
+  render('ctrComparisonChart', ctr, v => Number(v).toFixed(2) + '%');
+  render('conversionsComparisonChart', conversions);
+  render('clickedProductsComparisonChart', clickedProducts);
 }
 
 // 获取独立站上一周期数据

--- a/public/managed.html
+++ b/public/managed.html
@@ -166,16 +166,32 @@
       <div id="funnel" style="width:100%;height:320px;"></div>
     </div>
     <div class="panel">
-      <h3>曝光周期对比</h3>
-      <div id="expCompareBar" style="width:100%;height:320px;"></div>
+      <h3>总展示数</h3>
+      <div id="analysisExposureWeekly" style="width:100%;height:320px;"></div>
     </div>
     <div class="panel">
-      <h3>加购件数对比</h3>
-      <div id="addCompareBar" style="width:100%;height:320px;"></div>
+      <h3>详情页访客数</h3>
+      <div id="analysisVisitorsWeekly" style="width:100%;height:320px;"></div>
     </div>
     <div class="panel">
-      <h3>支付订单数对比</h3>
-      <div id="payCompareBar" style="width:100%;height:320px;"></div>
+      <h3>加购次数</h3>
+      <div id="analysisAddTimesWeekly" style="width:100%;height:320px;"></div>
+    </div>
+    <div class="panel">
+      <h3>订购商品数</h3>
+      <div id="analysisOrderItemsWeekly" style="width:100%;height:320px;"></div>
+    </div>
+    <div class="panel">
+      <h3>有曝光商品数</h3>
+      <div id="analysisExposureProductsWeekly" style="width:100%;height:320px;"></div>
+    </div>
+    <div class="panel">
+      <h3>有加购商品数</h3>
+      <div id="analysisAddProductsWeekly" style="width:100%;height:320px;"></div>
+    </div>
+    <div class="panel">
+      <h3>有支付商品数</h3>
+      <div id="analysisPayProductsWeekly" style="width:100%;height:320px;"></div>
     </div>
     <div class="panel">
       <h3>Top10 访客比（UV/曝光）</h3>
@@ -390,6 +406,12 @@
       });
 
       renderAnalysis(window._rowsA, window._rowsB);
+      try {
+        const weeklyRows = await fetchWeeklyStats();
+        renderWeeklyComparisonCharts(weeklyRows);
+      } catch(err) {
+        console.error('weekly stats error', err);
+      }
       renderTotalTrends();
       setStatus('加载完成');
     }catch(err){
@@ -733,31 +755,6 @@
     }
   }catch(e){ console.warn(e); }
 
-  // Period comparison charts
-  const renderCompare = (elId, label, curVal, prevVal) => {
-    try{
-      const el = document.getElementById(elId);
-      if (el){
-        const option = {
-          tooltip:{trigger:'axis',axisPointer:{type:'shadow'}},
-          legend:{ data:[nameA,nameB], textStyle:{color:'#374151'} },
-          xAxis:{ type:'category', data:[label], axisLabel:{color:'#374151'} },
-          yAxis:{ type:'value', axisLabel:{color:'#374151'} },
-          series:[
-            { name:nameA, type:'bar', data:[curVal], barMaxWidth:28, label:{show:true, position:'top'}, itemStyle:{color:COLOR_A} },
-            { name:nameB, type:'bar', data:[prevVal], barMaxWidth:28, label:{show:true, position:'top'}, itemStyle:{color:COLOR_B} }
-          ],
-          grid:{ left:40, right:20, top:30, bottom:40 }
-        };
-        initResponsiveChart(el, option);
-      }
-    }catch(e){ console.warn(e); }
-  };
-
-  renderCompare('expCompareBar','曝光',A.exp,B.exp);
-  renderCompare('addCompareBar','加购件数',A.atc_qty,B.atc_qty);
-  renderCompare('payCompareBar','支付订单数',A.pay_orders,B.pay_orders);
-
   // Top charts for A
   function topByRate(rows, denKey, numKey, elId, minDen){
     const list = rows.map(x=>{
@@ -787,6 +784,72 @@
   }
   topByRate(rowsA,'search_exposure','uv','vrBar',50);
   topByRate(rowsA,'add_to_cart_users','pay_buyers','payBar',5);
+}
+
+async function fetchWeeklyStats(){
+  const today = new Date();
+  const lastSunday = new Date(today);
+  lastSunday.setUTCDate(lastSunday.getUTCDate() - lastSunday.getUTCDay());
+  const weeks = [];
+  for(let i=0;i<8;i++){
+    const d = new Date(lastSunday);
+    d.setUTCDate(lastSunday.getUTCDate() - i*7);
+    weeks.push(d.toISOString().slice(0,10));
+  }
+  const promises = weeks.map(w => fetch('/api/stats?' + new URLSearchParams({ granularity:'week', period_end:w, limit:5000 })).then(r=>r.json().then(j=>({end:w, rows:j.rows||[]}))));
+  const results = await Promise.all(promises);
+  const all = [];
+  results.forEach(({end, rows}) => {
+    (rows||[]).forEach(r => all.push(Object.assign({ bucket:end }, r)));
+  });
+  return all;
+}
+
+function renderWeeklyComparisonCharts(rows){
+  const map = new Map();
+  rows.forEach(r=>{
+    const w = r.bucket || r.week || r.period_end || '';
+    if(!map.has(w)){
+      map.set(w,{ exposure:0, visitors:0, add_count:0, order_items:0, expSet:new Set(), addSet:new Set(), paySet:new Set() });
+    }
+    const acc = map.get(w);
+    const expVal = (r.search_exposure||0) || (r.exposure||0) || (r.pv||0) || 0;
+    const addUsers = r.add_people || r.add_to_cart_users || 0;
+    acc.exposure += expVal;
+    acc.visitors += r.uv || r.visitors || 0;
+    acc.add_count += addUsers;
+    acc.order_items += r.pay_items || 0;
+    if(expVal>0) acc.expSet.add(r.product_id);
+    if(addUsers>0) acc.addSet.add(r.product_id);
+    if((r.pay_items||0)>0 || (r.pay_orders||0)>0 || (r.pay_people||0)>0 || (r.pay_buyers||0)>0) acc.paySet.add(r.product_id);
+  });
+  const weeks = Array.from(map.keys()).sort();
+  const exp = weeks.map(w=>map.get(w).exposure);
+  const uv = weeks.map(w=>map.get(w).visitors);
+  const addTimes = weeks.map(w=>map.get(w).add_count);
+  const orderItems = weeks.map(w=>map.get(w).order_items);
+  const expProducts = weeks.map(w=>map.get(w).expSet.size);
+  const addProducts = weeks.map(w=>map.get(w).addSet.size);
+  const payProducts = weeks.map(w=>map.get(w).paySet.size);
+
+  const render = (id,data) => {
+    const option = {
+      tooltip:{ trigger:'axis' },
+      xAxis:{ type:'category', data:weeks, axisLabel:{ color:'#374151' } },
+      yAxis:{ type:'value', axisLabel:{ color:'#374151' } },
+      series:[{ type:'bar', data, barMaxWidth:24, itemStyle:{ color:'#3B82F6' }, label:{ show:true, position:'top', color:'#374151' } }],
+      grid:{ left:40, right:20, top:30, bottom:30 }
+    };
+    initResponsiveChart(id, option);
+  };
+
+  render('analysisExposureWeekly', exp);
+  render('analysisVisitorsWeekly', uv);
+  render('analysisAddTimesWeekly', addTimes);
+  render('analysisOrderItemsWeekly', orderItems);
+  render('analysisExposureProductsWeekly', expProducts);
+  render('analysisAddProductsWeekly', addProducts);
+  render('analysisPayProductsWeekly', payProducts);
 }
 
 </script>

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -631,16 +631,32 @@
             <div id="analysisFunnel" style="width:100%;height:320px;"></div>
           </div>
           <div class="panel">
-            <h3>曝光周期对比</h3>
-            <div id="analysisExposureCompare" style="width:100%;height:320px;"></div>
+            <h3>总展示数</h3>
+            <div id="analysisExposureWeekly" style="width:100%;height:320px;"></div>
           </div>
           <div class="panel">
-            <h3>加购件数对比</h3>
-            <div id="analysisCartCompare" style="width:100%;height:320px;"></div>
+            <h3>详情页访客数</h3>
+            <div id="analysisVisitorsWeekly" style="width:100%;height:320px;"></div>
           </div>
           <div class="panel">
-            <h3>支付订单数对比</h3>
-            <div id="analysisPayCompare" style="width:100%;height:320px;"></div>
+            <h3>加购次数</h3>
+            <div id="analysisAddTimesWeekly" style="width:100%;height:320px;"></div>
+          </div>
+          <div class="panel">
+            <h3>订购商品数</h3>
+            <div id="analysisOrderItemsWeekly" style="width:100%;height:320px;"></div>
+          </div>
+          <div class="panel">
+            <h3>有曝光商品数</h3>
+            <div id="analysisExposureProductsWeekly" style="width:100%;height:320px;"></div>
+          </div>
+          <div class="panel">
+            <h3>有加购商品数</h3>
+            <div id="analysisAddProductsWeekly" style="width:100%;height:320px;"></div>
+          </div>
+          <div class="panel">
+            <h3>有支付商品数</h3>
+            <div id="analysisPayProductsWeekly" style="width:100%;height:320px;"></div>
           </div>
           <div class="panel">
             <h3>Top10 访客比（UV/曝光）</h3>
@@ -1121,26 +1137,42 @@ document.addEventListener('DOMContentLoaded', ()=>{
         aggregate: 'time'
       });
 
-      const [currentResponse, prevResponse] = await Promise.all([
+      // 最近两个月的自然周起始日期
+      const weeklyStartDate = new Date();
+      weeklyStartDate.setMonth(weeklyStartDate.getMonth() - 2);
+      weeklyStartDate.setDate(weeklyStartDate.getDate() - ((weeklyStartDate.getDay() + 6) % 7));
+      const weeklyStart = weeklyStartDate.toISOString().slice(0,10);
+      const todayISO = new Date().toISOString().slice(0,10);
+      const weeklyParams = new URLSearchParams({
+        start: weeklyStart,
+        end: todayISO,
+        granularity: 'week',
+        site: currentSite,
+        aggregate: 'time'
+      });
+
+      const [currentResponse, prevResponse, weeklyResponse] = await Promise.all([
         fetch(`/api/ae_query?${currentParams.toString()}`, { method: 'GET', headers: { 'Content-Type': 'application/json' } }),
-        fetch(`/api/ae_query?${prevParams.toString()}`, { method: 'GET', headers: { 'Content-Type': 'application/json' } })
+        fetch(`/api/ae_query?${prevParams.toString()}`, { method: 'GET', headers: { 'Content-Type': 'application/json' } }),
+        fetch(`/api/ae_query?${weeklyParams.toString()}`, { method: 'GET', headers: { 'Content-Type': 'application/json' } })
       ]);
 
-      if (!currentResponse.ok || !prevResponse.ok) {
-        throw new Error(`API响应错误: ${currentResponse.status}/${prevResponse.status}`);
+      if (!currentResponse.ok || !prevResponse.ok || !weeklyResponse.ok) {
+        throw new Error(`API响应错误: ${currentResponse.status}/${prevResponse.status}/${weeklyResponse.status}`);
       }
 
       const currentData = await currentResponse.json();
       const prevData = await prevResponse.json();
-      console.log('运营分析数据响应:', currentData, prevData);
+      const weeklyData = await weeklyResponse.json();
+      console.log('运营分析数据响应:', currentData, prevData, weeklyData);
 
-      if (currentData.ok && currentData.rows && prevData.ok && prevData.rows) {
+      if (currentData.ok && currentData.rows && prevData.ok && prevData.rows && weeklyData.ok && weeklyData.rows) {
         renderAnalysisCharts(currentData.rows, prevData.rows);
-        renderPeriodComparisonCharts(currentData.rows, prevData.rows);
         renderFunnelChart(currentData.rows, prevData.rows);
         renderTopCharts(currentData.rows);
+        renderWeeklyComparisonCharts(weeklyData.rows);
       } else {
-        console.warn('运营分析数据格式不正确:', currentData, prevData);
+        console.warn('运营分析数据格式不正确:', currentData, prevData, weeklyData);
         showAnalysisError('数据格式不正确，请检查API响应');
       }
     } catch (error) {
@@ -1488,32 +1520,64 @@ document.addEventListener('DOMContentLoaded', ()=>{
     initResponsiveChart(id, option);
   }
 
-  function renderPeriodComparisonCharts(currentRows, previousRows) {
-    const sum = rows => ({
-      exp: rows.reduce((t, r) => t + (r.exposure || 0), 0),
-      add: rows.reduce((t, r) => t + (r.add_people || 0), 0),
-      pay: rows.reduce((t, r) => t + (r.pay_items || 0), 0)
+  function renderWeeklyComparisonCharts(rows) {
+    const map = new Map();
+    rows.forEach(r => {
+      const w = r.bucket || r.week || r.stat_date || '';
+      if (!map.has(w)) {
+        map.set(w, {
+          exposure: 0,
+          visitors: 0,
+          add_count: 0,
+          pay_items: 0,
+          expSet: new Set(),
+          addSet: new Set(),
+          paySet: new Set()
+        });
+      }
+      const acc = map.get(w);
+      acc.exposure += r.exposure || 0;
+      acc.visitors += r.visitors || 0;
+      acc.add_count += r.add_people || 0;
+      acc.pay_items += r.pay_items || 0;
+      if ((r.exposure || 0) > 0) acc.expSet.add(r.product_id);
+      if ((r.add_people || 0) > 0) acc.addSet.add(r.product_id);
+      if ((r.pay_items || 0) > 0 || (r.pay_orders || 0) > 0) acc.paySet.add(r.product_id);
     });
-    const cur = sum(currentRows);
-    const prev = sum(previousRows);
 
-    const render = (id, label, curVal, prevVal) => {
+    const weeks = Array.from(map.keys()).sort();
+    const exp = weeks.map(w => map.get(w).exposure);
+    const uv = weeks.map(w => map.get(w).visitors);
+    const addTimes = weeks.map(w => map.get(w).add_count);
+    const orderItems = weeks.map(w => map.get(w).pay_items);
+    const expProducts = weeks.map(w => map.get(w).expSet.size);
+    const addProducts = weeks.map(w => map.get(w).addSet.size);
+    const payProducts = weeks.map(w => map.get(w).paySet.size);
+
+    const render = (id, data) => {
       const option = {
-        tooltip:{ trigger:'axis', axisPointer:{ type:'shadow' } },
-        legend:{ data:['本期','上期'], textStyle:{ color:'#374151' } },
-        xAxis:{ type:'category', data:[label], axisLabel:{ color:'#374151' } },
+        tooltip:{ trigger:'axis' },
+        xAxis:{ type:'category', data:weeks, axisLabel:{ color:'#374151' } },
         yAxis:{ type:'value', axisLabel:{ color:'#374151' } },
-        series:[
-          { name:'本期', type:'bar', data:[curVal], label:{show:true, position:'top'} },
-          { name:'上期', type:'bar', data:[prevVal], label:{show:true, position:'top'} }
-        ]
+        series:[{
+          type:'bar',
+          data,
+          barMaxWidth:24,
+          itemStyle:{ color:'#3B82F6' },
+          label:{ show:true, position:'top', color:'#374151' }
+        }],
+        grid:{ left:40, right:20, top:30, bottom:30 }
       };
       initResponsiveChart(id, option);
     };
 
-    render('analysisExposureCompare', '曝光', cur.exp, prev.exp);
-    render('analysisCartCompare', '加购件数', cur.add, prev.add);
-    render('analysisPayCompare', '支付订单数', cur.pay, prev.pay);
+    render('analysisExposureWeekly', exp);
+    render('analysisVisitorsWeekly', uv);
+    render('analysisAddTimesWeekly', addTimes);
+    render('analysisOrderItemsWeekly', orderItems);
+    render('analysisExposureProductsWeekly', expProducts);
+    render('analysisAddProductsWeekly', addProducts);
+    render('analysisPayProductsWeekly', payProducts);
   }
 
   function renderFunnelChart(currentRows, previousRows) {


### PR DESCRIPTION
## Summary
- ensure Ozon product totals accumulate all historical products by fetching in pages instead of a limited query
- add weekly comparison bar charts on both self-operated and managed analysis pages showing last two months of metrics by natural week and remove outdated period comparisons
- display values atop weekly bars and base add-to-cart metrics on `add_people` so add-to-cart charts populate correctly
- switch independent-site analysis charts (product exposure total, CTR, conversion count, clicked product count) to 3-month weekly bar charts with value labels

## Testing
- `npm test` *(fails: ReferenceError: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68c8173fa1d08325a120d02a6baa4920