### PR TITLE
Add admin role/user management and refine self-operated detail view

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -145,6 +145,15 @@
       border-color: #111827;
       color: #f9fafb;
     }
+    .btn-danger {
+      background: #ef4444;
+      border-color: #ef4444;
+      color: #fff;
+    }
+    .btn-danger:hover {
+      background: #dc2626;
+      border-color: #dc2626;
+    }
     .btn-success {
       background: #059669;
       border-color: #059669;
@@ -159,6 +168,82 @@
       flex-wrap: wrap;
       gap: 10px;
       margin-bottom: 16px;
+    }
+    .role-grid,
+    .user-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: 16px;
+    }
+    .role-card,
+    .user-card {
+      border: 1px solid #e5e7eb;
+      border-radius: 12px;
+      padding: 20px;
+      background: #fff;
+      box-shadow: 0 1px 2px rgba(15,23,42,0.08);
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .role-card h3,
+    .user-card h3 {
+      margin: 0;
+      font-size: 18px;
+      color: #1f2937;
+    }
+    .role-meta,
+    .user-meta {
+      color: #6b7280;
+      font-size: 13px;
+      line-height: 1.6;
+    }
+    .user-meta {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 8px;
+    }
+    .role-modules {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px 12px;
+    }
+    .role-checkbox {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      color: #374151;
+      background: #f9fafb;
+      border-radius: 9999px;
+      padding: 6px 12px;
+      border: 1px solid #e5e7eb;
+    }
+    .role-checkbox input {
+      margin: 0;
+    }
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      padding: 4px 10px;
+      border-radius: 9999px;
+      background: #eff6ff;
+      color: #1d4ed8;
+      font-size: 12px;
+      margin: 2px 4px 2px 0;
+      white-space: nowrap;
+    }
+    .chip-muted {
+      background: #f3f4f6;
+      color: #6b7280;
+    }
+    select[multiple] {
+      min-height: 120px;
+    }
+    .multi-select-hint {
+      font-size: 12px;
+      color: #6b7280;
+      margin-top: -4px;
     }
     .site-card {
       border: 1px solid #e5e7eb;
@@ -317,7 +402,9 @@
     <div class="site-header">管理后台</div>
     <ul class="sub-nav" id="adminNav">
       <li><a href="#" class="active" data-target="siteConsole">站点管理</a></li>
+      <li><a href="#" data-target="roleConsole">角色管理</a></li>
       <li><a href="#" data-target="permissionConsole">权限矩阵</a></li>
+      <li><a href="#" data-target="userConsole">用户管理</a></li>
       <li><a href="#" data-target="syncConsole">同步工具</a></li>
     </ul>
   </nav>
@@ -396,6 +483,24 @@
       </div>
     </section>
 
+    <section id="roleConsole" class="admin-section">
+      <div class="section-header">
+        <div>
+          <h1>角色管理</h1>
+          <div class="section-subtitle">定义各角色的默认访问范围，并与权限矩阵保持同步。</div>
+        </div>
+        <div style="display:flex;gap:10px;flex-wrap:wrap;">
+          <button class="btn" id="resetRoleBtn">恢复默认</button>
+          <button class="btn btn-primary" id="saveRoleBtn">保存角色配置</button>
+        </div>
+      </div>
+
+      <div class="admin-card">
+        <div class="role-grid" id="roleList"></div>
+        <p class="section-subtitle">角色权限当前存储在浏览器中，后端权限中心上线后将写入数据库并支持审计。</p>
+      </div>
+    </section>
+
     <section id="permissionConsole" class="admin-section">
       <div class="section-header">
         <div>
@@ -426,6 +531,49 @@
           <button class="btn" id="exportPermissionBtn">复制 JSON</button>
         </div>
         <p class="section-subtitle">保存操作会在浏览器内缓存配置，后端写入接口将在权限中心上线时接入。</p>
+      </div>
+    </section>
+
+    <section id="userConsole" class="admin-section">
+      <div class="section-header">
+        <div>
+          <h1>用户管理</h1>
+          <div class="section-subtitle">为成员分配角色与站点范围，不同角色将继承相应模块权限。</div>
+        </div>
+      </div>
+
+      <div class="admin-card">
+        <h2 style="margin-top:0">新增 / 编辑用户</h2>
+        <form id="userForm">
+          <div class="form-grid">
+            <div class="form-group">
+              <label for="userNameInput">姓名 *</label>
+              <input id="userNameInput" placeholder="如：王小明" required>
+            </div>
+            <div class="form-group">
+              <label for="userEmailInput">邮箱 *</label>
+              <input id="userEmailInput" type="email" placeholder="name@example.com" required>
+            </div>
+            <div class="form-group">
+              <label for="userRoleSelect">角色 *</label>
+              <select id="userRoleSelect" required></select>
+            </div>
+            <div class="form-group">
+              <label for="userSiteMulti">授权站点</label>
+              <select id="userSiteMulti" multiple></select>
+            </div>
+          </div>
+          <p class="multi-select-hint">按住 Ctrl / Command 可多选站点，留空表示访问所有站点。</p>
+          <div class="form-actions">
+            <button type="submit" class="btn btn-primary">保存用户</button>
+            <button type="button" class="btn" id="resetUserForm">重置</button>
+          </div>
+        </form>
+      </div>
+
+      <div class="admin-card">
+        <h2 style="margin-top:0">已授权用户</h2>
+        <div id="userList" class="user-grid"></div>
       </div>
     </section>
 
@@ -578,9 +726,41 @@ const ROLE_LABELS = {
   viewer: '只读用户'
 };
 
+const ROLE_DESCRIPTIONS = {
+  super_admin: '拥有全部功能权限，可配置站点、模块与权限矩阵。',
+  operations_manager: '聚焦核心运营指标与商品表现，查看报表与看板。',
+  order_manager: '管理订单、售后与物流信息，确保履约准确。',
+  inventory_manager: '维护库存、调拨与预警配置，掌握供应链状态。',
+  ad_manager: '负责广告预算、投放配置与投放效果追踪。',
+  finance: '查看结算、回款与费用分摊等财务数据。',
+  viewer: '只读访问主要看板，适用于业务查看。'
+};
+
+function computeRoleAssignmentsFromMatrix(matrix) {
+  const assignments = {};
+  Object.keys(ROLE_LABELS).forEach(role => {
+    assignments[role] = [];
+  });
+  Object.entries(matrix).forEach(([moduleKey, roles]) => {
+    (roles || []).forEach(role => {
+      if (!assignments[role]) {
+        assignments[role] = [];
+      }
+      if (!assignments[role].includes(moduleKey)) {
+        assignments[role].push(moduleKey);
+      }
+    });
+  });
+  return assignments;
+}
+
 let siteConfigs = [];
 let matrixOverrides = {};
 let activeMatrix = cloneMatrix(DEFAULT_MATRIX);
+let roleAssignments = computeRoleAssignmentsFromMatrix(DEFAULT_MATRIX);
+let userAccounts = [];
+let editingUserId = null;
+let editingUserSites = [];
 
 function cloneMatrix(matrix) {
   return JSON.parse(JSON.stringify(matrix));
@@ -678,6 +858,7 @@ async function loadSiteConfigs() {
     document.getElementById('siteCount').textContent = siteConfigs.length;
     renderSiteList();
     populateSiteSelectors();
+    renderUserList();
     setMessage(`已加载 ${siteConfigs.length} 个站点`, 'success');
   } catch (error) {
     console.error('加载站点失败', error);
@@ -717,6 +898,7 @@ function renderSiteList() {
       <div class="site-actions">
         <button class="btn" data-action="prefill" data-site-id="${site.id}">填充到表单</button>
         <button class="btn btn-secondary" data-action="sync" data-site-id="${site.id}">同步结构</button>
+        <button class="btn btn-danger" data-action="delete" data-site-id="${site.id}">删除站点</button>
       </div>
     `;
     list.appendChild(card);
@@ -745,6 +927,10 @@ function renderSiteList() {
 
   list.querySelectorAll('button[data-action="sync"]').forEach(btn => {
     btn.addEventListener('click', () => runSync(btn.dataset.siteId, 'update'));
+  });
+
+  list.querySelectorAll('button[data-action="delete"]').forEach(btn => {
+    btn.addEventListener('click', () => deleteSiteConfig(btn.dataset.siteId));
   });
 }
 
@@ -828,6 +1014,21 @@ function populateSiteSelectors() {
       select.appendChild(option);
     });
   });
+
+  const userSiteSelect = document.getElementById('userSiteMulti');
+  if (userSiteSelect) {
+    const preserved = editingUserId ? new Set(editingUserSites) : new Set(Array.from(userSiteSelect.selectedOptions || []).map(opt => opt.value));
+    userSiteSelect.innerHTML = '';
+    siteConfigs.forEach(site => {
+      const option = document.createElement('option');
+      option.value = site.id;
+      option.textContent = `${site.display_name || site.name} (${site.platform})`;
+      if (preserved.has(site.id)) {
+        option.selected = true;
+      }
+      userSiteSelect.appendChild(option);
+    });
+  }
 }
 
 async function runSync(siteId, action) {
@@ -849,6 +1050,279 @@ async function runSync(siteId, action) {
     console.error('同步失败', error);
     setMessage(`站点同步失败：${error.message}`, 'error');
   }
+}
+
+async function deleteSiteConfig(siteId) {
+  if (!siteId) return;
+  const target = siteConfigs.find(item => item.id === siteId);
+  const name = target ? (target.display_name || target.name || siteId) : siteId;
+  const confirmed = confirm(`确定要删除站点「${name}」吗？删除后导航与权限配置将移除该站点。`);
+  if (!confirmed) return;
+
+  setMessage('正在删除站点...', 'info');
+  try {
+    const res = await fetch('/api/site-configs/delete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ siteId })
+    });
+    const payload = await res.json();
+    if (!res.ok) throw new Error(payload.error || '删除失败');
+    setMessage('站点已删除。', 'success');
+    await loadSiteConfigs();
+  } catch (error) {
+    console.error('删除站点失败', error);
+    setMessage(`删除站点失败：${error.message}`, 'error');
+  }
+}
+
+function refreshRoleAssignments() {
+  roleAssignments = computeRoleAssignmentsFromMatrix(DEFAULT_MATRIX);
+  renderRoleManagement();
+  renderUserList();
+}
+
+function renderRoleManagement() {
+  const container = document.getElementById('roleList');
+  if (!container) return;
+  container.innerHTML = '';
+
+  Object.entries(ROLE_LABELS).forEach(([role, label]) => {
+    const modules = new Set(roleAssignments[role] || []);
+    const card = document.createElement('div');
+    card.className = 'role-card';
+    const checkboxHtml = Object.entries(MODULE_LABELS).map(([moduleKey, moduleLabel]) => {
+      const checked = modules.has(moduleKey) ? 'checked' : '';
+      return `<label class="role-checkbox"><input type="checkbox" data-role="${role}" data-module="${moduleKey}" ${checked}><span>${moduleLabel}</span></label>`;
+    }).join('');
+    card.innerHTML = `
+      <div>
+        <h3>${label}</h3>
+        <div class="role-meta">${ROLE_DESCRIPTIONS[role] || ''}</div>
+      </div>
+      <div class="role-modules">
+        ${checkboxHtml || '<span class="chip chip-muted">暂无可配置模块</span>'}
+      </div>
+    `;
+    container.appendChild(card);
+  });
+
+  container.querySelectorAll('input[type="checkbox"]').forEach(input => {
+    input.addEventListener('change', () => {
+      const role = input.dataset.role;
+      const moduleKey = input.dataset.module;
+      const modules = new Set(roleAssignments[role] || []);
+      if (input.checked) {
+        modules.add(moduleKey);
+      } else {
+        modules.delete(moduleKey);
+      }
+      roleAssignments[role] = Array.from(modules);
+      renderUserList();
+    });
+  });
+}
+
+function populateRoleOptions() {
+  const roleSelect = document.getElementById('userRoleSelect');
+  if (!roleSelect) return;
+  const current = roleSelect.value;
+  roleSelect.innerHTML = '<option value="">选择角色</option>';
+  Object.entries(ROLE_LABELS).forEach(([value, label]) => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = label;
+    if (value === current) {
+      option.selected = true;
+    }
+    roleSelect.appendChild(option);
+  });
+}
+
+function saveRoleAssignments() {
+  const updatedMatrix = {};
+  Object.keys(MODULE_LABELS).forEach(moduleKey => {
+    updatedMatrix[moduleKey] = Object.keys(roleAssignments).filter(role => {
+      return (roleAssignments[role] || []).includes(moduleKey);
+    });
+  });
+  Object.keys(DEFAULT_MATRIX).forEach(key => delete DEFAULT_MATRIX[key]);
+  Object.assign(DEFAULT_MATRIX, updatedMatrix);
+  const siteId = document.getElementById('permissionSiteSelect').value;
+  if (!siteId) {
+    activeMatrix = cloneMatrix(DEFAULT_MATRIX);
+    renderPermissionMatrix();
+  }
+  refreshRoleAssignments();
+  setMessage('角色权限已保存并同步至全局默认。', 'success');
+}
+
+function resetRoleAssignments() {
+  roleAssignments = computeRoleAssignmentsFromMatrix(DEFAULT_MATRIX);
+  renderRoleManagement();
+  renderUserList();
+  setMessage('已恢复当前默认的角色配置。', 'success');
+}
+
+function getRoleModuleLabels(role) {
+  return (roleAssignments[role] || []).map(moduleKey => MODULE_LABELS[moduleKey] || moduleKey);
+}
+
+function getSiteDisplayName(siteId) {
+  const site = siteConfigs.find(item => item.id === siteId);
+  return site ? (site.display_name || site.name || siteId) : siteId;
+}
+
+function loadUserAccounts() {
+  try {
+    const cached = localStorage.getItem('adminUserAccounts');
+    userAccounts = cached ? JSON.parse(cached) : [];
+  } catch (error) {
+    console.warn('加载用户配置失败', error);
+    userAccounts = [];
+  }
+}
+
+function saveUserAccounts() {
+  try {
+    localStorage.setItem('adminUserAccounts', JSON.stringify(userAccounts));
+  } catch (error) {
+    console.warn('保存用户配置失败', error);
+  }
+}
+
+function renderUserList() {
+  const container = document.getElementById('userList');
+  if (!container) return;
+
+  if (!userAccounts.length) {
+    container.innerHTML = '<div class="message info">暂无用户，请添加成员后分配角色。</div>';
+    return;
+  }
+
+  container.innerHTML = '';
+  userAccounts.forEach(user => {
+    const card = document.createElement('div');
+    card.className = 'user-card';
+    const moduleLabels = getRoleModuleLabels(user.role);
+    const moduleHtml = moduleLabels.length
+      ? moduleLabels.map(label => `<span class="chip">${label}</span>`).join('')
+      : '<span class="chip chip-muted">未分配模块</span>';
+    const siteHtml = user.sites && user.sites.length
+      ? user.sites.map(getSiteDisplayName).map(name => `<span class="chip chip-muted">${name}</span>`).join('')
+      : '<span class="chip chip-muted">全部站点</span>';
+
+    card.innerHTML = `
+      <div>
+        <h3>${user.name}</h3>
+        <div class="section-subtitle">${user.email}</div>
+      </div>
+      <div class="user-meta">
+        <div><strong>角色：</strong>${ROLE_LABELS[user.role] || user.role}</div>
+        <div><strong>可访问模块：</strong>${moduleHtml}</div>
+        <div><strong>授权站点：</strong>${siteHtml}</div>
+      </div>
+      <div class="site-actions">
+        <button class="btn" data-action="edit-user" data-user-id="${user.id}">编辑</button>
+        <button class="btn btn-danger" data-action="remove-user" data-user-id="${user.id}">删除</button>
+      </div>
+    `;
+    container.appendChild(card);
+  });
+
+  container.querySelectorAll('button[data-action="edit-user"]').forEach(btn => {
+    btn.addEventListener('click', () => editUser(btn.dataset.userId));
+  });
+
+  container.querySelectorAll('button[data-action="remove-user"]').forEach(btn => {
+    btn.addEventListener('click', () => removeUser(btn.dataset.userId));
+  });
+}
+
+function handleUserFormSubmit(event) {
+  event.preventDefault();
+  const name = document.getElementById('userNameInput').value.trim();
+  const email = document.getElementById('userEmailInput').value.trim();
+  const role = document.getElementById('userRoleSelect').value;
+  const siteSelect = document.getElementById('userSiteMulti');
+  const sites = siteSelect ? Array.from(siteSelect.selectedOptions).map(opt => opt.value) : [];
+
+  if (!name || !email || !role) {
+    setMessage('请填写完整的用户姓名、邮箱并选择角色。', 'error');
+    return;
+  }
+
+  const payload = {
+    id: editingUserId || `user_${Date.now()}`,
+    name,
+    email,
+    role,
+    sites
+  };
+
+  if (editingUserId) {
+    const index = userAccounts.findIndex(user => user.id === editingUserId);
+    if (index >= 0) {
+      userAccounts[index] = payload;
+      setMessage(`已更新用户 ${name}。`, 'success');
+    }
+  } else {
+    userAccounts.push(payload);
+    setMessage(`已添加用户 ${name}。`, 'success');
+  }
+
+  saveUserAccounts();
+  resetUserForm();
+  renderUserList();
+}
+
+function resetUserForm() {
+  editingUserId = null;
+  editingUserSites = [];
+  const form = document.getElementById('userForm');
+  if (form) {
+    form.reset();
+  }
+  populateRoleOptions();
+  const siteSelect = document.getElementById('userSiteMulti');
+  if (siteSelect) {
+    Array.from(siteSelect.options).forEach(option => {
+      option.selected = false;
+    });
+  }
+}
+
+function editUser(userId) {
+  const target = userAccounts.find(user => user.id === userId);
+  if (!target) return;
+  editingUserId = target.id;
+  editingUserSites = Array.isArray(target.sites) ? [...target.sites] : [];
+  document.getElementById('userNameInput').value = target.name || '';
+  document.getElementById('userEmailInput').value = target.email || '';
+  populateRoleOptions();
+  document.getElementById('userRoleSelect').value = target.role || '';
+  const siteSelect = document.getElementById('userSiteMulti');
+  if (siteSelect) {
+    Array.from(siteSelect.options).forEach(option => {
+      option.selected = editingUserSites.includes(option.value);
+    });
+  }
+  setMessage(`正在编辑用户 ${target.name}`, 'info');
+  switchSection('userConsole');
+}
+
+function removeUser(userId) {
+  const target = userAccounts.find(user => user.id === userId);
+  if (!target) return;
+  const confirmed = confirm(`确定要删除用户「${target.name}」吗？`);
+  if (!confirmed) return;
+  userAccounts = userAccounts.filter(user => user.id !== userId);
+  saveUserAccounts();
+  renderUserList();
+  if (editingUserId === userId) {
+    resetUserForm();
+  }
+  setMessage(`已删除用户 ${target.name}。`, 'success');
 }
 
 function renderPermissionMatrix() {
@@ -936,6 +1410,7 @@ function savePermissionMatrix() {
     Object.keys(matrixOverrides).forEach(key => delete matrixOverrides[key]);
     Object.assign(DEFAULT_MATRIX, cloneMatrix(activeMatrix));
     setMessage('已更新全局默认权限矩阵。', 'success');
+    refreshRoleAssignments();
   }
 }
 
@@ -1023,9 +1498,31 @@ function initializeAdmin() {
     runSync(siteId, action);
   });
 
+  const saveRoleBtn = document.getElementById('saveRoleBtn');
+  const resetRoleBtn = document.getElementById('resetRoleBtn');
+  if (saveRoleBtn) {
+    saveRoleBtn.addEventListener('click', saveRoleAssignments);
+  }
+  if (resetRoleBtn) {
+    resetRoleBtn.addEventListener('click', resetRoleAssignments);
+  }
+
+  const userForm = document.getElementById('userForm');
+  if (userForm) {
+    userForm.addEventListener('submit', handleUserFormSubmit);
+  }
+  const resetUserBtn = document.getElementById('resetUserForm');
+  if (resetUserBtn) {
+    resetUserBtn.addEventListener('click', resetUserForm);
+  }
+
   populatePlatformOptions();
   populateQuickTemplates();
   updateDataSourceOptions();
+  populateRoleOptions();
+  renderRoleManagement();
+  loadUserAccounts();
+  renderUserList();
   renderPermissionMatrix();
   loadSiteConfigs();
   switchSection('siteConsole');

--- a/public/assets/self-operated.js
+++ b/public/assets/self-operated.js
@@ -458,6 +458,12 @@
         .product-id-cell {
           text-align: left !important;
         }
+        #report th.period-column,
+        #report td.period-column,
+        #report_wrapper th.period-column,
+        #report_wrapper td.period-column {
+          display: none !important;
+        }
       `;
       document.head.appendChild(style);
       console.log('商品链接样式已添加');
@@ -491,7 +497,7 @@
       thead.innerHTML = `
         <tr>
           <th style="text-align: left; min-width: 120px;">商品(ID)</th>
-          <th style="text-align: center; min-width: 150px;">周期</th>
+          <th class="period-column" style="text-align: center; min-width: 150px;">周期</th>
           <th style="text-align: center; min-width: 100px;">访客比(%)</th>
           <th style="text-align: center; min-width: 100px;">加购比(%)</th>
           <th style="text-align: center; min-width: 100px;">支付比(%)</th>
@@ -559,7 +565,7 @@
 
           tr.innerHTML = `
             <td style="text-align: left;">${productLink}</td>
-            <td style="text-align: center;">${row.bucket || this.formatDateRange(row.start_date, row.end_date)}</td>
+            <td class="period-column" style="text-align: center;">${row.bucket || this.formatDateRange(row.start_date, row.end_date)}</td>
             <td style="text-align: center;">${this.formatPercentage(visitorRatio)}</td>
             <td style="text-align: center;">${this.formatPercentage(addToCartRatio)}</td>
             <td style="text-align: center;">${this.formatPercentage(paymentRatio)}</td>
@@ -621,11 +627,14 @@
               this.dataTable = jQuery(table).DataTable({
                 destroy: true,
                 pageLength: 10,
-                order: [[1, 'desc']], 
-                scrollX: true, 
-                scrollY: 'calc(100vh - 420px)', 
-                scrollCollapse: true, 
+                order: [[1, 'desc']],
+                scrollX: true,
+                scrollY: 'calc(100vh - 420px)',
+                scrollCollapse: true,
                 fixedHeader: true,
+                columnDefs: [
+                  { targets: 1, visible: false, searchable: false }
+                ],
                 language: {
                   url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/zh.json'
                 }

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -136,7 +136,54 @@
     .legend-list a:hover {
       text-decoration: underline;
     }
-    
+
+    /* 数据明细展示区域 */
+    .section-heading {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 4px 12px;
+    }
+
+    .section-heading h3 {
+      margin: 0;
+      font-size: 1.125rem;
+      font-weight: 600;
+      color: #1f2937;
+    }
+
+    #detail .table-section {
+      padding: 0;
+    }
+
+    #detailLoading {
+      margin: 0 0 12px;
+    }
+
+    #detailContent {
+      overflow-x: auto;
+    }
+
+    #detailContent .dataTables_wrapper {
+      width: 100%;
+    }
+
+    #detailContent table.dataTable,
+    #detailContent table.dataTable th,
+    #detailContent table.dataTable td {
+      font-size: 12px;
+    }
+
+    #detailContent table.dataTable th,
+    #detailContent table.dataTable td {
+      padding: 6px 10px;
+      white-space: nowrap;
+    }
+
+    #detailContent table.dataTable td {
+      line-height: 1.5;
+    }
+
     /* KPI对比数据样式 */
     .kpi-comparison {
       margin-top: 0.5rem;
@@ -533,7 +580,7 @@
     </ul>
   </nav>
 
-  <main class="main mx-auto max-w-container px-6">
+  <main class="main">
     <!-- 页面标题 -->
     <div class="page-header" style="margin-bottom: 20px; text-align: center;">
       <h1 style="font-size: 28px; font-weight: 600; color: #1f2937; margin: 0;">自运营Robot站 - 智能数据分析与决策支持</h1>
@@ -608,18 +655,20 @@
     <div class="content">
       <!-- 明细表 -->
       <section id="detail" class="content-pad">
-        <div class="chart-container">
+        <div class="section-heading">
           <h3>数据明细</h3>
-          
+        </div>
+
+        <div class="table-section">
           <!-- 加载状态 -->
           <div id="detailLoading" class="loading-state" style="display: none;">
             <div class="loading-spinner"></div>
             <p class="loading-text">努力加载中,请等待片刻。。。</p>
           </div>
-          
+
           <!-- 数据表格 -->
-          <div id="detailContent">
-            <table id="report" class="data-table display nowrap" style="width:100%"></table>
+          <div id="detailContent" class="table-wrapper">
+            <table id="report" class="display nowrap" style="width:100%"></table>
           </div>
         </div>
       </section>

--- a/public/site-management.html
+++ b/public/site-management.html
@@ -506,8 +506,35 @@
     alert('如需编辑站点配置，请前往 admin.html 管理后台。');
   };
 
-  window.deleteSite = function() {
-    alert('站点删除操作受限，请在数据库或管理后台审核后执行。');
+  window.deleteSite = async function(siteId) {
+    if (!siteId) {
+      alert('未找到站点ID，无法删除。');
+      return;
+    }
+
+    const confirmed = confirm('确定要删除该站点吗？此操作将移除站点配置并从导航中隐藏。');
+    if (!confirmed) return;
+
+    try {
+      const response = await fetch('/api/site-configs/delete', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ siteId })
+      });
+
+      const result = await response.json();
+      if (!response.ok) {
+        throw new Error(result.error || '删除失败');
+      }
+
+      alert('站点已删除。');
+      await loadSites();
+    } catch (error) {
+      console.error('删除站点失败:', error);
+      alert('删除站点失败：' + error.message);
+    }
   };
 
   updateDataSourceOptions();


### PR DESCRIPTION
## Summary
- allow deleting duplicate or obsolete sites directly from the site-management page and the admin console via the existing /api/site-configs/delete endpoint
- add a role management panel that lets operators review and tweak per-role module access while keeping the permission matrix in sync
- introduce a user management workflow that stores members with assigned roles and site scopes in local storage and exposes edit/delete actions for quick adjustments
- restyle the AliExpress self-operated data detail table with a full-width wrapper, tighter typography, and the same table container treatment used on the managed site page

## Testing
- `npm test` *(fails: tests/lazada-oauth.test.js defines mocha-style beforeEach which is undefined under node --test)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb2f172ac8325abb2bf55e0668035