### PR TITLE
Improve Lazada token exchange logging and parsing

### DIFF
--- a/api/lazada/oauth/callback/index.js
+++ b/api/lazada/oauth/callback/index.js
@@ -2,9 +2,18 @@ const crypto = require('crypto');
 const { createClient } = require('@supabase/supabase-js');
 const { storeTokenRecord } = require('../../../../lib/lazada-auth');
 const { decodeState } = require('../../../../lib/lazada-oauth-state');
+const { findKeyDeep } = require('../../../../lib/find-key-deep');
 
 const TOKEN_ENDPOINT = 'https://auth.lazada.com/rest/auth/token/create';
 const TOKEN_PATH = '/rest/auth/token/create';
+
+const ACCESS_KEYS = ['access_token', 'accessToken', 'token'];
+const REFRESH_KEYS = ['refresh_token', 'refreshToken', 'refresh'];
+const EXPIRES_IN_KEYS = ['expires_in', 'expiresIn', 'expire_in'];
+const REFRESH_EXPIRES_IN_KEYS = ['refresh_expires_in', 'refreshExpiresIn'];
+const ACCOUNT_ID_KEYS = ['account_id', 'accountId', 'seller_id', 'sellerId', 'user_id', 'userId'];
+const COUNTRY_KEYS = ['country', 'region'];
+const STATE_KEYS = ['country_user_info', 'account_user_info'];
 
 function fetchLazada(endpoint, options) {
   if (typeof global.fetch === 'function') {
@@ -51,23 +60,216 @@ function createSupabaseClient() {
   return createClient(url, key, { auth: { persistSession: false } });
 }
 
-function pickTokenValue(payload, keys) {
-  if (!payload || typeof payload !== 'object') return null;
-  for (const key of keys) {
-    if (Object.prototype.hasOwnProperty.call(payload, key)) {
-      const value = payload[key];
-      if (typeof value === 'string' && value.trim()) {
-        return value.trim();
+function maskTokenString(value) {
+  if (!value) return value;
+  const stringValue = String(value);
+  const leading = stringValue.match(/^\s*/)?.[0] || '';
+  const trailing = stringValue.match(/\s*$/)?.[0] || '';
+  const trimmed = stringValue.trim();
+  if (!trimmed) return stringValue;
+  const masked = trimmed.length <= 8
+    ? `${trimmed.slice(0, 2)}***${trimmed.slice(-2)}`
+    : `${trimmed.slice(0, 4)}…${trimmed.slice(-4)}`;
+  return `${leading}${masked}${trailing}`;
+}
+
+function redactTokenText(text) {
+  if (typeof text !== 'string' || !text) {
+    return text;
+  }
+
+  const TOKEN_REGEX = /(["']?(?:access|refresh)(?:_token|Token)["']?\s*[:=]\s*["'])([^"']+)(["'])/gi;
+  return text.replace(TOKEN_REGEX, (match, prefix, tokenValue, suffix) => {
+    return `${prefix}${maskTokenString(tokenValue)}${suffix}`;
+  });
+}
+
+function coerceString(value) {
+  if (value == null) return null;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed || null;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const result = coerceString(item);
+      if (result) return result;
+    }
+  }
+  return null;
+}
+
+function coerceNumber(value) {
+  if (value == null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function safeJsonParse(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const firstChar = trimmed[0];
+  if (firstChar !== '{' && firstChar !== '[') {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(trimmed);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch (err) {
+    return null;
+  }
+}
+
+function pickDeepValue(payload, keys, transformer) {
+  const result = findKeyDeep(payload, keys);
+  if (!result) return null;
+  return transformer(result.value);
+}
+
+function pickDeepString(payload, keys) {
+  return pickDeepValue(payload, keys, coerceString);
+}
+
+function pickDeepNumber(payload, keys) {
+  return pickDeepValue(payload, keys, coerceNumber);
+}
+
+function firstObjectMatch(payload, keys) {
+  const result = findKeyDeep(payload, keys);
+  if (!result) return null;
+  const value = result.value;
+  if (!value || typeof value !== 'object') return null;
+  return value;
+}
+
+function gatherSearchSpaces(...roots) {
+  const spaces = [];
+  const queue = roots.filter((value) => value != null);
+  const seen = new Set();
+
+  while (queue.length) {
+    const current = queue.shift();
+    if (current == null) continue;
+
+    if (typeof current === 'string') {
+      const parsed = safeJsonParse(current);
+      if (parsed) {
+        queue.push(parsed);
       }
-      if (value && typeof value === 'object' && !Array.isArray(value)) {
-        const nested = pickTokenValue(value, keys);
-        if (nested) {
-          return nested;
+      continue;
+    }
+
+    if (typeof current === 'object') {
+      if (seen.has(current)) {
+        continue;
+      }
+      seen.add(current);
+      spaces.push(current);
+
+      const values = Array.isArray(current) ? current : Object.values(current);
+      for (const value of values) {
+        if (value && (typeof value === 'object' || typeof value === 'string')) {
+          queue.push(value);
         }
       }
     }
   }
+
+  return spaces;
+}
+
+function findFirst(spaces, resolver) {
+  for (const space of spaces) {
+    const value = resolver(space);
+    if (value !== null && value !== undefined) {
+      return value;
+    }
+  }
   return null;
+}
+
+function buildSellerCountryMap(info) {
+  if (!info) return null;
+
+  const buckets = [];
+  if (Array.isArray(info)) {
+    buckets.push(...info);
+  } else if (info && typeof info === 'object') {
+    if (Array.isArray(info.country_user_info)) {
+      buckets.push(...info.country_user_info);
+    }
+    if (Array.isArray(info.account_user_info)) {
+      buckets.push(...info.account_user_info);
+    }
+  }
+
+  if (!buckets.length) {
+    return null;
+  }
+
+  const map = {};
+  for (const entry of buckets) {
+    if (!entry || typeof entry !== 'object') continue;
+    const country = coerceString(entry.country || entry.region);
+    const sellerId = coerceString(entry.seller_id || entry.sellerId);
+    if (country && sellerId) {
+      map[country] = sellerId;
+    }
+  }
+
+  return Object.keys(map).length ? map : null;
+}
+
+function redactTokens(input, depth = 0, maxDepth = 6) {
+  if (depth > maxDepth) {
+    return '[depth-exceeded]';
+  }
+  if (input == null) return input;
+  if (typeof input !== 'object') return input;
+  if (Array.isArray(input)) {
+    return input.map((item) => redactTokens(item, depth + 1, maxDepth));
+  }
+
+  const output = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (typeof value === 'string' && /token/i.test(key)) {
+      output[key] = maskTokenString(value);
+      continue;
+    }
+    output[key] = redactTokens(value, depth + 1, maxDepth);
+  }
+  return output;
+}
+
+function logTokenResponse(envelope, tokenPayload) {
+  try {
+    const safeEnvelope = redactTokens(envelope);
+    const safePayload = tokenPayload === envelope ? safeEnvelope : redactTokens(tokenPayload);
+
+    console.info('[Lazada OAuth] raw token response envelope (debug):', envelope);
+    if (tokenPayload && tokenPayload !== envelope) {
+      console.info('[Lazada OAuth] raw extracted token payload (debug):', tokenPayload);
+    }
+
+    console.info('[Lazada OAuth] token response envelope:', JSON.stringify(safeEnvelope));
+    if (tokenPayload) {
+      console.info('[Lazada OAuth] extracted token payload:', JSON.stringify(safePayload));
+    }
+  } catch (logError) {
+    console.warn('[Lazada OAuth] failed to log Lazada token response', logError);
+  }
 }
 
 function extractTokenPayload(envelope) {
@@ -97,26 +299,54 @@ async function persistTokens({ supabase, siteId, payload, raw }) {
     throw err;
   }
 
-  if (!payload || typeof payload !== 'object') {
+  const searchSpaces = gatherSearchSpaces(payload, raw);
+  if (!searchSpaces.length) {
     const err = new Error('Lazada 授权响应缺失，无法存储凭据');
     err.code = 'LAZADA_TOKEN_RESPONSE_MISSING';
     err.status = 500;
     throw err;
   }
 
-  const refreshToken = pickTokenValue(payload, ['refresh_token', 'refreshToken']);
+  const primarySpace = searchSpaces.find((space) => !Array.isArray(space)) || searchSpaces[0] || null;
+
+  const refreshToken = findFirst(searchSpaces, (space) => pickDeepString(space, REFRESH_KEYS));
   if (!refreshToken) {
+    console.error('[Lazada OAuth] Missing refresh token in payload', {
+      keys: REFRESH_KEYS,
+      snapshot: redactTokens(primarySpace || payload || raw || null)
+    });
     const err = new Error('Lazada 授权响应缺少 refresh_token，无法存储凭据');
     err.code = 'REFRESH_TOKEN_MISSING';
     err.status = 500;
     throw err;
   }
 
-  const accessToken = pickTokenValue(payload, ['access_token', 'accessToken']);
-  const expiresIn = Number(payload.expires_in || payload.expire_in);
+  const accessToken = findFirst(searchSpaces, (space) => pickDeepString(space, ACCESS_KEYS));
+  const expiresIn = findFirst(searchSpaces, (space) => pickDeepNumber(space, EXPIRES_IN_KEYS));
   const expiresAt = Number.isFinite(expiresIn) && expiresIn > 0
     ? new Date(Date.now() + expiresIn * 1000).toISOString()
     : null;
+
+  const refreshExpiresIn = findFirst(searchSpaces, (space) => pickDeepNumber(space, REFRESH_EXPIRES_IN_KEYS));
+
+  const stateInfo =
+    findFirst(searchSpaces, (space) => firstObjectMatch(space, STATE_KEYS)) ||
+    (primarySpace && (primarySpace.country_user_info || primarySpace.account_user_info)) ||
+    null;
+
+  const accountId =
+    findFirst(searchSpaces, (space) => pickDeepString(space, ACCOUNT_ID_KEYS)) ||
+    (stateInfo ? pickDeepString(stateInfo, ACCOUNT_ID_KEYS) : null);
+
+  const country =
+    findFirst(searchSpaces, (space) => pickDeepString(space, COUNTRY_KEYS)) ||
+    (stateInfo ? pickDeepString(stateInfo, COUNTRY_KEYS) : null);
+
+  const sellerMap = buildSellerCountryMap(stateInfo);
+
+  const rawForStorage =
+    (raw && typeof raw === 'object') ? raw :
+    (primarySpace && typeof primarySpace === 'object' ? primarySpace : undefined);
 
   return storeTokenRecord(supabase, {
     siteId,
@@ -124,19 +354,12 @@ async function persistTokens({ supabase, siteId, payload, raw }) {
     refreshToken,
     expiresAt,
     meta: {
-      account_id:
-        payload.account_id ||
-        payload.accountId ||
-        payload.country_user_info?.userId ||
-        payload.account_user_info?.userId ||
-        null,
-      country:
-        payload.country ||
-        payload.country_user_info?.country ||
-        payload.account_user_info?.country ||
-        null,
-      state: payload.country_user_info || payload.account_user_info || null,
-      raw: raw && typeof raw === 'object' ? raw : undefined
+      account_id: accountId || null,
+      country: country || null,
+      refresh_expires_in: refreshExpiresIn || null,
+      state: stateInfo || null,
+      seller_map: sellerMap || null,
+      raw: rawForStorage
     }
   });
 }
@@ -146,7 +369,7 @@ async function exchangeAuthorizationCode(code, redirectUri) {
   const appSecret = getEnvOrThrow('LAZADA_APP_SECRET');
 
   const timestamp = Date.now().toString();
-  const params = {
+  const signatureParams = {
     app_key: appKey,
     code,
     redirect_uri: redirectUri,
@@ -155,21 +378,53 @@ async function exchangeAuthorizationCode(code, redirectUri) {
     need_refresh_token: 'true',
   };
 
-  params.sign = buildLazadaSignature(params, appSecret);
-
-  const search = new URLSearchParams(params);
-  const response = await fetchLazada(`${TOKEN_ENDPOINT}?${search.toString()}`, {
-    method: 'POST',
+  const body = new URLSearchParams({
+    ...signatureParams,
+    sign: buildLazadaSignature(signatureParams, appSecret),
+    app_secret: appSecret,
+    client_id: appKey,
+    client_secret: appSecret,
+    grant_type: 'authorization_code',
   });
 
-  const payload = await response.json().catch(() => null);
+  const response = await fetchLazada(TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: body.toString(),
+    cache: 'no-store',
+  });
+
+  const rawText = await response.text();
+  if (rawText) {
+    console.info('[Lazada OAuth] token/create raw response:', redactTokenText(rawText));
+  } else {
+    console.info('[Lazada OAuth] token/create raw response: <empty>');
+  }
+
+  let payload = null;
+  if (rawText) {
+    try {
+      payload = JSON.parse(rawText);
+    } catch (parseError) {
+      payload = safeJsonParse(rawText);
+    }
+  }
 
   if (!response.ok) {
     const message = payload?.message || payload?.error_description || response.statusText;
     const error = new Error(message || 'Failed to exchange Lazada auth code');
     error.status = response.status;
-    error.details = payload;
+    error.details = payload || rawText;
     throw error;
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    const err = new Error('Lazada 授权响应不是有效的 JSON');
+    err.status = 502;
+    err.details = rawText || null;
+    throw err;
   }
 
   return payload;
@@ -234,6 +489,8 @@ async function handler(req, res) {
     const redirectUri = getEnvOrThrow('LAZADA_REDIRECT_URI', 'must match Lazada app settings');
     const tokenEnvelope = await exchangeAuthorizationCode(code, redirectUri);
     const { tokens: tokenResponse, raw: rawTokenResponse } = extractTokenPayload(tokenEnvelope);
+
+    logTokenResponse(tokenEnvelope, tokenResponse);
 
     const safeData = tokenResponse && typeof tokenResponse === 'object'
       ? {

--- a/lib/find-key-deep.js
+++ b/lib/find-key-deep.js
@@ -1,0 +1,60 @@
+'use strict';
+
+function normalizeKeys(keys) {
+  const input = keys instanceof Set ? Array.from(keys) : Array.isArray(keys) ? keys : [keys];
+  return new Set(input.filter(Boolean).map((key) => String(key).toLowerCase()));
+}
+
+function maskPathSegment(path, key) {
+  return path ? `${path}.${key}` : String(key);
+}
+
+function findKeyDeep(input, keys, maxDepth = 10) {
+  if (input == null) return null;
+  const wanted = normalizeKeys(keys);
+  if (!wanted.size) {
+    return null;
+  }
+
+  const stack = [{ val: input, path: '', depth: 0 }];
+  const seen = new Set();
+
+  while (stack.length) {
+    const current = stack.pop();
+    if (!current) continue;
+    const { val, path, depth } = current;
+    if (depth > maxDepth) continue;
+
+    if (val && typeof val === 'object') {
+      if (seen.has(val)) {
+        continue;
+      }
+      seen.add(val);
+
+      if (Array.isArray(val)) {
+        for (let i = val.length - 1; i >= 0; i -= 1) {
+          stack.push({ val: val[i], path: `${path}[${i}]`, depth: depth + 1 });
+        }
+        continue;
+      }
+
+      const entries = Object.entries(val);
+      for (const [key, value] of entries) {
+        if (wanted.has(String(key).toLowerCase())) {
+          return { value, path: maskPathSegment(path, key) };
+        }
+      }
+
+      for (let i = entries.length - 1; i >= 0; i -= 1) {
+        const [key, value] = entries[i];
+        stack.push({ val: value, path: maskPathSegment(path, key), depth: depth + 1 });
+      }
+    }
+  }
+
+  return null;
+}
+
+module.exports = {
+  findKeyDeep,
+};

--- a/tests/find-key-deep.test.js
+++ b/tests/find-key-deep.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { findKeyDeep } = require('../lib/find-key-deep');
+
+test('findKeyDeep locates first matching key regardless of nesting', () => {
+  const payload = {
+    data: {
+      wrapper: [
+        { accessToken: 'first' },
+        { refresh_token: 'second' },
+      ],
+      meta: { refresh_token: 'third' }
+    }
+  };
+
+  const refresh = findKeyDeep(payload, ['refresh_token']);
+  assert.equal(refresh.value, 'second');
+  assert.equal(refresh.path, 'data.wrapper[1].refresh_token');
+
+  const access = findKeyDeep(payload, ['accesstoken']);
+  assert.equal(access.value, 'first');
+  assert.equal(access.path, 'data.wrapper[0].accessToken');
+});
+
+test('findKeyDeep respects maximum depth and avoids cycles', () => {
+  const payload = { level0: { level1: { target: 'found' } } };
+  assert.equal(findKeyDeep(payload, ['target'], 0), null);
+
+  const circular = {};
+  circular.self = circular;
+  assert.equal(findKeyDeep(circular, ['missing']), null);
+});

--- a/tests/lazada-oauth-callback.test.js
+++ b/tests/lazada-oauth-callback.test.js
@@ -111,7 +111,7 @@ test('lazada oauth callback exchanges code for tokens', async () => {
     return {
       ok: true,
       status: 200,
-      json: async () => ({
+      text: async () => JSON.stringify({
         access_token: 'access',
         refresh_token: 'refresh',
         expires_in: 3600,
@@ -152,12 +152,24 @@ test('lazada oauth callback exchanges code for tokens', async () => {
     assert.equal(res.statusCode, 302);
     assert.equal(res.headers.Location, '/lazada.html?lazadaAuth=success');
     assert.equal(fetchCalls.length, 1);
-    assert.match(fetchCalls[0].url, /rest\/auth\/token\/create/);
-    const url = new URL(fetchCalls[0].url);
-    assert.equal(url.searchParams.get('need_refresh_token'), 'true');
+    assert.equal(fetchCalls[0].url, 'https://auth.lazada.com/rest/auth/token/create');
+    const { headers, body } = fetchCalls[0].options;
+    assert.equal(headers['Content-Type'], 'application/x-www-form-urlencoded');
+    const params = new URLSearchParams(body);
+    assert.equal(params.get('need_refresh_token'), 'true');
+    assert.equal(params.get('grant_type'), 'authorization_code');
+    assert.equal(params.get('client_id'), 'key');
+    assert.equal(params.get('client_secret'), 'secret');
+    assert.equal(params.get('app_secret'), 'secret');
+    assert.ok(params.get('sign'));
     assert.equal(upsertCalls.length, 1);
     assert.equal(upsertCalls[0].site_id, 'lazada_site');
     assert.equal(upsertCalls[0].refresh_token, 'refresh');
+    assert.equal(upsertCalls[0].access_token, 'access');
+    assert.equal(upsertCalls[0].meta.refresh_expires_in, 86400);
+    assert.equal(upsertCalls[0].meta.country, 'SG');
+    assert.deepEqual(upsertCalls[0].meta.state, [{ country: 'SG' }]);
+    assert.equal(upsertCalls[0].meta.seller_map, null);
   });
 
   if (originalFetch) {
@@ -180,7 +192,7 @@ test('lazada oauth callback handles responses wrapped in data envelope', async (
   global.fetch = async () => ({
     ok: true,
     status: 200,
-    json: async () => ({
+    text: async () => JSON.stringify({
       code: '0',
       data: {
         access_token: 'access',
@@ -225,7 +237,179 @@ test('lazada oauth callback handles responses wrapped in data envelope', async (
     assert.equal(upsertCalls.length, 1);
     assert.equal(upsertCalls[0].refresh_token, 'refresh');
     assert.equal(upsertCalls[0].meta.account_id, 'seller-1');
+    assert.equal(upsertCalls[0].meta.refresh_expires_in, null);
+    assert.equal(upsertCalls[0].meta.country, null);
+    assert.equal(upsertCalls[0].meta.state, null);
     assert.equal(upsertCalls[0].meta.raw.request_id, 'req-123');
+    assert.equal(upsertCalls[0].meta.seller_map, null);
+  });
+
+  if (originalFetch) {
+    global.fetch = originalFetch;
+  } else {
+    delete global.fetch;
+  }
+  restoreEnv(originalEnv);
+});
+
+test('lazada oauth callback finds tokens nested inside Lazada wrapper objects', async () => {
+  const originalEnv = snapshotEnv();
+  process.env.LAZADA_APP_KEY = 'key';
+  process.env.LAZADA_APP_SECRET = 'secret';
+  process.env.LAZADA_REDIRECT_URI = 'https://example.com/callback';
+  process.env.SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role';
+
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify({
+      data: {
+        token_result: [
+          {
+            token_info: {
+              tokens: {
+                refreshToken: '  nested-refresh  ',
+                accessToken: ' nested-access ',
+              },
+              metrics: {
+                expiresIn: ' 3600 ',
+                refreshExpiresIn: '172800',
+              },
+              profile: {
+                sellerId: 'seller-2',
+                region: 'PH',
+              }
+            }
+          }
+        ]
+      }
+    })
+  });
+
+  const upsertCalls = [];
+  await withSupabaseClientStub(() => ({
+    schema() {
+      return {
+        from() {
+          return {
+            upsert(row) {
+              upsertCalls.push(row);
+              return {
+                select: async () => ({ data: [{ id: 'record', ...row }], error: null })
+              };
+            }
+          };
+        }
+      };
+    }
+  }), async () => {
+    const handler = loadHandler();
+    const state = createSignedState({ siteId: 'lazada_site', returnTo: '/lazada.html' }, { secret: 'secret' });
+    const req = {
+      method: 'GET',
+      query: { code: 'abc123', state },
+      headers: { host: 'example.com' }
+    };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 302);
+    assert.equal(res.headers.Location, '/lazada.html?lazadaAuth=success');
+    assert.equal(upsertCalls.length, 1);
+    assert.equal(upsertCalls[0].refresh_token, 'nested-refresh');
+    assert.equal(upsertCalls[0].access_token, 'nested-access');
+    assert.equal(upsertCalls[0].meta.account_id, 'seller-2');
+    assert.equal(upsertCalls[0].meta.country, 'PH');
+    assert.equal(upsertCalls[0].meta.refresh_expires_in, 172800);
+    assert.equal(upsertCalls[0].meta.state, null);
+    assert.equal(upsertCalls[0].meta.seller_map, null);
+  });
+
+  if (originalFetch) {
+    global.fetch = originalFetch;
+  } else {
+    delete global.fetch;
+  }
+  restoreEnv(originalEnv);
+});
+
+test('lazada oauth callback parses JSON string token payloads', async () => {
+  const originalEnv = snapshotEnv();
+  process.env.LAZADA_APP_KEY = 'key';
+  process.env.LAZADA_APP_SECRET = 'secret';
+  process.env.LAZADA_REDIRECT_URI = 'https://example.com/callback';
+  process.env.SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role';
+
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify({
+      code: '0',
+      data: JSON.stringify({
+        token_info: {
+          refresh_token: '  string-refresh  ',
+          access_token: ' string-access ',
+          expires_in: ' 900 ',
+          refresh_expires_in: ' 3600 ',
+          country_user_info: [
+            {
+              country: 'VN',
+              seller_id: 'seller-99',
+              user_id: 8888,
+            }
+          ]
+        }
+      }),
+      request_id: 'req-json'
+    })
+  });
+
+  const upsertCalls = [];
+  await withSupabaseClientStub(() => ({
+    schema() {
+      return {
+        from() {
+          return {
+            upsert(row) {
+              upsertCalls.push(row);
+              return {
+                select: async () => ({ data: [{ id: 'record', ...row }], error: null })
+              };
+            }
+          };
+        }
+      };
+    }
+  }), async () => {
+    const handler = loadHandler();
+    const state = createSignedState({ siteId: 'lazada_site', returnTo: '/lazada.html' }, { secret: 'secret' });
+    const req = {
+      method: 'GET',
+      query: { code: 'abc123', state },
+      headers: { host: 'example.com' }
+    };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 302);
+    assert.equal(res.headers.Location, '/lazada.html?lazadaAuth=success');
+    assert.equal(upsertCalls.length, 1);
+    assert.equal(upsertCalls[0].refresh_token, 'string-refresh');
+    assert.equal(upsertCalls[0].access_token, 'string-access');
+    assert.equal(upsertCalls[0].meta.country, 'VN');
+    assert.equal(upsertCalls[0].meta.account_id, 'seller-99');
+    assert.equal(upsertCalls[0].meta.refresh_expires_in, 3600);
+    assert.ok(Array.isArray(upsertCalls[0].meta.state));
+    assert.equal(upsertCalls[0].meta.state[0].country, 'VN');
+    assert.equal(upsertCalls[0].meta.raw.request_id, 'req-json');
+    assert.equal(typeof upsertCalls[0].meta.raw.data, 'string');
+    assert.deepEqual(upsertCalls[0].meta.seller_map, { VN: 'seller-99' });
   });
 
   if (originalFetch) {
@@ -248,7 +432,7 @@ test('lazada oauth callback reports Supabase credential misconfiguration', async
   global.fetch = async () => ({
     ok: true,
     status: 200,
-    json: async () => ({
+    text: async () => JSON.stringify({
       access_token: 'access',
       refresh_token: 'refresh',
       expires_in: 3600,


### PR DESCRIPTION
## Summary
- broaden the Lazada OAuth callback search to parse JSON string payloads, scan both envelope and nested objects for token fields, and capture account/user metadata via unified helpers
- add raw response logging alongside redacted logs so returned key paths can be inspected when refresh tokens appear missing, including sanitized raw text dumps from Lazada token/create responses
- send Lazada token/create requests as form-encoded POSTs with redundant credentials/signature, build seller-by-country mappings, and extend the Lazada OAuth callback test suite to assert the new exchange payload and stored metadata

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd7dcd70bc83258328102f6f587ea9