### PR TITLE
Revamp admin role and user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,20 +64,20 @@
 | `shopee.html` | Shopee 站点壳层，为东南亚多店铺提供统一模块框架 | 同样复用 `platform-page.js`，根据导航选择同步显示当前站点信息 | —（规划中，待 Shopee API 接入）【F:public/shopee.html†L1-L88】【F:public/assets/platform-page.js†L1-L54】 |
 | `inventory.html` | 全局库存管理入口 | 卡片式布局概述库存总览、库存变动与采购管理，将连接 `inventory*` 系列表 | —（规划中）【F:public/inventory.html†L1-L60】 |
 | `permissions.html` | 全局权限管理入口 | 汇总角色矩阵、站点授权与审计日志的计划功能，待与 admin 权限矩阵联动 | —（规划中）【F:public/permissions.html†L1-L58】 |
-| `admin.html` | 管理后台，将站点配置、模块同步与权限矩阵集中在一个入口 | 左侧“站点管理/权限矩阵/同步工具”三段式布局，站点新增后自动触发 `/api/site-sync` | `/api/site-configs`、`/api/site-sync`【F:public/admin.html†L1-L320】 |
-| `site-management.html` | 轻量站点登记视图，支持快速创建 Lazada/Shopee 等站点并引导进入管理后台 | 卡片式站点网格 + 表单，提交后会调用 `/api/site-sync` 刷新模块 | `/api/site-configs`、`/api/site-sync`【F:public/site-management.html†L1-L420】 |
+| `admin.html` | 管理后台，将站点配置、角色与成员集中在一个入口 | 左侧“站点管理/角色管理/用户管理”布局，内置快捷模板、站点删除与角色/用户卡片管理 | `/api/site-configs`、`/api/site-configs/delete`【F:public/admin.html†L360-L543】【F:public/admin.html†L932-L1390】 |
+| `site-management.html` | 轻量站点登记视图，支持快速创建 Lazada/Shopee 等站点并引导进入管理后台 | 卡片式站点网格 + 表单，提交后触发 `/api/site-sync` 并支持一键删除重复站点 | `/api/site-configs`、`/api/site-configs/delete`、`/api/site-sync`【F:public/site-management.html†L397-L541】 |
 
 - **入口页 `public/index.html`**：作为平台门户，内置渐变过渡和加载动画，并在 1 秒内自动重定向到自运营 Robot 站，确保默认落地页一致。【F:public/index.html†L1-L58】
-- **自运营页 `public/self-operated.html`**：聚合 DataTables、ECharts、Flatpickr 等库，侧边栏固定包含“详细数据/运营分析/产品分析/订单中心/广告中心”五大模块；订单与广告板块暂提供占位说明，默认站点包含 Robot 与 Poolslab，可在导航中快速切换。【F:public/self-operated.html†L520-L788】【F:public/assets/site-nav.js†L12-L191】
+- **自运营页 `public/self-operated.html`**：聚合 DataTables、ECharts、Flatpickr 等库，侧边栏固定包含“详细数据/运营分析/产品分析/订单中心/广告中心”五大模块；数据明细表默认隐藏“周期”列并复用固定表头/滚动配置压缩宽度，默认站点包含 Robot 与 Poolslab，可在导航中快速切换。【F:public/self-operated.html†L520-L788】【F:public/assets/self-operated.js†L461-L639】【F:public/assets/site-nav.js†L13-L159】
 - **全托管页 `public/managed.html`**：带登录覆盖层与统一侧边栏，顶部导航涵盖速卖通、亚马逊、TikTok Shop、Temu、Ozon、独立站等平台；页面内按 Hash 切分“详细数据/运营分析/产品分析/订单中心/广告中心”，并支持上传全托管周/月报表。【F:public/managed.html†L20-L260】
-- **管理后台 `public/admin.html`**：集中提供站点配置、权限矩阵与站点同步工具，表单内置 Lazada/Shopee/TikTok/Temu 模板并会自动触发 `/api/site-sync`，权限矩阵部分复用 `rules.json` 默认角色。【F:public/admin.html†L1-L420】
-- **站点管理页 `public/site-management.html`**：轻量化的站点登记入口，表单直接写入 `site_configs` 并调用 `/api/site-sync`，在成功创建后引导管理员前往 `admin.html` 做进一步配置。【F:public/site-management.html†L1-L420】
+- **管理后台 `public/admin.html`**：站点管理支持快捷模板、筛选与删除，角色管理基于模块定义生成角色卡片并允许自定义保存，用户管理要求同时选择角色与站点并以标签展示授权范围，整体配置保存在浏览器以便快速迭代。【F:public/admin.html†L360-L543】【F:public/admin.html†L932-L1390】
+- **站点管理页 `public/site-management.html`**：轻量化的站点登记入口，表单直接写入 `site_configs` 并调用 `/api/site-sync`，新增支持在网格中直接删除重复或无效站点并在成功创建后提示同步到管理后台。【F:public/site-management.html†L397-L541】
 - **独立站页 `public/independent-site.html`**：面向 Landing Page 运营分析，侧边栏同步扩展至五大模块，包含渠道选择、时间控件、KPI 卡片与数据明细，并保留列显隐、产品双击跳转等增强交互。【F:public/independent-site.html†L697-L852】
 - **亚马逊总览 `public/amazon-overview.html`**：按 Amazon 指标构建 KPI、趋势图和明细表的总览页，侧边栏新增五大模块并通过 Hash 切换，`amazon-ads.html` 负责重定向到新的广告分栏。【F:public/amazon-overview.html†L104-L215】【F:public/amazon-ads.html†L1-L35】
 - **Ozon 页面集**：`public/ozon-detail.html` 等页面提供上传入口、日期筛选及多图表分栏，并补充订单中心、广告中心入口；`ozon-orders.html` 在同步订单头与明细的基础上，将商品明细列移动至首列并限制宽度为 140px，单独展示“采购件数”，且商品明细/下单时间/状态/结算状态四列可点击切换正序或倒序，保持与运营数据的产品 ID 对齐，并统一移除商品图片仅保留文本信息，广告模块仍预留官方 API 接入。【F:public/ozon-detail.html†L40-L78】【F:public/ozon-orders.html†L1-L210】【F:api/ozon/orders/index.js†L1-L117】
 - **Temu/TikTok 占位页**：`public/temu.html` 与 `public/tiktok.html` 已接入统一导航与布局，并预留“详细数据/运营分析/产品分析/订单中心/广告中心”五个分栏占位，等待后端接口补齐。【F:public/temu.html†L1-L36】【F:public/tiktok.html†L1-L36】
 - **Lazada 数据枢纽 / Shopee 占位**：`public/lazada.html` 已接入 Lazada 运营、产品、订单、广告 API，并在站点切换时自动刷新五大模块；最新的授权回调会在后端使用 `findKeyDeep` 兜底提取嵌套的访问/刷新令牌并返还脱敏调试信息，保证页面切换后始终可拉取实时数据。`public/shopee.html` 则继续保留统一布局与导航，占位等待后续 API 补齐。【F:public/lazada.html†L1-L284】【F:api/lazada/oauth/callback/index.js†L1-L226】【F:lib/find-key-deep.js†L1-L89】【F:api/lazada/stats/index.js†L1-L72】【F:public/shopee.html†L1-L88】
-- **动态导航脚本 `public/assets/site-nav.js`**：初始化时调用 `/api/site-configs` 合并默认站点，自动插入 Lazada、Shopee 等平台入口，并在点击站点后写入 `localStorage` 供壳层页面显示当前站点名称。【F:public/assets/site-nav.js†L24-L309】【F:public/assets/site-nav.js†L563-L589】
+- **动态导航脚本 `public/assets/site-nav.js`**：初始化时调用 `/api/site-configs` 合并默认站点，基于平台 + 站点 ID 去重后再渲染 Lazada、Shopee 等入口，并仅拦截带 `data-platform` 属性的切换链接以保证“管理后台”等普通导航可直接跳转。【F:public/assets/site-nav.js†L13-L159】【F:public/assets/site-nav.js†L373-L457】【F:public/assets/site-nav.js†L666-L691】
 - **库存管理 `public/inventory.html`**：全局入口以卡片形式描述库存总览、库存变动与采购管理模块，后续上线后将直接接入 `inventory`、`inventory_movements`、`purchases` 数据表。【F:public/inventory.html†L1-L60】
 - **权限管理 `public/permissions.html`**：全局入口汇总角色矩阵、站点授权和审计日志三大能力，未来会与 admin 权限矩阵共享数据源以维持一致性。【F:public/permissions.html†L1-L58】
 

--- a/public/admin.html
+++ b/public/admin.html
@@ -145,6 +145,15 @@
       border-color: #111827;
       color: #f9fafb;
     }
+    .btn-danger {
+      background: #ef4444;
+      border-color: #ef4444;
+      color: #fff;
+    }
+    .btn-danger:hover {
+      background: #dc2626;
+      border-color: #dc2626;
+    }
     .btn-success {
       background: #059669;
       border-color: #059669;
@@ -159,6 +168,82 @@
       flex-wrap: wrap;
       gap: 10px;
       margin-bottom: 16px;
+    }
+    .role-grid,
+    .user-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: 16px;
+    }
+    .role-card,
+    .user-card {
+      border: 1px solid #e5e7eb;
+      border-radius: 12px;
+      padding: 20px;
+      background: #fff;
+      box-shadow: 0 1px 2px rgba(15,23,42,0.08);
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .role-card h3,
+    .user-card h3 {
+      margin: 0;
+      font-size: 18px;
+      color: #1f2937;
+    }
+    .role-meta,
+    .user-meta {
+      color: #6b7280;
+      font-size: 13px;
+      line-height: 1.6;
+    }
+    .user-meta {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 8px;
+    }
+    .role-modules {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px 12px;
+    }
+    .role-checkbox {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      color: #374151;
+      background: #f9fafb;
+      border-radius: 9999px;
+      padding: 6px 12px;
+      border: 1px solid #e5e7eb;
+    }
+    .role-checkbox input {
+      margin: 0;
+    }
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      padding: 4px 10px;
+      border-radius: 9999px;
+      background: #eff6ff;
+      color: #1d4ed8;
+      font-size: 12px;
+      margin: 2px 4px 2px 0;
+      white-space: nowrap;
+    }
+    .chip-muted {
+      background: #f3f4f6;
+      color: #6b7280;
+    }
+    select[multiple] {
+      min-height: 120px;
+    }
+    .multi-select-hint {
+      font-size: 12px;
+      color: #6b7280;
+      margin-top: -4px;
     }
     .site-card {
       border: 1px solid #e5e7eb;
@@ -207,45 +292,20 @@
       color: #b91c1c;
       border: 1px solid #fecaca;
     }
-    .permissions-table {
-      width: 100%;
-      border-collapse: collapse;
-    }
-    .permissions-table thead th {
-      text-align: left;
-      font-size: 13px;
-      letter-spacing: 0.02em;
-      color: #6b7280;
-      padding: 12px;
-      border-bottom: 1px solid #e5e7eb;
-    }
-    .permissions-table tbody td {
-      padding: 12px;
-      border-bottom: 1px solid #f3f4f6;
-      font-size: 14px;
-    }
-    .permissions-table tbody tr:nth-child(odd) {
-      background: #f9fafb;
-    }
-    .permissions-table .module-label {
-      font-weight: 600;
-      color: #1f2937;
-    }
-    .matrix-controls {
+    .role-card-header {
       display: flex;
-      flex-wrap: wrap;
+      align-items: flex-start;
+      justify-content: space-between;
       gap: 12px;
-      margin-bottom: 16px;
-      align-items: center;
     }
-    .badge {
-      display: inline-block;
-      padding: 2px 8px;
-      border-radius: 9999px;
+    .role-card-actions {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .role-card-actions .btn {
+      padding: 6px 12px;
       font-size: 12px;
-      background: #e0f2fe;
-      color: #0369a1;
-      margin-left: 6px;
     }
     @media (max-width: 960px) {
       .admin-layout {
@@ -317,8 +377,8 @@
     <div class="site-header">管理后台</div>
     <ul class="sub-nav" id="adminNav">
       <li><a href="#" class="active" data-target="siteConsole">站点管理</a></li>
-      <li><a href="#" data-target="permissionConsole">权限矩阵</a></li>
-      <li><a href="#" data-target="syncConsole">同步工具</a></li>
+      <li><a href="#" data-target="roleConsole">角色管理</a></li>
+      <li><a href="#" data-target="userConsole">用户管理</a></li>
     </ul>
   </nav>
 
@@ -396,70 +456,90 @@
       </div>
     </section>
 
-    <section id="permissionConsole" class="admin-section">
+    <section id="roleConsole" class="admin-section">
       <div class="section-header">
         <div>
-          <h1>权限矩阵</h1>
-          <div class="section-subtitle">基于 `rules.json` 默认策略管理模块可见性，可按站点覆写。</div>
+          <h1>角色管理</h1>
+          <div class="section-subtitle">根据功能模块组合定义角色，新增角色可在用户管理中直接分配。</div>
         </div>
-        <div class="matrix-controls">
-          <select id="permissionSiteSelect" class="btn">
-            <option value="">全局默认</option>
-          </select>
-          <button class="btn" id="resetPermissionBtn">恢复默认</button>
+        <div style="display:flex;gap:10px;flex-wrap:wrap;">
+          <button class="btn" id="resetRoleBtn">恢复默认角色</button>
+          <button class="btn btn-primary" id="saveRoleBtn">保存角色配置</button>
         </div>
       </div>
 
       <div class="admin-card">
-        <table class="permissions-table">
-          <thead>
-            <tr>
-              <th style="width:180px">模块</th>
-              <th>描述</th>
-              <th>角色访问</th>
-            </tr>
-          </thead>
-          <tbody id="permissionMatrix"></tbody>
-        </table>
-        <div class="form-actions">
-          <button class="btn btn-primary" id="savePermissionBtn">保存配置</button>
-          <button class="btn" id="exportPermissionBtn">复制 JSON</button>
-        </div>
-        <p class="section-subtitle">保存操作会在浏览器内缓存配置，后端写入接口将在权限中心上线时接入。</p>
+        <h2 style="margin-top:0">已有角色</h2>
+        <div class="role-grid" id="roleList"></div>
+        <p class="section-subtitle">角色配置当前存储在浏览器中，后续可与权限中心打通后同步至数据库。</p>
+      </div>
+
+      <div class="admin-card">
+        <h2 style="margin-top:0">新增角色</h2>
+        <form id="roleForm">
+          <div class="form-grid">
+            <div class="form-group">
+              <label for="roleNameInput">角色名称 *</label>
+              <input id="roleNameInput" placeholder="如：数据分析师" required>
+            </div>
+            <div class="form-group">
+              <label for="roleDescInput">角色描述</label>
+              <input id="roleDescInput" placeholder="用于说明角色职责">
+            </div>
+          </div>
+          <div class="form-group">
+            <label>功能模块权限 *</label>
+            <div class="role-modules" id="newRoleModules"></div>
+            <div class="multi-select-hint">至少选择一个模块</div>
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="btn btn-primary">添加角色</button>
+            <button type="button" class="btn" id="resetRoleForm">重置</button>
+          </div>
+        </form>
       </div>
     </section>
 
-    <section id="syncConsole" class="admin-section">
+    <section id="userConsole" class="admin-section">
       <div class="section-header">
         <div>
-          <h1>同步工具</h1>
-          <div class="section-subtitle">用于触发 `/api/site-sync` 与检查指标字段覆盖，保障新站点上线即连通。</div>
+          <h1>用户管理</h1>
+          <div class="section-subtitle">为成员分配角色与站点范围，不同角色将继承相应模块权限。</div>
         </div>
       </div>
+
       <div class="admin-card">
-        <h2 style="margin-top:0">站点同步</h2>
-        <div class="form-grid">
-          <div class="form-group">
-            <label for="syncSiteSelect">选择站点</label>
-            <select id="syncSiteSelect"></select>
+        <h2 style="margin-top:0">新增 / 编辑用户</h2>
+        <form id="userForm">
+          <div class="form-grid">
+            <div class="form-group">
+              <label for="userNameInput">姓名 *</label>
+              <input id="userNameInput" placeholder="如：王小明" required>
+            </div>
+            <div class="form-group">
+              <label for="userEmailInput">邮箱 *</label>
+              <input id="userEmailInput" type="email" placeholder="name@example.com" required>
+            </div>
+            <div class="form-group">
+              <label for="userRoleSelect">角色 *</label>
+              <select id="userRoleSelect" required></select>
+            </div>
+            <div class="form-group">
+              <label for="userSiteMulti">授权站点 *</label>
+              <select id="userSiteMulti" multiple></select>
+            </div>
           </div>
-          <div class="form-group">
-            <label for="syncActionSelect">同步动作</label>
-            <select id="syncActionSelect">
-              <option value="create">创建站点结构</option>
-              <option value="update">更新站点结构</option>
-            </select>
+          <p class="multi-select-hint">按住 Ctrl / Command 可多选站点，至少选择一个站点。</p>
+          <div class="form-actions">
+            <button type="submit" class="btn btn-primary">保存用户</button>
+            <button type="button" class="btn" id="resetUserForm">重置</button>
           </div>
-        </div>
-        <div class="form-actions">
-          <button class="btn btn-secondary" id="runSyncBtn">执行同步</button>
-        </div>
-        <p class="section-subtitle">同步操作将刷新 `site_module_configs`、`site_channel_configs` 等依赖站点 ID 的表，以便 Lazada/Shopee 等新站点立即生效。</p>
+        </form>
       </div>
+
       <div class="admin-card">
-        <h2 style="margin-top:0">字段覆盖校验</h2>
-        <p class="section-subtitle">即将上线：自动对比 `platform_metric_profiles` 与接口返回的 `availableFields`，提示缺失字段或可选字段。</p>
-        <button class="btn" disabled>开发中</button>
+        <h2 style="margin-top:0">已授权用户</h2>
+        <div id="userList" class="user-grid"></div>
       </div>
     </section>
   </main>
@@ -550,41 +630,83 @@ const DATA_SOURCE_LABELS = Object.values(PLATFORM_CATALOG).reduce((acc, platform
   return acc;
 }, { custom: '自定义/第三方' });
 
-const MODULE_LABELS = {
-  operations: '运营分析',
-  products: '产品分析',
-  orders: '订单中心',
-  advertising: '广告中心',
-  inventory: '库存管理 (全局)',
-  permissions: '权限管理 (全局)'
+const MODULE_DEFINITIONS = {
+  operations: {
+    label: '运营分析',
+    description: '曝光、访客、加购、支付等全链路指标。'
+  },
+  products: {
+    label: '产品分析',
+    description: '商品维度分析、属性与绩效对比。'
+  },
+  orders: {
+    label: '订单中心',
+    description: '订单列表、客户信息、物流成本与结算状态。'
+  },
+  advertising: {
+    label: '广告中心',
+    description: '广告预算、投放配置、归因与带来访客/订单。'
+  },
+  inventory: {
+    label: '库存管理 (全局)',
+    description: '全局库存中心（批次、调拨、预警）。'
+  },
+  permissions: {
+    label: '权限管理 (全局)',
+    description: '角色与资源管理，仅限超级管理员。'
+  }
 };
 
-const DEFAULT_MATRIX = {
-  operations: ['super_admin', 'operations_manager', 'viewer'],
-  products: ['super_admin', 'operations_manager', 'viewer'],
-  orders: ['super_admin', 'operations_manager', 'order_manager', 'finance', 'viewer'],
-  advertising: ['super_admin', 'operations_manager', 'ad_manager', 'viewer'],
-  inventory: ['super_admin', 'inventory_manager', 'operations_manager'],
-  permissions: ['super_admin']
-};
-
-const ROLE_LABELS = {
-  super_admin: '超级管理员',
-  operations_manager: '运营管理员',
-  order_manager: '订单管理员',
-  inventory_manager: '库存管理员',
-  ad_manager: '广告管理员',
-  finance: '财务',
-  viewer: '只读用户'
-};
+const DEFAULT_ROLES = [
+  {
+    id: 'super_admin',
+    name: '超级管理员',
+    description: '拥有全部功能权限，可配置站点、模块与成员。',
+    modules: Object.keys(MODULE_DEFINITIONS)
+  },
+  {
+    id: 'operations_manager',
+    name: '运营管理员',
+    description: '聚焦核心运营指标与商品表现，查看报表与看板。',
+    modules: ['operations', 'products', 'orders', 'advertising', 'inventory']
+  },
+  {
+    id: 'order_manager',
+    name: '订单管理员',
+    description: '管理订单、售后与物流信息，确保履约准确。',
+    modules: ['orders']
+  },
+  {
+    id: 'inventory_manager',
+    name: '库存管理员',
+    description: '维护库存、调拨与预警配置，掌握供应链状态。',
+    modules: ['inventory']
+  },
+  {
+    id: 'ad_manager',
+    name: '广告管理员',
+    description: '负责广告预算、投放配置与投放效果追踪。',
+    modules: ['advertising']
+  },
+  {
+    id: 'finance',
+    name: '财务',
+    description: '查看结算、回款与费用分摊等财务数据。',
+    modules: ['orders']
+  },
+  {
+    id: 'viewer',
+    name: '只读用户',
+    description: '只读访问主要看板，适用于业务查看。',
+    modules: ['operations', 'products', 'orders', 'advertising']
+  }
+];
 
 let siteConfigs = [];
-let matrixOverrides = {};
-let activeMatrix = cloneMatrix(DEFAULT_MATRIX);
-
-function cloneMatrix(matrix) {
-  return JSON.parse(JSON.stringify(matrix));
-}
+let roleRegistry = {};
+let userAccounts = [];
+let editingUserId = null;
+let editingUserSites = [];
 
 function setMessage(text, type = 'info') {
   const bar = document.getElementById('adminMessage');
@@ -604,6 +726,127 @@ function switchSection(targetId) {
   });
   document.querySelectorAll('#adminNav a').forEach(link => {
     link.classList.toggle('active', link.dataset.target === targetId);
+  });
+}
+
+function buildDefaultRoleRegistry() {
+  const registry = {};
+  DEFAULT_ROLES.forEach(role => {
+    registry[role.id] = {
+      id: role.id,
+      name: role.name,
+      description: role.description || '',
+      modules: sanitizeModules(role.modules),
+      isDefault: true
+    };
+  });
+  return registry;
+}
+
+function sanitizeModules(modules = []) {
+  return Array.from(new Set((modules || []).filter(key => MODULE_DEFINITIONS[key])));
+}
+
+function loadRoleRegistry() {
+  const registry = buildDefaultRoleRegistry();
+  try {
+    const cached = localStorage.getItem('adminRoleRegistry');
+    if (!cached) {
+      return registry;
+    }
+    const parsed = JSON.parse(cached);
+    const roles = parsed?.roles;
+    if (roles && typeof roles === 'object') {
+      Object.entries(roles).forEach(([id, role]) => {
+        if (!role || typeof role !== 'object') return;
+        const base = registry[id];
+        const modules = sanitizeModules(role.modules);
+        registry[id] = {
+          id,
+          name: role.name || base?.name || id,
+          description: role.description || base?.description || '',
+          modules: modules.length ? modules : sanitizeModules(base?.modules || []),
+          isDefault: Boolean(base?.isDefault)
+        };
+        if (!base) {
+          registry[id].isDefault = false;
+        }
+      });
+    }
+  } catch (error) {
+    console.warn('加载角色配置失败', error);
+  }
+  return registry;
+}
+
+function persistRoleRegistry(showMessage = false) {
+  try {
+    const payload = {};
+    Object.values(roleRegistry).forEach(role => {
+      payload[role.id] = {
+        id: role.id,
+        name: role.name,
+        description: role.description || '',
+        modules: sanitizeModules(role.modules),
+        isDefault: Boolean(role.isDefault)
+      };
+    });
+    localStorage.setItem('adminRoleRegistry', JSON.stringify({ roles: payload }));
+    if (showMessage) {
+      setMessage('角色配置已保存。', 'success');
+    }
+  } catch (error) {
+    console.warn('保存角色配置失败', error);
+    if (showMessage) {
+      setMessage('保存角色配置失败，请检查浏览器存储权限。', 'error');
+    }
+  }
+}
+
+function resetRoleRegistry() {
+  roleRegistry = buildDefaultRoleRegistry();
+  persistRoleRegistry();
+  renderRoleManagement();
+  populateRoleOptions();
+  renderUserList();
+  setMessage('已恢复默认角色配置。', 'success');
+}
+
+function getSortedRoles() {
+  const order = new Map(DEFAULT_ROLES.map((role, index) => [role.id, index]));
+  return Object.values(roleRegistry).sort((a, b) => {
+    const orderA = order.has(a.id) ? order.get(a.id) : Number.MAX_SAFE_INTEGER;
+    const orderB = order.has(b.id) ? order.get(b.id) : Number.MAX_SAFE_INTEGER;
+    if (orderA !== orderB) return orderA - orderB;
+    return (a.name || a.id).localeCompare(b.name || b.id, 'zh-Hans-CN');
+  });
+}
+
+function generateRoleId(name) {
+  const base = name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '');
+  let candidate = base || `role_${Date.now()}`;
+  let suffix = 2;
+  while (roleRegistry[candidate]) {
+    candidate = `${base || 'role'}_${suffix++}`;
+  }
+  return candidate;
+}
+
+function renderNewRoleModules() {
+  const container = document.getElementById('newRoleModules');
+  if (!container) return;
+  container.innerHTML = Object.entries(MODULE_DEFINITIONS).map(([moduleKey, info]) => {
+    return `<label class="role-checkbox"><input type="checkbox" value="${moduleKey}"><span>${info.label}</span></label>`;
+  }).join('');
+}
+
+function resetNewRoleForm() {
+  const form = document.getElementById('roleForm');
+  if (form) {
+    form.reset();
+  }
+  document.querySelectorAll('#newRoleModules input[type="checkbox"]').forEach(input => {
+    input.checked = false;
   });
 }
 
@@ -678,6 +921,7 @@ async function loadSiteConfigs() {
     document.getElementById('siteCount').textContent = siteConfigs.length;
     renderSiteList();
     populateSiteSelectors();
+    renderUserList();
     setMessage(`已加载 ${siteConfigs.length} 个站点`, 'success');
   } catch (error) {
     console.error('加载站点失败', error);
@@ -716,7 +960,7 @@ function renderSiteList() {
       </div>
       <div class="site-actions">
         <button class="btn" data-action="prefill" data-site-id="${site.id}">填充到表单</button>
-        <button class="btn btn-secondary" data-action="sync" data-site-id="${site.id}">同步结构</button>
+        <button class="btn btn-danger" data-action="delete" data-site-id="${site.id}">删除站点</button>
       </div>
     `;
     list.appendChild(card);
@@ -743,8 +987,8 @@ function renderSiteList() {
     });
   });
 
-  list.querySelectorAll('button[data-action="sync"]').forEach(btn => {
-    btn.addEventListener('click', () => runSync(btn.dataset.siteId, 'update'));
+  list.querySelectorAll('button[data-action="delete"]').forEach(btn => {
+    btn.addEventListener('click', () => deleteSiteConfig(btn.dataset.siteId));
   });
 }
 
@@ -791,9 +1035,8 @@ async function submitSiteForm(event) {
     const payload = await res.json();
     if (!res.ok) throw new Error(payload.error || '保存失败');
 
-    setMessage('站点已保存，正在触发结构同步...', 'success');
+    setMessage('站点已保存。', 'success');
     await loadSiteConfigs();
-    await runSync(payload.data?.id, 'create');
     document.getElementById('siteForm').reset();
     updateDataSourceOptions();
   } catch (error) {
@@ -803,151 +1046,346 @@ async function submitSiteForm(event) {
 }
 
 function populateSiteSelectors() {
-  const siteSelects = [
-    document.getElementById('permissionSiteSelect'),
-    document.getElementById('syncSiteSelect')
-  ];
-  siteSelects.forEach(select => {
-    if (!select) return;
-    const preserveFirst = select === document.getElementById('permissionSiteSelect');
-    const defaultOption = preserveFirst ? select.querySelector('option[value=""]') : null;
-    select.innerHTML = '';
-    if (preserveFirst && defaultOption) {
-      select.appendChild(defaultOption);
-    } else {
-      const placeholder = document.createElement('option');
-      placeholder.value = '';
-      placeholder.textContent = '选择站点';
-      select.appendChild(placeholder);
+  const userSiteSelect = document.getElementById('userSiteMulti');
+  if (!userSiteSelect) return;
+  const preserved = editingUserId ? new Set(editingUserSites) : new Set(Array.from(userSiteSelect.selectedOptions || []).map(opt => opt.value));
+  userSiteSelect.innerHTML = '';
+  siteConfigs.forEach(site => {
+    const option = document.createElement('option');
+    option.value = site.id;
+    option.textContent = `${site.display_name || site.name} (${site.platform})`;
+    if (preserved.has(site.id)) {
+      option.selected = true;
     }
-
-    siteConfigs.forEach(site => {
-      const option = document.createElement('option');
-      option.value = site.id;
-      option.textContent = `${site.display_name || site.name} (${site.platform})`;
-      select.appendChild(option);
-    });
+    userSiteSelect.appendChild(option);
   });
 }
 
-async function runSync(siteId, action) {
-  if (!siteId) {
-    setMessage('请先选择站点后再执行同步。', 'error');
-    return;
-  }
-  setMessage('正在执行站点同步...', 'info');
+async function deleteSiteConfig(siteId) {
+  if (!siteId) return;
+  const target = siteConfigs.find(item => item.id === siteId);
+  const name = target ? (target.display_name || target.name || siteId) : siteId;
+  const confirmed = confirm(`确定要删除站点「${name}」吗？删除后导航与权限配置将移除该站点。`);
+  if (!confirmed) return;
+
+  setMessage('正在删除站点...', 'info');
   try {
-    const res = await fetch('/api/site-sync', {
+    const res = await fetch('/api/site-configs/delete', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ siteId, action })
+      body: JSON.stringify({ siteId })
     });
     const payload = await res.json();
-    if (!res.ok) throw new Error(payload.error || '同步失败');
-    setMessage('站点同步成功，模块与渠道配置已刷新。', 'success');
+    if (!res.ok) throw new Error(payload.error || '删除失败');
+    setMessage('站点已删除。', 'success');
+    await loadSiteConfigs();
   } catch (error) {
-    console.error('同步失败', error);
-    setMessage(`站点同步失败：${error.message}`, 'error');
+    console.error('删除站点失败', error);
+    setMessage(`删除站点失败：${error.message}`, 'error');
   }
 }
 
-function renderPermissionMatrix() {
-  const matrixBody = document.getElementById('permissionMatrix');
-  matrixBody.innerHTML = '';
-  Object.entries(MODULE_LABELS).forEach(([moduleKey, label]) => {
-    const row = document.createElement('tr');
-    const roleList = Object.keys(ROLE_LABELS).map(role => {
-      const checked = (activeMatrix[moduleKey] || []).includes(role);
-      return `<label style="margin-right:12px;display:inline-flex;align-items:center;gap:6px;">
-        <input type="checkbox" data-module="${moduleKey}" data-role="${role}" ${checked ? 'checked' : ''}>
-        <span>${ROLE_LABELS[role]}</span>
-      </label>`;
+function getSiteDisplayName(siteId) {
+  const site = siteConfigs.find(item => item.id === siteId);
+  return site ? (site.display_name || site.name || siteId) : siteId;
+}
+
+function renderRoleManagement() {
+  const container = document.getElementById('roleList');
+  if (!container) return;
+  container.innerHTML = '';
+  const roles = getSortedRoles();
+  if (!roles.length) {
+    container.innerHTML = '<div class="message info">暂无角色，请添加新的角色配置。</div>';
+    return;
+  }
+
+  roles.forEach(role => {
+    const modules = new Set(sanitizeModules(role.modules));
+    role.modules = Array.from(modules);
+    const card = document.createElement('div');
+    card.className = 'role-card';
+    const checkboxHtml = Object.entries(MODULE_DEFINITIONS).map(([moduleKey, info]) => {
+      const checked = modules.has(moduleKey) ? 'checked' : '';
+      return `<label class="role-checkbox"><input type="checkbox" data-role-id="${role.id}" data-module="${moduleKey}" ${checked}><span>${info.label}</span></label>`;
     }).join('');
-    row.innerHTML = `
-      <td class="module-label">${label}</td>
-      <td>${getModuleDescription(moduleKey)}</td>
-      <td>${roleList}</td>
+    const actionHtml = role.isDefault
+      ? ''
+      : `<div class="role-card-actions"><button class="btn btn-danger" data-action="remove-role" data-role-id="${role.id}">删除角色</button></div>`;
+    card.innerHTML = `
+      <div class="role-card-header">
+        <div>
+          <h3>${role.name}</h3>
+          <div class="role-meta">${role.description || '—'}</div>
+        </div>
+        ${actionHtml}
+      </div>
+      <div class="role-modules">
+        ${checkboxHtml || '<span class="chip chip-muted">暂无可配置模块</span>'}
+      </div>
     `;
-    matrixBody.appendChild(row);
+    container.appendChild(card);
   });
 
-  matrixBody.querySelectorAll('input[type="checkbox"]').forEach(input => {
+  container.querySelectorAll('input[type="checkbox"]').forEach(input => {
     input.addEventListener('change', () => {
+      const roleId = input.dataset.roleId;
       const moduleKey = input.dataset.module;
-      const role = input.dataset.role;
-      const target = activeMatrix[moduleKey] || [];
-      if (input.checked && !target.includes(role)) {
-        target.push(role);
-      } else if (!input.checked) {
-        activeMatrix[moduleKey] = target.filter(item => item !== role);
+      const role = roleRegistry[roleId];
+      if (!role) return;
+      const modules = new Set(role.modules || []);
+      if (input.checked) {
+        modules.add(moduleKey);
+      } else {
+        modules.delete(moduleKey);
+        if (!modules.size) {
+          input.checked = true;
+          setMessage('每个角色至少需要一个模块。', 'error');
+          return;
+        }
       }
+      role.modules = sanitizeModules(Array.from(modules));
+      persistRoleRegistry();
+      renderUserList();
     });
   });
-}
 
-function getModuleDescription(moduleKey) {
-  switch (moduleKey) {
-    case 'operations':
-      return '曝光、访客、加购、支付等全链路指标。';
-    case 'products':
-      return '商品维度分析、属性与绩效对比。';
-    case 'orders':
-      return '订单列表、客户信息、物流成本与结算状态。';
-    case 'advertising':
-      return '广告预算、投放配置、归因与带来访客/订单。';
-    case 'inventory':
-      return '全局库存中心（批次、调拨、预警）。';
-    case 'permissions':
-      return '角色与资源矩阵，仅限超级管理员。';
-    default:
-      return '';
-  }
-}
-
-function handlePermissionSiteChange() {
-  const siteId = document.getElementById('permissionSiteSelect').value;
-  if (siteId && matrixOverrides[siteId]) {
-    activeMatrix = cloneMatrix(matrixOverrides[siteId]);
-  } else {
-    activeMatrix = cloneMatrix(siteId ? DEFAULT_MATRIX : DEFAULT_MATRIX);
-    if (siteId && !matrixOverrides[siteId]) {
-      matrixOverrides[siteId] = cloneMatrix(DEFAULT_MATRIX);
-    }
-  }
-  renderPermissionMatrix();
-}
-
-function resetPermissionMatrix() {
-  const siteId = document.getElementById('permissionSiteSelect').value;
-  if (siteId) {
-    matrixOverrides[siteId] = cloneMatrix(DEFAULT_MATRIX);
-  }
-  activeMatrix = cloneMatrix(DEFAULT_MATRIX);
-  renderPermissionMatrix();
-  setMessage('已恢复默认权限矩阵。', 'success');
-}
-
-function savePermissionMatrix() {
-  const siteId = document.getElementById('permissionSiteSelect').value;
-  if (siteId) {
-    matrixOverrides[siteId] = cloneMatrix(activeMatrix);
-    setMessage(`已暂存 ${siteId} 的权限矩阵，后端接口上线后将写入数据库。`, 'success');
-  } else {
-    Object.keys(matrixOverrides).forEach(key => delete matrixOverrides[key]);
-    Object.assign(DEFAULT_MATRIX, cloneMatrix(activeMatrix));
-    setMessage('已更新全局默认权限矩阵。', 'success');
-  }
-}
-
-function exportPermissionMatrix() {
-  const siteId = document.getElementById('permissionSiteSelect').value;
-  const payload = siteId ? matrixOverrides[siteId] || activeMatrix : activeMatrix;
-  const json = JSON.stringify(payload, null, 2);
-  navigator.clipboard?.writeText(json).then(() => {
-    setMessage('权限矩阵 JSON 已复制到剪贴板。', 'success');
-  }).catch(() => {
-    setMessage('请手动复制：\n' + json, 'info');
+  container.querySelectorAll('button[data-action="remove-role"]').forEach(btn => {
+    btn.addEventListener('click', () => removeCustomRole(btn.dataset.roleId));
   });
+}
+
+function removeCustomRole(roleId) {
+  const role = roleRegistry[roleId];
+  if (!role || role.isDefault) return;
+  const confirmed = confirm(`确定要删除角色「${role.name}」吗？`);
+  if (!confirmed) return;
+
+  delete roleRegistry[roleId];
+  let affected = 0;
+  userAccounts = userAccounts.map(user => {
+    if (user.role === roleId) {
+      affected += 1;
+      return { ...user, role: '' };
+    }
+    return user;
+  });
+  saveUserAccounts();
+  persistRoleRegistry();
+  renderRoleManagement();
+  populateRoleOptions();
+  renderUserList();
+  setMessage(`已删除角色 ${role.name}${affected ? `，${affected} 位用户需要重新分配角色。` : '。'}`, 'success');
+}
+
+function populateRoleOptions() {
+  const roleSelect = document.getElementById('userRoleSelect');
+  if (!roleSelect) return;
+  const current = roleSelect.value;
+  roleSelect.innerHTML = '<option value="">选择角色</option>';
+  getSortedRoles().forEach(role => {
+    const option = document.createElement('option');
+    option.value = role.id;
+    option.textContent = role.name;
+    if (role.id === current) {
+      option.selected = true;
+    }
+    roleSelect.appendChild(option);
+  });
+}
+
+function getRoleDisplayName(roleId) {
+  return roleRegistry[roleId]?.name || roleId || '未分配';
+}
+
+function getRoleModuleLabels(roleId) {
+  const modules = roleRegistry[roleId]?.modules || [];
+  return modules.map(moduleKey => MODULE_DEFINITIONS[moduleKey]?.label || moduleKey);
+}
+
+function handleRoleFormSubmit(event) {
+  event.preventDefault();
+  const name = document.getElementById('roleNameInput').value.trim();
+  const description = document.getElementById('roleDescInput').value.trim();
+  const modules = Array.from(document.querySelectorAll('#newRoleModules input[type="checkbox"]:checked')).map(input => input.value);
+
+  if (!name) {
+    setMessage('请输入角色名称。', 'error');
+    return;
+  }
+  if (!modules.length) {
+    setMessage('请至少选择一个模块。', 'error');
+    return;
+  }
+
+  const id = generateRoleId(name);
+  roleRegistry[id] = {
+    id,
+    name,
+    description,
+    modules: sanitizeModules(modules),
+    isDefault: false
+  };
+  persistRoleRegistry();
+  populateRoleOptions();
+  renderRoleManagement();
+  renderUserList();
+  resetNewRoleForm();
+  setMessage(`已新增角色 ${name}。`, 'success');
+}
+
+function loadUserAccounts() {
+  try {
+    const cached = localStorage.getItem('adminUserAccounts');
+    userAccounts = cached ? JSON.parse(cached) : [];
+  } catch (error) {
+    console.warn('加载用户配置失败', error);
+    userAccounts = [];
+  }
+}
+
+function saveUserAccounts() {
+  try {
+    localStorage.setItem('adminUserAccounts', JSON.stringify(userAccounts));
+  } catch (error) {
+    console.warn('保存用户配置失败', error);
+  }
+}
+
+function renderUserList() {
+  const container = document.getElementById('userList');
+  if (!container) return;
+
+  if (!userAccounts.length) {
+    container.innerHTML = '<div class="message info">暂无用户，请添加成员后分配角色与站点。</div>';
+    return;
+  }
+
+  container.innerHTML = '';
+  userAccounts.forEach(user => {
+    const card = document.createElement('div');
+    card.className = 'user-card';
+    const roleDef = roleRegistry[user.role];
+    const roleHtml = roleDef ? roleDef.name : '<span class="chip chip-muted">待分配</span>';
+    const moduleLabels = roleDef ? getRoleModuleLabels(user.role) : [];
+    const moduleHtml = moduleLabels.length
+      ? moduleLabels.map(label => `<span class="chip">${label}</span>`).join('')
+      : '<span class="chip chip-muted">未分配模块</span>';
+    const siteHtml = Array.isArray(user.sites) && user.sites.length
+      ? user.sites.map(getSiteDisplayName).map(name => `<span class="chip chip-muted">${name}</span>`).join('')
+      : '<span class="chip chip-muted">未选择站点</span>';
+
+    card.innerHTML = `
+      <div>
+        <h3>${user.name}</h3>
+        <div class="section-subtitle">${user.email}</div>
+      </div>
+      <div class="user-meta">
+        <div><strong>角色：</strong>${roleHtml}</div>
+        <div><strong>可访问模块：</strong>${moduleHtml}</div>
+        <div><strong>授权站点：</strong>${siteHtml}</div>
+      </div>
+      <div class="site-actions">
+        <button class="btn" data-action="edit-user" data-user-id="${user.id}">编辑</button>
+        <button class="btn btn-danger" data-action="remove-user" data-user-id="${user.id}">删除</button>
+      </div>
+    `;
+    container.appendChild(card);
+  });
+
+  container.querySelectorAll('button[data-action="edit-user"]').forEach(btn => {
+    btn.addEventListener('click', () => editUser(btn.dataset.userId));
+  });
+
+  container.querySelectorAll('button[data-action="remove-user"]').forEach(btn => {
+    btn.addEventListener('click', () => removeUser(btn.dataset.userId));
+  });
+}
+
+function handleUserFormSubmit(event) {
+  event.preventDefault();
+  const name = document.getElementById('userNameInput').value.trim();
+  const email = document.getElementById('userEmailInput').value.trim();
+  const role = document.getElementById('userRoleSelect').value;
+  const siteSelect = document.getElementById('userSiteMulti');
+  const sites = siteSelect ? Array.from(siteSelect.selectedOptions).map(opt => opt.value) : [];
+
+  if (!name || !email || !role || !sites.length) {
+    setMessage('请填写完整的用户姓名、邮箱、角色并至少选择一个站点。', 'error');
+    return;
+  }
+
+  const payload = {
+    id: editingUserId || `user_${Date.now()}`,
+    name,
+    email,
+    role,
+    sites
+  };
+
+  if (editingUserId) {
+    const index = userAccounts.findIndex(user => user.id === editingUserId);
+    if (index >= 0) {
+      userAccounts[index] = payload;
+      setMessage(`已更新用户 ${name}。`, 'success');
+    }
+  } else {
+    userAccounts.push(payload);
+    setMessage(`已添加用户 ${name}。`, 'success');
+  }
+
+  saveUserAccounts();
+  resetUserForm();
+  renderUserList();
+}
+
+function resetUserForm() {
+  editingUserId = null;
+  editingUserSites = [];
+  const form = document.getElementById('userForm');
+  if (form) {
+    form.reset();
+  }
+  populateRoleOptions();
+  const siteSelect = document.getElementById('userSiteMulti');
+  if (siteSelect) {
+    Array.from(siteSelect.options).forEach(option => {
+      option.selected = false;
+    });
+  }
+}
+
+function editUser(userId) {
+  const target = userAccounts.find(user => user.id === userId);
+  if (!target) return;
+  editingUserId = target.id;
+  editingUserSites = Array.isArray(target.sites) ? [...target.sites] : [];
+  document.getElementById('userNameInput').value = target.name || '';
+  document.getElementById('userEmailInput').value = target.email || '';
+  populateRoleOptions();
+  document.getElementById('userRoleSelect').value = target.role || '';
+  const siteSelect = document.getElementById('userSiteMulti');
+  if (siteSelect) {
+    Array.from(siteSelect.options).forEach(option => {
+      option.selected = editingUserSites.includes(option.value);
+    });
+  }
+  setMessage(`正在编辑用户 ${target.name}`, 'info');
+  switchSection('userConsole');
+}
+
+function removeUser(userId) {
+  const target = userAccounts.find(user => user.id === userId);
+  if (!target) return;
+  const confirmed = confirm(`确定要删除用户「${target.name}」吗？`);
+  if (!confirmed) return;
+  userAccounts = userAccounts.filter(user => user.id !== userId);
+  saveUserAccounts();
+  renderUserList();
+  if (editingUserId === userId) {
+    resetUserForm();
+  }
+  setMessage(`已删除用户 ${target.name}。`, 'success');
 }
 
 function setupAuth() {
@@ -993,6 +1431,8 @@ function setupAuth() {
 }
 
 function initializeAdmin() {
+  roleRegistry = loadRoleRegistry();
+
   document.querySelectorAll('#adminNav a').forEach(link => {
     link.addEventListener('click', event => {
       event.preventDefault();
@@ -1011,22 +1451,42 @@ function initializeAdmin() {
     updateDataSourceOptions();
   });
   document.getElementById('refreshSitesBtn').addEventListener('click', loadSiteConfigs);
-  document.getElementById('permissionSiteSelect').addEventListener('change', () => {
-    handlePermissionSiteChange();
-  });
-  document.getElementById('resetPermissionBtn').addEventListener('click', resetPermissionMatrix);
-  document.getElementById('savePermissionBtn').addEventListener('click', savePermissionMatrix);
-  document.getElementById('exportPermissionBtn').addEventListener('click', exportPermissionMatrix);
-  document.getElementById('runSyncBtn').addEventListener('click', () => {
-    const siteId = document.getElementById('syncSiteSelect').value;
-    const action = document.getElementById('syncActionSelect').value;
-    runSync(siteId, action);
-  });
+
+  const saveRoleBtn = document.getElementById('saveRoleBtn');
+  if (saveRoleBtn) {
+    saveRoleBtn.addEventListener('click', () => persistRoleRegistry(true));
+  }
+  const resetRoleBtn = document.getElementById('resetRoleBtn');
+  if (resetRoleBtn) {
+    resetRoleBtn.addEventListener('click', resetRoleRegistry);
+  }
+
+  const roleForm = document.getElementById('roleForm');
+  if (roleForm) {
+    roleForm.addEventListener('submit', handleRoleFormSubmit);
+  }
+  const resetRoleFormBtn = document.getElementById('resetRoleForm');
+  if (resetRoleFormBtn) {
+    resetRoleFormBtn.addEventListener('click', resetNewRoleForm);
+  }
+
+  const userForm = document.getElementById('userForm');
+  if (userForm) {
+    userForm.addEventListener('submit', handleUserFormSubmit);
+  }
+  const resetUserBtn = document.getElementById('resetUserForm');
+  if (resetUserBtn) {
+    resetUserBtn.addEventListener('click', resetUserForm);
+  }
 
   populatePlatformOptions();
   populateQuickTemplates();
   updateDataSourceOptions();
-  renderPermissionMatrix();
+  renderNewRoleModules();
+  populateRoleOptions();
+  renderRoleManagement();
+  loadUserAccounts();
+  renderUserList();
   loadSiteConfigs();
   switchSection('siteConsole');
 }

--- a/public/assets/self-operated.js
+++ b/public/assets/self-operated.js
@@ -458,6 +458,12 @@
         .product-id-cell {
           text-align: left !important;
         }
+        #report th.period-column,
+        #report td.period-column,
+        #report_wrapper th.period-column,
+        #report_wrapper td.period-column {
+          display: none !important;
+        }
       `;
       document.head.appendChild(style);
       console.log('商品链接样式已添加');
@@ -490,20 +496,20 @@
       const thead = document.createElement('thead');
       thead.innerHTML = `
         <tr>
-          <th style="text-align: left; min-width: 120px;">商品(ID)</th>
-          <th style="text-align: center; min-width: 150px;">周期</th>
-          <th style="text-align: center; min-width: 100px;">访客比(%)</th>
-          <th style="text-align: center; min-width: 100px;">加购比(%)</th>
-          <th style="text-align: center; min-width: 100px;">支付比(%)</th>
-          <th style="text-align: center; min-width: 80px;">曝光量</th>
-          <th style="text-align: center; min-width: 80px;">访客数</th>
-          <th style="text-align: center; min-width: 80px;">浏览量</th>
-          <th style="text-align: center; min-width: 80px;">加购件数</th>
-          <th style="text-align: center; min-width: 100px;">下单商品件数</th>
-          <th style="text-align: center; min-width: 80px;">支付件数</th>
-          <th style="text-align: center; min-width: 80px;">支付买家数</th>
-          <th style="text-align: center; min-width: 100px;">搜索点击率(%)</th>
-          <th style="text-align: center; min-width: 120px;">平均停留时长(秒)</th>
+          <th class="col-product">商品ID</th>
+          <th class="period-column">周期</th>
+          <th>访客比(%)</th>
+          <th>加购比(%)</th>
+          <th>支付比(%)</th>
+          <th>曝光量</th>
+          <th>访客数</th>
+          <th>浏览量</th>
+          <th>加购件数</th>
+          <th>下单商品件数</th>
+          <th>支付件数</th>
+          <th>支付买家数</th>
+          <th>搜索点击率(%)</th>
+          <th>平均停留时长(秒)</th>
         </tr>
       `;
       table.appendChild(thead);
@@ -530,6 +536,7 @@
           
           // 计算比率，优先使用 add_people
           const addPeople = row.add_people || 0;
+          const addCount = row.add_times || row.add_people || 0;
           const visitors = row.visitors || 0;
           const exposure = row.exposure || 0;
           const payItems = row.pay_items || 0;
@@ -558,20 +565,20 @@
           }
 
           tr.innerHTML = `
-            <td style="text-align: left;">${productLink}</td>
-            <td style="text-align: center;">${row.bucket || this.formatDateRange(row.start_date, row.end_date)}</td>
-            <td style="text-align: center;">${this.formatPercentage(visitorRatio)}</td>
-            <td style="text-align: center;">${this.formatPercentage(addToCartRatio)}</td>
-            <td style="text-align: center;">${this.formatPercentage(paymentRatio)}</td>
-            <td style="text-align: center;">${this.formatNumber(row.exposure || 0)}</td>
-            <td style="text-align: center;">${this.formatNumber(row.visitors || 0)}</td>
-            <td style="text-align: center;">${this.formatNumber(row.views || 0)}</td>
-            <td style="text-align: center;">${this.formatNumber(addPeople)}</td>
-            <td style="text-align: center;">${this.formatNumber(row.order_items || 0)}</td>
-            <td style="text-align: center;">${this.formatNumber(row.pay_items || 0)}</td>
-            <td style="text-align: center;">${this.formatNumber(row.pay_buyers || 0)}</td>
-            <td style="text-align: center;">${this.formatPercentage(row.search_ctr)}</td>
-            <td style="text-align: center;">${this.formatNumber(row.avg_stay_seconds || 0)}</td>
+            <td class="product-id-cell col-product">${productLink}</td>
+            <td class="period-column">${row.bucket || this.formatDateRange(row.start_date, row.end_date)}</td>
+            <td>${this.formatPercentage(visitorRatio)}</td>
+            <td>${this.formatPercentage(addToCartRatio)}</td>
+            <td>${this.formatPercentage(paymentRatio)}</td>
+            <td>${this.formatNumber(row.exposure || 0)}</td>
+            <td>${this.formatNumber(row.visitors || 0)}</td>
+            <td>${this.formatNumber(row.views || 0)}</td>
+            <td>${this.formatNumber(addCount)}</td>
+            <td>${this.formatNumber(row.order_items || 0)}</td>
+            <td>${this.formatNumber(row.pay_items || 0)}</td>
+            <td>${this.formatNumber(row.pay_buyers || 0)}</td>
+            <td>${this.formatPercentage(row.search_ctr)}</td>
+            <td>${this.formatNumber(row.avg_stay_seconds || 0)}</td>
           `;
           
           // 为每行数据添加双击事件（排除商品ID列）
@@ -621,27 +628,30 @@
               this.dataTable = jQuery(table).DataTable({
                 destroy: true,
                 pageLength: 10,
-                order: [[1, 'desc']], 
-                scrollX: true, 
-                scrollY: 'calc(100vh - 420px)', 
-                scrollCollapse: true, 
+                order: [[1, 'desc']],
+                autoWidth: false,
+                scrollY: '60vh',
+                scrollCollapse: true,
                 fixedHeader: true,
+                columnDefs: [
+                  { targets: 1, visible: false, searchable: false }
+                ],
                 language: {
                   url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/zh.json'
                 }
               });
-              
+
+              this.dataTable.columns.adjust();
               console.log('DataTable初始化成功！');
               console.log('DataTable数据行数:', this.dataTable.data().count());
               console.log('DataTable实际显示行数:', this.dataTable.rows().count());
-              
-                         } else {
-               console.warn('表格没有实际数据行，跳过DataTable初始化');
-               // 如果没有数据，显示"暂无数据"提示
-               if (tbody) {
-                 tbody.innerHTML = '<tr><td colspan="14" style="text-align: center; padding: 20px; color: #666;">暂无数据</td></tr>';
-               }
-             }
+             } else {
+              console.warn('表格没有实际数据行，跳过DataTable初始化');
+              // 如果没有数据，显示"暂无数据"提示
+              if (tbody) {
+                tbody.innerHTML = '<tr><td colspan="14" style="text-align: center; padding: 20px; color: #666;">暂无数据</td></tr>';
+              }
+            }
             
           } catch (error) {
             console.error('DataTable初始化失败:', error);

--- a/public/managed.html
+++ b/public/managed.html
@@ -302,8 +302,9 @@
 </div>
 
 <script>
+const MANAGED_MODULE_IDS = ['detail', 'analysis', 'products', 'orders', 'advertising'];
+
 (function(){
-  const MODULE_IDS = ['detail', 'analysis', 'products', 'orders', 'advertising'];
   const state = { granularity: 'week', table: null, uploading: false };
 
   // 初始化粒度：若本地存储有记录则使用
@@ -664,16 +665,16 @@
 
   // Hash路由处理
   function handleHashRoute() {
-    const hash = window.location.hash.slice(1) || 'detail';
+    const hash = window.location.hash.slice(1) || MANAGED_MODULE_IDS[0];
     const targetLink = document.querySelector(`[data-target="${hash}"]`);
-    
+
     if (targetLink) {
       // 更新导航状态
       document.querySelectorAll('.sub-nav a').forEach(x => x.classList.remove('active'));
       targetLink.classList.add('active');
-      
+
       // 显示对应内容
-      MODULE_IDS.forEach(id => {
+      MANAGED_MODULE_IDS.forEach(id => {
         const el = document.getElementById(id);
         if (el) el.style.display = (id === hash ? '' : 'none');
       });

--- a/public/self-operated.html
+++ b/public/self-operated.html
@@ -95,7 +95,70 @@
       font-size: 14px;
       margin: 0;
     }
-    
+
+    /* 数据明细区域 */
+    #detail .table-card {
+      background: #ffffff;
+      border: 1px solid var(--primary-200);
+      border-radius: var(--radius-lg);
+      padding: var(--space-4);
+      box-shadow: var(--shadow-sm);
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-4);
+    }
+
+    #detail .table-card h3 {
+      margin: 0;
+      font-size: 1.125rem;
+      font-weight: 600;
+      color: var(--primary-800);
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    #detail .table-wrapper {
+      width: 100%;
+      overflow: auto;
+    }
+
+    #detail #report_wrapper {
+      width: 100%;
+    }
+
+    #detail table.dataTable {
+      width: 100% !important;
+      font-size: 0.75rem;
+      table-layout: auto;
+    }
+
+    #detail table.dataTable thead th,
+    #detail table.dataTable tbody td {
+      font-size: 0.75rem;
+      padding: 0.5rem 0.75rem;
+      white-space: nowrap;
+    }
+
+    #detail table.dataTable tbody td {
+      font-variant-numeric: tabular-nums;
+      color: var(--primary-800);
+    }
+
+    #detail table.dataTable thead th {
+      color: var(--primary-700);
+    }
+
+    #detail table.dataTable .col-product {
+      text-align: left;
+      min-width: 140px;
+    }
+
+    #detail table.dataTable tbody td:not(.col-product),
+    #detail table.dataTable thead th:not(.col-product) {
+      text-align: center;
+    }
+
     .grid-2 {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
@@ -608,17 +671,17 @@
     <div class="content">
       <!-- 明细表 -->
       <section id="detail" class="content-pad">
-        <div class="chart-container">
+        <div class="table-card">
           <h3>数据明细</h3>
-          
+
           <!-- 加载状态 -->
           <div id="detailLoading" class="loading-state" style="display: none;">
             <div class="loading-spinner"></div>
             <p class="loading-text">努力加载中,请等待片刻。。。</p>
           </div>
-          
+
           <!-- 数据表格 -->
-          <div id="detailContent">
+          <div id="detailContent" class="table-wrapper">
             <table id="report" class="data-table display nowrap" style="width:100%"></table>
           </div>
         </div>

--- a/public/site-management.html
+++ b/public/site-management.html
@@ -506,8 +506,35 @@
     alert('如需编辑站点配置，请前往 admin.html 管理后台。');
   };
 
-  window.deleteSite = function() {
-    alert('站点删除操作受限，请在数据库或管理后台审核后执行。');
+  window.deleteSite = async function(siteId) {
+    if (!siteId) {
+      alert('未找到站点ID，无法删除。');
+      return;
+    }
+
+    const confirmed = confirm('确定要删除该站点吗？此操作将移除站点配置并从导航中隐藏。');
+    if (!confirmed) return;
+
+    try {
+      const response = await fetch('/api/site-configs/delete', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ siteId })
+      });
+
+      const result = await response.json();
+      if (!response.ok) {
+        throw new Error(result.error || '删除失败');
+      }
+
+      alert('站点已删除。');
+      await loadSites();
+    } catch (error) {
+      console.error('删除站点失败:', error);
+      alert('删除站点失败：' + error.message);
+    }
   };
 
   updateDataSourceOptions();


### PR DESCRIPTION
## Summary
- consolidate the admin role console into a module-based manager with an inline form for creating custom roles while removing the old permission matrix and sync sections【F:public/admin.html†L380-L383】【F:public/admin.html†L459-L499】
- introduce a persistent role registry backed by module definitions so role cards, add/remove flows, and DataTable interactions stay in sync with saved assignments【F:public/admin.html†L632-L1194】
- require explicit site selection when managing users and surface the assigned role modules and sites in the user list cards【F:public/admin.html†L520-L533】【F:public/admin.html†L1255-L1339】

## Testing
- `npm test` *(fails: tests/lazada-oauth.test.js still references mocha beforeEach under node --test)*【74747d†L1-L64】【614603†L1-L63】

------
https://chatgpt.com/codex/tasks/task_e_68ceb2f172ac8325abb2bf55e0668035