### PR TITLE
Improve Lazada token exchange diagnostics and parsing

### DIFF
--- a/lib/find-key-deep.js
+++ b/lib/find-key-deep.js
@@ -1,0 +1,60 @@
+'use strict';
+
+function normalizeKeys(keys) {
+  const input = keys instanceof Set ? Array.from(keys) : Array.isArray(keys) ? keys : [keys];
+  return new Set(input.filter(Boolean).map((key) => String(key).toLowerCase()));
+}
+
+function maskPathSegment(path, key) {
+  return path ? `${path}.${key}` : String(key);
+}
+
+function findKeyDeep(input, keys, maxDepth = 10) {
+  if (input == null) return null;
+  const wanted = normalizeKeys(keys);
+  if (!wanted.size) {
+    return null;
+  }
+
+  const stack = [{ val: input, path: '', depth: 0 }];
+  const seen = new Set();
+
+  while (stack.length) {
+    const current = stack.pop();
+    if (!current) continue;
+    const { val, path, depth } = current;
+    if (depth > maxDepth) continue;
+
+    if (val && typeof val === 'object') {
+      if (seen.has(val)) {
+        continue;
+      }
+      seen.add(val);
+
+      if (Array.isArray(val)) {
+        for (let i = val.length - 1; i >= 0; i -= 1) {
+          stack.push({ val: val[i], path: `${path}[${i}]`, depth: depth + 1 });
+        }
+        continue;
+      }
+
+      const entries = Object.entries(val);
+      for (const [key, value] of entries) {
+        if (wanted.has(String(key).toLowerCase())) {
+          return { value, path: maskPathSegment(path, key) };
+        }
+      }
+
+      for (let i = entries.length - 1; i >= 0; i -= 1) {
+        const [key, value] = entries[i];
+        stack.push({ val: value, path: maskPathSegment(path, key), depth: depth + 1 });
+      }
+    }
+  }
+
+  return null;
+}
+
+module.exports = {
+  findKeyDeep,
+};

--- a/tests/find-key-deep.test.js
+++ b/tests/find-key-deep.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { findKeyDeep } = require('../lib/find-key-deep');
+
+test('findKeyDeep locates first matching key regardless of nesting', () => {
+  const payload = {
+    data: {
+      wrapper: [
+        { accessToken: 'first' },
+        { refresh_token: 'second' },
+      ],
+      meta: { refresh_token: 'third' }
+    }
+  };
+
+  const refresh = findKeyDeep(payload, ['refresh_token']);
+  assert.equal(refresh.value, 'second');
+  assert.equal(refresh.path, 'data.wrapper[1].refresh_token');
+
+  const access = findKeyDeep(payload, ['accesstoken']);
+  assert.equal(access.value, 'first');
+  assert.equal(access.path, 'data.wrapper[0].accessToken');
+});
+
+test('findKeyDeep respects maximum depth and avoids cycles', () => {
+  const payload = { level0: { level1: { target: 'found' } } };
+  assert.equal(findKeyDeep(payload, ['target'], 0), null);
+
+  const circular = {};
+  circular.self = circular;
+  assert.equal(findKeyDeep(circular, ['missing']), null);
+});

--- a/tests/lazada-oauth-callback.test.js
+++ b/tests/lazada-oauth-callback.test.js
@@ -108,16 +108,17 @@ test('lazada oauth callback exchanges code for tokens', async () => {
   const originalFetch = global.fetch;
   global.fetch = async (url, options) => {
     fetchCalls.push({ url, options });
+    const body = JSON.stringify({
+      access_token: 'access',
+      refresh_token: 'refresh',
+      expires_in: 3600,
+      refresh_expires_in: 86400,
+      country_user_info: [{ country: 'SG' }],
+    });
     return {
       ok: true,
       status: 200,
-      json: async () => ({
-        access_token: 'access',
-        refresh_token: 'refresh',
-        expires_in: 3600,
-        refresh_expires_in: 86400,
-        country_user_info: [{ country: 'SG' }],
-      }),
+      text: async () => body,
     };
   };
 
@@ -152,12 +153,26 @@ test('lazada oauth callback exchanges code for tokens', async () => {
     assert.equal(res.statusCode, 302);
     assert.equal(res.headers.Location, '/lazada.html?lazadaAuth=success');
     assert.equal(fetchCalls.length, 1);
-    assert.match(fetchCalls[0].url, /rest\/auth\/token\/create/);
-    const url = new URL(fetchCalls[0].url);
-    assert.equal(url.searchParams.get('need_refresh_token'), 'true');
+    assert.equal(fetchCalls[0].url, 'https://auth.lazada.com/rest/auth/token/create');
+    const params = new URLSearchParams(fetchCalls[0].options.body);
+    assert.equal(params.get('need_refresh_token'), 'true');
+    assert.equal(params.get('grant_type'), 'authorization_code');
+    assert.equal(params.get('client_id'), 'key');
+    assert.equal(params.get('client_secret'), 'secret');
+    assert.equal(params.get('app_secret'), 'secret');
+    assert.equal(params.get('redirect_uri'), 'https://example.com/callback');
+    assert.equal(params.get('code'), 'abc123');
+    assert.equal(params.get('sign_method'), 'sha256');
+    assert.ok(params.get('sign'));
+    assert.equal(fetchCalls[0].options.headers['Content-Type'], 'application/x-www-form-urlencoded');
+    assert.equal(fetchCalls[0].options.cache, 'no-store');
     assert.equal(upsertCalls.length, 1);
     assert.equal(upsertCalls[0].site_id, 'lazada_site');
     assert.equal(upsertCalls[0].refresh_token, 'refresh');
+    assert.equal(upsertCalls[0].access_token, 'access');
+    assert.equal(upsertCalls[0].meta.refresh_expires_in, 86400);
+    assert.equal(upsertCalls[0].meta.country, 'SG');
+    assert.deepEqual(upsertCalls[0].meta.state, [{ country: 'SG' }]);
   });
 
   if (originalFetch) {
@@ -177,10 +192,8 @@ test('lazada oauth callback handles responses wrapped in data envelope', async (
   process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role';
 
   const originalFetch = global.fetch;
-  global.fetch = async () => ({
-    ok: true,
-    status: 200,
-    json: async () => ({
+  global.fetch = async () => {
+    const body = JSON.stringify({
       code: '0',
       data: {
         access_token: 'access',
@@ -189,8 +202,13 @@ test('lazada oauth callback handles responses wrapped in data envelope', async (
         account_id: 'seller-1'
       },
       request_id: 'req-123'
-    })
-  });
+    });
+    return {
+      ok: true,
+      status: 200,
+      text: async () => body,
+    };
+  };
 
   const upsertCalls = [];
   await withSupabaseClientStub(() => ({
@@ -225,7 +243,182 @@ test('lazada oauth callback handles responses wrapped in data envelope', async (
     assert.equal(upsertCalls.length, 1);
     assert.equal(upsertCalls[0].refresh_token, 'refresh');
     assert.equal(upsertCalls[0].meta.account_id, 'seller-1');
+    assert.equal(upsertCalls[0].meta.refresh_expires_in, null);
+    assert.equal(upsertCalls[0].meta.country, null);
+    assert.equal(upsertCalls[0].meta.state, null);
     assert.equal(upsertCalls[0].meta.raw.request_id, 'req-123');
+  });
+
+  if (originalFetch) {
+    global.fetch = originalFetch;
+  } else {
+    delete global.fetch;
+  }
+  restoreEnv(originalEnv);
+});
+
+test('lazada oauth callback finds tokens nested inside Lazada wrapper objects', async () => {
+  const originalEnv = snapshotEnv();
+  process.env.LAZADA_APP_KEY = 'key';
+  process.env.LAZADA_APP_SECRET = 'secret';
+  process.env.LAZADA_REDIRECT_URI = 'https://example.com/callback';
+  process.env.SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role';
+
+  const originalFetch = global.fetch;
+  global.fetch = async () => {
+    const body = JSON.stringify({
+      data: {
+        token_result: [
+          {
+            token_info: {
+              tokens: {
+                refreshToken: '  nested-refresh  ',
+                accessToken: ' nested-access ',
+              },
+              metrics: {
+                expiresIn: ' 3600 ',
+                refreshExpiresIn: '172800',
+              },
+              profile: {
+                sellerId: 'seller-2',
+                region: 'PH',
+              }
+            }
+          }
+        ]
+      }
+    });
+    return {
+      ok: true,
+      status: 200,
+      text: async () => body,
+    };
+  };
+
+  const upsertCalls = [];
+  await withSupabaseClientStub(() => ({
+    schema() {
+      return {
+        from() {
+          return {
+            upsert(row) {
+              upsertCalls.push(row);
+              return {
+                select: async () => ({ data: [{ id: 'record', ...row }], error: null })
+              };
+            }
+          };
+        }
+      };
+    }
+  }), async () => {
+    const handler = loadHandler();
+    const state = createSignedState({ siteId: 'lazada_site', returnTo: '/lazada.html' }, { secret: 'secret' });
+    const req = {
+      method: 'GET',
+      query: { code: 'abc123', state },
+      headers: { host: 'example.com' }
+    };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 302);
+    assert.equal(res.headers.Location, '/lazada.html?lazadaAuth=success');
+    assert.equal(upsertCalls.length, 1);
+    assert.equal(upsertCalls[0].refresh_token, 'nested-refresh');
+    assert.equal(upsertCalls[0].access_token, 'nested-access');
+    assert.equal(upsertCalls[0].meta.account_id, 'seller-2');
+    assert.equal(upsertCalls[0].meta.country, 'PH');
+    assert.equal(upsertCalls[0].meta.refresh_expires_in, 172800);
+    assert.equal(upsertCalls[0].meta.state, null);
+  });
+
+  if (originalFetch) {
+    global.fetch = originalFetch;
+  } else {
+    delete global.fetch;
+  }
+  restoreEnv(originalEnv);
+});
+
+test('lazada oauth callback parses JSON string token payloads', async () => {
+  const originalEnv = snapshotEnv();
+  process.env.LAZADA_APP_KEY = 'key';
+  process.env.LAZADA_APP_SECRET = 'secret';
+  process.env.LAZADA_REDIRECT_URI = 'https://example.com/callback';
+  process.env.SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role';
+
+  const originalFetch = global.fetch;
+  global.fetch = async () => {
+    const body = JSON.stringify({
+      code: '0',
+      data: JSON.stringify({
+        token_info: {
+          refresh_token: '  string-refresh  ',
+          access_token: ' string-access ',
+          expires_in: ' 900 ',
+          refresh_expires_in: ' 3600 ',
+          country_user_info: [
+            {
+              country: 'VN',
+              seller_id: 'seller-99',
+              user_id: 8888,
+            }
+          ]
+        }
+      }),
+      request_id: 'req-json'
+    });
+    return {
+      ok: true,
+      status: 200,
+      text: async () => body,
+    };
+  };
+
+  const upsertCalls = [];
+  await withSupabaseClientStub(() => ({
+    schema() {
+      return {
+        from() {
+          return {
+            upsert(row) {
+              upsertCalls.push(row);
+              return {
+                select: async () => ({ data: [{ id: 'record', ...row }], error: null })
+              };
+            }
+          };
+        }
+      };
+    }
+  }), async () => {
+    const handler = loadHandler();
+    const state = createSignedState({ siteId: 'lazada_site', returnTo: '/lazada.html' }, { secret: 'secret' });
+    const req = {
+      method: 'GET',
+      query: { code: 'abc123', state },
+      headers: { host: 'example.com' }
+    };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 302);
+    assert.equal(res.headers.Location, '/lazada.html?lazadaAuth=success');
+    assert.equal(upsertCalls.length, 1);
+    assert.equal(upsertCalls[0].refresh_token, 'string-refresh');
+    assert.equal(upsertCalls[0].access_token, 'string-access');
+    assert.equal(upsertCalls[0].meta.country, 'VN');
+    assert.equal(upsertCalls[0].meta.account_id, 'seller-99');
+    assert.equal(upsertCalls[0].meta.refresh_expires_in, 3600);
+    assert.ok(Array.isArray(upsertCalls[0].meta.state));
+    assert.equal(upsertCalls[0].meta.state[0].country, 'VN');
+    assert.equal(upsertCalls[0].meta.raw.request_id, 'req-json');
+    assert.equal(typeof upsertCalls[0].meta.raw.data, 'string');
   });
 
   if (originalFetch) {
@@ -245,15 +438,18 @@ test('lazada oauth callback reports Supabase credential misconfiguration', async
   delete process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   const originalFetch = global.fetch;
-  global.fetch = async () => ({
-    ok: true,
-    status: 200,
-    json: async () => ({
+  global.fetch = async () => {
+    const body = JSON.stringify({
       access_token: 'access',
       refresh_token: 'refresh',
       expires_in: 3600,
-    })
-  });
+    });
+    return {
+      ok: true,
+      status: 200,
+      text: async () => body,
+    };
+  };
 
   const state = createSignedState({ siteId: 'lazada_site', returnTo: '/lazada.html' }, { secret: 'secret' });
   const req = {


### PR DESCRIPTION
## Summary
- send Lazada token exchange requests as signed form posts that include grant metadata and compatible client credentials, and retain the raw body for inspection
- feed the raw response text into the deep token search so refresh tokens nested inside wrapper structures are discovered, while logging the body and storing sanitized envelopes
- update the Lazada OAuth callback tests to assert the new POST contract and confirm tokens persist from nested or stringified payloads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd7dcd70bc83258328102f6f587ea9